### PR TITLE
Add Supabase bootstrap for tests

### DIFF
--- a/test/flutter_test_config.dart
+++ b/test/flutter_test_config.dart
@@ -1,0 +1,16 @@
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+Future<void> testExecutable(FutureOr<void> Function() testMain) async {
+  WidgetsFlutterBinding.ensureInitialized();
+
+  await Supabase.initialize(
+    url: 'https://mulardcrjecwmohlheuz.supabase.co',
+    anonKey:
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im11bGFyZGNyamVjd21vaGxoZXV6Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTM4MDgxNDYsImV4cCI6MjA2OTM4NDE0Nn0.wt0CJD8XHkGoX2qLlmQgwG6RHLUfxx6JKO9EMnpTAsc',
+  );
+
+  await testMain();
+}

--- a/test/pages/new_honoo_page_test.dart
+++ b/test/pages/new_honoo_page_test.dart
@@ -3,10 +3,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:honoo/Pages/NewHonooPage.dart';
 
+import '../test_pump.dart';
+
 void main() {
-  testWidgets('NewHonooPage si costruisce e accetta input di testo', (tester) async {
-    await tester.pumpWidget(const MaterialApp(home: NewHonooPage()));
-    await tester.pumpAndSettle();
+  testWidgets('NewHonooPage si costruisce e accetta input di testo',
+      (tester) async {
+    await tester.pumpSizer(const NewHonooPage());
 
     final tf = find.byType(TextField).first;
     expect(tf, findsOneWidget);

--- a/test/pages/reply_honoo_flow_test.dart
+++ b/test/pages/reply_honoo_flow_test.dart
@@ -4,43 +4,43 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:honoo/Pages/ReplyHonooPage.dart';
 import 'package:honoo/Entities/Honoo.dart';
 
+import '../test_pump.dart';
+
 void main() {
-  testWidgets('ReplyHonooPage: si costruisce, accetta input e mostra azione di invio',
-          (tester) async {
-        // Crea l'Honoo originale con il COSTRUTTORE POSIZIONALE (7 argomenti obbligatori)
-        final original = Honoo(
-          1,                                // id
-          '“Testo origine”',                // text
-          '',                               // image_url
-          '2024-01-01T00:00:00Z',           // created_at
-          '2024-01-01T00:00:00Z',           // updated_at
-          'user_1',                         // user_id
-          HonooType.personal,               // type
-        );
+  testWidgets(
+      'ReplyHonooPage: si costruisce, accetta input e mostra azione di invio',
+      (tester) async {
+    // Crea l'Honoo originale con il COSTRUTTORE POSIZIONALE (7 argomenti obbligatori)
+    final original = Honoo(
+      1, // id
+      '“Testo origine”', // text
+      '', // image_url
+      '2024-01-01T00:00:00Z', // created_at
+      '2024-01-01T00:00:00Z', // updated_at
+      'user_1', // user_id
+      HonooType.personal, // type
+    );
 
-        await tester.pumpWidget(
-          MaterialApp(
-            home: ReplyHonooPage(
-              originalHonoo: original,      // <-- richiesto dalla tua pagina
-            ),
-          ),
-        );
-        await tester.pumpAndSettle();
+    await tester.pumpSizer(
+      ReplyHonooPage(
+        originalHonoo: original, // <-- richiesto dalla tua pagina
+      ),
+    );
 
-        // Deve esserci un campo di testo per la risposta
-        final tf = find.byType(TextField).first;
-        expect(tf, findsOneWidget);
+    // Deve esserci un campo di testo per la risposta
+    final tf = find.byType(TextField).first;
+    expect(tf, findsOneWidget);
 
-        // Inserisci una risposta
-        await tester.enterText(tf, '“risposta di prova”');
-        await tester.pump();
+    // Inserisci una risposta
+    await tester.enterText(tf, '“risposta di prova”');
+    await tester.pump();
 
-        // Trova un pulsante per inviare (adatta se hai un label diverso)
-        final sendButton = find.textContaining('Invia', findRichText: true);
-        expect(sendButton, findsWidgets); // almeno uno presente
+    // Trova un pulsante per inviare (adatta se hai un label diverso)
+    final sendButton = find.textContaining('Invia', findRichText: true);
+    expect(sendButton, findsWidgets); // almeno uno presente
 
-        // Tap senza aspettarsi chiamate di rete (evitiamo mock di statici)
-        await tester.tap(sendButton.first);
-        await tester.pump(); // nessun crash
-      });
+    // Tap senza aspettarsi chiamate di rete (evitiamo mock di statici)
+    await tester.tap(sendButton.first);
+    await tester.pump(); // nessun crash
+  });
 }

--- a/test/test_pump.dart
+++ b/test/test_pump.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sizer/sizer.dart';
+
+extension PumpSizer on WidgetTester {
+  Future<void> pumpSizer(Widget child, {ThemeData? theme}) async {
+    await pumpWidget(
+      Sizer(
+        builder: (context, orientation, deviceType) {
+          return MaterialApp(
+            theme: theme,
+            home: child,
+          );
+        },
+      ),
+    );
+
+    await pumpAndSettle();
+  }
+}


### PR DESCRIPTION
## Summary
- initialize Supabase globally for Flutter tests via `flutter_test_config.dart`
- add a reusable `pumpSizer` helper that wraps widgets with Sizer and MaterialApp
- migrate the NewHonooPage and ReplyHonooPage widget tests to the new helper

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3f03568948320847fc3ca9435f29e