### PR TITLE
Harden chest persistence and loading

### DIFF
--- a/integration_test/live_conversation_flow_test.dart
+++ b/integration_test/live_conversation_flow_test.dart
@@ -207,58 +207,81 @@ void main() {
       expect((secondHinooThread as List).length, 2);
 
       a.realtime.setAuth(a.auth.currentSession!.accessToken);
-      final realtimeInsert = Completer<void>();
+      var realtimeInsert = Completer<void>();
       final realtimeDelete = Completer<void>();
-      final subscribed = Completer<void>();
-      channel = a.channel('live-test-$marker')
-        ..on(
-          RealtimeListenTypes.postgresChanges,
-          ChannelFilter(
-            event: 'INSERT',
-            schema: 'public',
-            table: 'honoo',
-          ),
-          (payload, [__]) {
-            final record = payload is Map ? payload['new'] : null;
-            if (record is Map &&
-                record['conversation_id']?.toString() == honooConversationId &&
-                !realtimeInsert.isCompleted) {
-              realtimeInsert.complete();
-            }
-          },
-        )
-        ..on(
-          RealtimeListenTypes.postgresChanges,
-          ChannelFilter(
-            event: 'DELETE',
-            schema: 'public',
-            table: 'honoo',
-          ),
-          (payload, [__]) {
-            final oldRecord = payload is Map ? payload['old'] : null;
-            if (oldRecord is Map &&
-                oldRecord['id']?.toString() == expectedRealtimeDeleteId &&
-                !realtimeDelete.isCompleted) {
-              realtimeDelete.complete();
-            }
-          },
-        );
-      channel.subscribe((status, [error]) {
-        if (status == 'SUBSCRIBED' && !subscribed.isCompleted) {
-          subscribed.complete();
-        } else if ((status == 'CHANNEL_ERROR' || status == 'TIMED_OUT') &&
-            !subscribed.isCompleted) {
-          subscribed.completeError(
-            StateError('Sottoscrizione Realtime fallita: $status'),
+      var subscribed = Completer<void>();
+      var insertCallbacks = 0;
+      var lastInsertDiagnostic = 'nessun callback INSERT';
+
+      String describePayload(dynamic payload, String conversationId) {
+        if (payload is! Map) return 'payload=${payload.runtimeType}';
+        final keys = payload.keys.map((key) => key.toString()).toList()..sort();
+        final record = payload['new'];
+        return 'keys=$keys, record=${record.runtimeType}, '
+            'conversationMatches='
+            '${record is Map && record['conversation_id']?.toString() == conversationId}';
+      }
+
+      RealtimeChannel subscribeToHonoo(String suffix) {
+        final nextChannel = a.channel('live-test-$suffix-$marker')
+          ..on(
+            RealtimeListenTypes.postgresChanges,
+            ChannelFilter(
+              event: 'INSERT',
+              schema: 'public',
+              table: 'honoo',
+            ),
+            (payload, [__]) {
+              insertCallbacks++;
+              lastInsertDiagnostic =
+                  describePayload(payload, honooConversationId);
+              final record = payload is Map ? payload['new'] : null;
+              if (record is Map &&
+                  record['conversation_id']?.toString() ==
+                      honooConversationId &&
+                  !realtimeInsert.isCompleted) {
+                realtimeInsert.complete();
+              }
+            },
+          )
+          ..on(
+            RealtimeListenTypes.postgresChanges,
+            ChannelFilter(
+              event: 'DELETE',
+              schema: 'public',
+              table: 'honoo',
+            ),
+            (payload, [__]) {
+              final oldRecord = payload is Map ? payload['old'] : null;
+              if (oldRecord is Map &&
+                  oldRecord['id']?.toString() == expectedRealtimeDeleteId &&
+                  !realtimeDelete.isCompleted) {
+                realtimeDelete.complete();
+              }
+            },
           );
-        }
-      });
-      await subscribed.future.timeout(
-        const Duration(seconds: 12),
-        onTimeout: () => throw StateError(
-          'Il canale Realtime non ha raggiunto SUBSCRIBED',
-        ),
-      );
+        nextChannel.subscribe((status, [error]) {
+          if (status == 'SUBSCRIBED' && !subscribed.isCompleted) {
+            subscribed.complete();
+          } else if ((status == 'CHANNEL_ERROR' || status == 'TIMED_OUT') &&
+              !subscribed.isCompleted) {
+            subscribed.completeError(
+              StateError('Sottoscrizione Realtime fallita: $status'),
+            );
+          }
+        });
+        return nextChannel;
+      }
+
+      Future<void> waitUntilSubscribed() => subscribed.future.timeout(
+            const Duration(seconds: 25),
+            onTimeout: () => throw StateError(
+              'Il canale Realtime non ha raggiunto SUBSCRIBED',
+            ),
+          );
+
+      channel = subscribeToHonoo('initial');
+      await waitUntilSubscribed();
       await insertHonoo(
         b,
         text: 'realtime check',
@@ -267,18 +290,40 @@ void main() {
         conversationId: honooConversationId,
         recipientTag: aId,
       );
-      await realtimeInsert.future.timeout(
-        const Duration(seconds: 12),
-        onTimeout: () => throw StateError(
-          'Canale sottoscritto, ma evento INSERT non ricevuto',
-        ),
-      );
+      try {
+        await realtimeInsert.future.timeout(const Duration(seconds: 25));
+      } on TimeoutException {
+        // A transient Realtime delay must not make the whole live suite flaky.
+        // Recreate the subscription once and emit a fresh probe: Postgres
+        // changes are not replayed to a newly joined channel.
+        await channel.unsubscribe();
+        realtimeInsert = Completer<void>();
+        subscribed = Completer<void>();
+        channel = subscribeToHonoo('retry');
+        await waitUntilSubscribed();
+        await insertHonoo(
+          b,
+          text: 'realtime retry check',
+          destination: 'reply',
+          replyTo: honooRootId,
+          conversationId: honooConversationId,
+          recipientTag: aId,
+        );
+        try {
+          await realtimeInsert.future.timeout(const Duration(seconds: 25));
+        } on TimeoutException {
+          throw StateError(
+            'Evento INSERT non ricevuto dopo una risottoscrizione; '
+            'callbacks=$insertCallbacks, ultimo=$lastInsertDiagnostic',
+          );
+        }
+      }
 
       final realtimeRow = createdHonoo.last;
       expectedRealtimeDeleteId = realtimeRow;
       await b.from('honoo').delete().eq('id', realtimeRow);
       await realtimeDelete.future.timeout(
-        const Duration(seconds: 12),
+        const Duration(seconds: 25),
         onTimeout: () => throw StateError(
           'Canale sottoscritto, ma evento DELETE non ricevuto',
         ),
@@ -296,6 +341,8 @@ void main() {
       a.realtime.connect();
       final reconnected = Completer<void>();
       final resubscribed = Completer<void>();
+      var reconnectCallbacks = 0;
+      var lastReconnectDiagnostic = 'nessun callback INSERT';
       reconnectedChannel = a.channel('live-test-reconnect-$marker')
         ..on(
           RealtimeListenTypes.postgresChanges,
@@ -305,6 +352,9 @@ void main() {
             table: 'honoo',
           ),
           (payload, [__]) {
+            reconnectCallbacks++;
+            lastReconnectDiagnostic =
+                describePayload(payload, honooConversationId);
             final record = payload is Map ? payload['new'] : null;
             if (record is Map &&
                 record['conversation_id']?.toString() == honooConversationId &&
@@ -323,7 +373,7 @@ void main() {
         }
       });
       await resubscribed.future.timeout(
-        const Duration(seconds: 12),
+        const Duration(seconds: 25),
         onTimeout: () => throw StateError(
           'Il canale Realtime non si è risottoscritto dopo il reconnect',
         ),
@@ -337,9 +387,10 @@ void main() {
         recipientTag: aId,
       );
       await reconnected.future.timeout(
-        const Duration(seconds: 12),
+        const Duration(seconds: 25),
         onTimeout: () => throw StateError(
-          'Evento INSERT non ricevuto dopo la riconnessione',
+          'Evento INSERT non ricevuto dopo la riconnessione; '
+          'callbacks=$reconnectCallbacks, ultimo=$lastReconnectDiagnostic',
         ),
       );
     } finally {
@@ -369,5 +420,5 @@ void main() {
       skip: LiveConfig.liveRun
           ? false
           : 'Set HONOO_LIVE_RUN=true per eseguire il test live',
-      timeout: const Timeout(Duration(minutes: 2)));
+      timeout: const Timeout(Duration(minutes: 4)));
 }

--- a/lib/Controller/chest_controller.dart
+++ b/lib/Controller/chest_controller.dart
@@ -8,6 +8,7 @@ import '../Entities/hinoo_thread_entry.dart';
 import '../Services/chest_repository.dart';
 import '../Services/chest_realtime_service.dart';
 import '../Services/hinoo_service.dart';
+import '../Services/reliability_policy.dart';
 
 class ChestState {
   ChestState({
@@ -17,7 +18,8 @@ class ChestState {
     Map<String, List<HinooThreadEntry>> hinooRepliesByRoot = const {},
     this.isHinooLoading = true,
     this.isReplyLoading = false,
-    this.error,
+    this.hinooError,
+    this.replyError,
   })  : hinoo = List.unmodifiable(hinoo),
         honooLatestReplies = Map.unmodifiable(honooLatestReplies),
         hinooLatestReplies = Map.unmodifiable(hinooLatestReplies),
@@ -33,24 +35,30 @@ class ChestState {
   final Map<String, List<HinooThreadEntry>> hinooRepliesByRoot;
   final bool isHinooLoading;
   final bool isReplyLoading;
-  final Object? error;
+  final Object? hinooError;
+  final Object? replyError;
+  Object? get error => hinooError ?? replyError;
 }
 
 class ChestController extends ValueNotifier<ChestState> {
   ChestController({
     required ChestRepository repository,
     ChestRealtimeGateway? realtimeGateway,
+    ReliabilityPolicy reliabilityPolicy = const ReliabilityPolicy(),
   })  : _realtimeGateway = realtimeGateway ?? SupabaseChestRealtimeGateway(),
         _repository = repository,
+        _reliability = reliabilityPolicy,
         super(ChestState());
 
   final ChestRepository _repository;
   final ChestRealtimeGateway _realtimeGateway;
+  final ReliabilityPolicy _reliability;
   ChestRealtimeSubscription? _realtimeSubscription;
   Timer? _periodicRefreshTimer;
   Timer? _realtimeDebounce;
   String? _activeUserId;
   bool _isRefreshingReplies = false;
+  bool _refreshPending = false;
 
   void startRealtime(
     String userId, {
@@ -81,10 +89,16 @@ class ChestController extends ValueNotifier<ChestState> {
   }
 
   Future<void> refreshReplies(String userId) async {
-    if (_isRefreshingReplies) return;
+    if (_isRefreshingReplies) {
+      _refreshPending = true;
+      return;
+    }
     _isRefreshingReplies = true;
     try {
-      await loadReplies(userId);
+      do {
+        _refreshPending = false;
+        await loadReplies(userId);
+      } while (_refreshPending);
     } finally {
       _isRefreshingReplies = false;
     }
@@ -114,6 +128,8 @@ class ChestController extends ValueNotifier<ChestState> {
       hinooRepliesByRoot: value.hinooRepliesByRoot,
       isHinooLoading: false,
       isReplyLoading: false,
+      hinooError: value.hinooError,
+      replyError: value.replyError,
     );
   }
 
@@ -125,6 +141,8 @@ class ChestController extends ValueNotifier<ChestState> {
       hinooRepliesByRoot: value.hinooRepliesByRoot,
       isHinooLoading: value.isHinooLoading,
       isReplyLoading: value.isReplyLoading,
+      hinooError: value.hinooError,
+      replyError: value.replyError,
     );
   }
 
@@ -150,7 +168,8 @@ class ChestController extends ValueNotifier<ChestState> {
       hinooRepliesByRoot: value.hinooRepliesByRoot,
       isHinooLoading: value.isHinooLoading,
       isReplyLoading: value.isReplyLoading,
-      error: value.error,
+      hinooError: value.hinooError,
+      replyError: value.replyError,
     );
   }
 
@@ -162,13 +181,18 @@ class ChestController extends ValueNotifier<ChestState> {
       hinooRepliesByRoot: value.hinooRepliesByRoot,
       isHinooLoading: true,
       isReplyLoading: value.isReplyLoading,
+      replyError: value.replyError,
     );
 
     try {
-      final rows = await _repository.fetchHinooRows(userId);
+      final rows = await _reliability.read<List<dynamic>>(
+        () => _repository.fetchHinooRows(userId),
+      );
       Set<String> moonFingerprints = const {};
       try {
-        moonFingerprints = await _repository.fetchHinooMoonFingerprints(userId);
+        moonFingerprints = await _reliability.read<Set<String>>(
+          () => _repository.fetchHinooMoonFingerprints(userId),
+        );
       } catch (_) {
         // Il contenuto dello Scrigno resta utilizzabile anche se il controllo
         // dello stato Luna non è temporaneamente disponibile.
@@ -199,6 +223,7 @@ class ChestController extends ValueNotifier<ChestState> {
         hinooRepliesByRoot: value.hinooRepliesByRoot,
         isHinooLoading: false,
         isReplyLoading: value.isReplyLoading,
+        replyError: value.replyError,
       );
     } catch (error) {
       value = ChestState(
@@ -208,7 +233,8 @@ class ChestController extends ValueNotifier<ChestState> {
         hinooRepliesByRoot: value.hinooRepliesByRoot,
         isHinooLoading: false,
         isReplyLoading: value.isReplyLoading,
-        error: error,
+        hinooError: error,
+        replyError: value.replyError,
       );
     }
   }
@@ -221,11 +247,14 @@ class ChestController extends ValueNotifier<ChestState> {
       hinooRepliesByRoot: value.hinooRepliesByRoot,
       isHinooLoading: value.isHinooLoading,
       isReplyLoading: true,
+      hinooError: value.hinooError,
     );
 
     try {
       final honooLatest = <String, DateTime>{};
-      final honooRows = await _repository.fetchHonooReplyRows(userId);
+      final honooRows = await _reliability.refresh<List<dynamic>>(
+        () => _repository.fetchHonooReplyRows(userId),
+      );
       final seenHonooKeys = <String>{};
       for (final row in honooRows.whereType<Map>()) {
         final rootId = row['reply_to']?.toString() ?? '';
@@ -243,7 +272,9 @@ class ChestController extends ValueNotifier<ChestState> {
       final hinooLatest = <String, DateTime>{};
       final hinooReplies = <String, List<HinooThreadEntry>>{};
       final rootIds = value.hinoo.map((item) => item.id).toList();
-      final rows = await _repository.fetchHinooReplyRows(userId, rootIds);
+      final rows = await _reliability.refresh<List<dynamic>>(
+        () => _repository.fetchHinooReplyRows(userId, rootIds),
+      );
       final seenHinooIds = <String>{};
       for (final row in rows.whereType<Map>()) {
         final id = row['id']?.toString() ?? '';
@@ -284,6 +315,7 @@ class ChestController extends ValueNotifier<ChestState> {
         hinooRepliesByRoot: hinooReplies,
         isHinooLoading: value.isHinooLoading,
         isReplyLoading: false,
+        hinooError: value.hinooError,
       );
     } catch (error) {
       value = ChestState(
@@ -293,7 +325,8 @@ class ChestController extends ValueNotifier<ChestState> {
         hinooRepliesByRoot: value.hinooRepliesByRoot,
         isHinooLoading: value.isHinooLoading,
         isReplyLoading: false,
-        error: error,
+        hinooError: value.hinooError,
+        replyError: error,
       );
     }
   }

--- a/lib/Controller/hinoo_controller.dart
+++ b/lib/Controller/hinoo_controller.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart';
 import 'package:honoo/Services/supabase_provider.dart';
 import 'package:honoo/Services/hinoo_service.dart';
 import 'package:honoo/Services/hinoo_storage_uploader.dart';
+import 'package:honoo/Services/duplication_result.dart';
 
 import '../Entities/hinoo.dart';
 
@@ -91,8 +92,10 @@ class HinooController {
     }
 
     final sanitized = draft.copyWith(type: HinooType.moon);
-    final ok = await HinooService.duplicateToMoon(sanitized);
-    return ok ? HinooMoonResult.published : HinooMoonResult.alreadyPresent;
+    final result = await HinooService.duplicateToMoon(sanitized);
+    return result == DuplicationResult.inserted
+        ? HinooMoonResult.published
+        : HinooMoonResult.alreadyPresent;
   }
 
   /// (Opzionale) autosave bozza

--- a/lib/Controller/honoo_controller.dart
+++ b/lib/Controller/honoo_controller.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:honoo/Services/supabase_provider.dart';
 import '../Entities/honoo.dart';
 import '../Services/honoo_service.dart';
+import '../Services/duplication_result.dart';
 
 /// Repository + cache in memoria (niente mock)
 class HonooController {
@@ -105,9 +106,9 @@ class HonooController {
   /// Ritorna:
   ///  - true  => inserito ora ("Spedito sulla Luna")
   ///  - false => già presente ("Già presente sulla Luna")
-  Future<bool> sendToMoon(Honoo h) async {
+  Future<DuplicationResult> sendToMoon(Honoo h) async {
     try {
-      final inserted = await HonooService.duplicateToMoon(h);
+      final result = await HonooService.duplicateToMoon(h);
       final index = _personal.indexWhere(
         (item) => item.dbId != null && item.dbId == h.dbId,
       );
@@ -115,28 +116,28 @@ class HonooController {
         _personal[index] = _personal[index].copyWith(isOnMoon: true);
         version.value++;
       }
-      return inserted;
+      return result;
     } catch (e) {
       debugPrint('duplicateToMoon error: $e');
       rethrow;
     }
   }
 
-  Future<bool> saveToChest(Honoo h) async {
+  Future<DuplicationResult> saveToChest(Honoo h) async {
     try {
-      final inserted = await HonooService.duplicateToChest(h);
-      if (inserted) {
+      final result = await HonooService.duplicateToChest(h);
+      if (result == DuplicationResult.inserted) {
         await loadChest();
       }
-      return inserted;
+      return result;
     } catch (e) {
       debugPrint('duplicateToChest error: $e');
-      return false;
+      rethrow;
     }
   }
 
   Future<void> deleteHonoo(Honoo h) async {
-    final String? id = (h.dbId ?? h.id) as String?;
+    final String? id = h.dbId;
     if (id == null || id.isEmpty) {
       debugPrint('deleteHonoo: id mancante');
       return;
@@ -144,7 +145,7 @@ class HonooController {
 
     await HonooService.deleteHonooById(id);
 
-    _personal.removeWhere((x) => (x.dbId ?? x.id) == id);
+    _personal.removeWhere((x) => x.dbId == id);
     version.value++;
   }
 
@@ -156,7 +157,7 @@ class HonooController {
 
     await HonooService.deleteHonooById(id);
 
-    _personal.removeWhere((x) => (x.dbId ?? x.id) == id);
+    _personal.removeWhere((x) => x.dbId == id);
     version.value++;
   }
 }

--- a/lib/Pages/chest_page.dart
+++ b/lib/Pages/chest_page.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:carousel_slider/carousel_slider.dart' as cs;
@@ -5,6 +7,7 @@ import 'package:honoo/Services/supabase_provider.dart';
 import 'package:honoo/Services/chest_repository.dart';
 import 'package:honoo/Services/download_capture_service.dart';
 import 'package:honoo/Services/chest_hint_service.dart';
+import 'package:honoo/Services/duplication_result.dart';
 
 import '../Controller/honoo_controller.dart';
 import '../Controller/hinoo_controller.dart';
@@ -72,6 +75,8 @@ class _ChestPageState extends State<ChestPage> {
 
   int _currentIndex = 0;
   int _conversationRefreshToken = 0;
+  Object? _honooLoadError;
+  bool _isMutating = false;
   // Data lists for normal vs conversation mode
   List<ChestItem> _itemsNormal = const [];
   List<ChestHinooItem> get _hinoo => _chestController.value.hinoo;
@@ -104,10 +109,8 @@ class _ChestPageState extends State<ChestPage> {
   void initState() {
     super.initState();
     _chestController.addListener(_onChestStateChanged);
-    _loadAll();
+    unawaited(_initialize());
     _maybeShowScrignoHint();
-    final uid = SupabaseProvider.client.auth.currentUser?.id;
-    if (uid != null) _chestController.startRealtime(uid);
   }
 
   @override
@@ -141,9 +144,12 @@ class _ChestPageState extends State<ChestPage> {
   }
 
   Future<void> _loadAll() async {
+    if (mounted) setState(() => _honooLoadError = null);
     try {
       await ctrl.loadChest();
-    } catch (_) {}
+    } catch (error) {
+      if (mounted) setState(() => _honooLoadError = error);
+    }
     final uid = SupabaseProvider.client.auth.currentUser?.id;
     if (uid == null) {
       _chestController.completeWithoutUser();
@@ -152,6 +158,18 @@ class _ChestPageState extends State<ChestPage> {
     await _chestController.loadHinoo(uid);
     await _chestController.refreshReplies(uid);
   }
+
+  Future<void> _initialize() async {
+    await _loadAll();
+    if (!mounted) return;
+    final uid = SupabaseProvider.client.auth.currentUser?.id;
+    if (uid != null) _chestController.startRealtime(uid);
+  }
+
+  Object? get _loadError =>
+      _honooLoadError ??
+      _chestController.value.hinooError ??
+      _chestController.value.replyError;
 
   String _stableIdOf(ChestItem it) {
     return it.when(
@@ -274,39 +292,50 @@ class _ChestPageState extends State<ChestPage> {
     required double gap,
     required double bottomPadding,
   }) {
-    return ChestFooter(
-      item: item,
-      selectedConversationEntry: _selectedConvEntry,
-      currentUserId: SupabaseProvider.client.auth.currentUser?.id,
-      iconSize: iconSize,
-      gap: gap,
-      bottomPadding: bottomPadding,
-      onHome: _goHome,
-      onInfo: _showScrignoInfo,
-      onSendHonooToMoon: _sendHonooToMoon,
-      onReplyToHonoo: _showReplyChoiceForHonoo,
-      onDeleteHonoo: _deleteHonoo,
-      onSendHinooToMoon: _sendHinooToMoon,
-      onReplyToHinoo: _showReplyChoiceForHinoo,
-      onDeleteHinoo: _deleteHinoo,
-      onSendConversationEntryToMoon: _sendConversationEntryToMoon,
+    return AnimatedOpacity(
+      duration: const Duration(milliseconds: 160),
+      opacity: _isMutating ? 0.55 : 1,
+      child: IgnorePointer(
+        ignoring: _isMutating,
+        child: ChestFooter(
+          item: item,
+          selectedConversationEntry: _selectedConvEntry,
+          currentUserId: SupabaseProvider.client.auth.currentUser?.id,
+          iconSize: iconSize,
+          gap: gap,
+          bottomPadding: bottomPadding,
+          onHome: _goHome,
+          onInfo: _showScrignoInfo,
+          onSendHonooToMoon: _sendHonooToMoon,
+          onReplyToHonoo: _showReplyChoiceForHonoo,
+          onDeleteHonoo: _deleteHonoo,
+          onSendHinooToMoon: _sendHinooToMoon,
+          onReplyToHinoo: _showReplyChoiceForHinoo,
+          onDeleteHinoo: _deleteHinoo,
+          onSendConversationEntryToMoon: _sendConversationEntryToMoon,
+        ),
+      ),
     );
   }
 
   Future<void> _sendHonooToMoon(Honoo honoo) async {
+    if (_isMutating) return;
+    setState(() => _isMutating = true);
     try {
-      final ok = await HonooController().sendToMoon(honoo);
+      final result = await HonooController().sendToMoon(honoo);
       if (!mounted) return;
       setState(_rebuildItems);
       showHonooToast(
         context,
-        message: ok
+        message: result == DuplicationResult.inserted
             ? "L'honoo è anche sulla Luna."
             : "L'honoo era già presente sulla Luna.",
       );
     } catch (error) {
       if (!mounted) return;
       showHonooToast(context, message: 'Errore: $error');
+    } finally {
+      if (mounted) setState(() => _isMutating = false);
     }
   }
 
@@ -316,17 +345,28 @@ class _ChestPageState extends State<ChestPage> {
       target: HonooDeletionTarget.honoo,
     );
     if (!mounted || confirmed != true) return;
-    final String? id = (honoo.dbId ?? honoo.id) as String?;
+    final String? id = honoo.dbId;
     if (id == null || id.isEmpty) {
       showHonooToast(context, message: 'Impossibile cancellare: id mancante.');
       return;
     }
-    await ctrl.deleteHonooById(id);
-    if (!mounted) return;
-    showHonooToast(context, message: 'honoo eliminato.');
+    setState(() => _isMutating = true);
+    try {
+      await ctrl.deleteHonooById(id);
+      if (!mounted) return;
+      showHonooToast(context, message: 'honoo eliminato.');
+    } catch (error) {
+      if (!mounted) return;
+      showHonooToast(context,
+          message: 'Errore durante l\'eliminazione: $error');
+    } finally {
+      if (mounted) setState(() => _isMutating = false);
+    }
   }
 
   Future<void> _sendHinooToMoon(ChestHinooItem hinoo) async {
+    if (_isMutating) return;
+    setState(() => _isMutating = true);
     try {
       final result = await _hinooController.sendToMoon(hinoo.draft);
       if (!mounted) return;
@@ -338,13 +378,24 @@ class _ChestPageState extends State<ChestPage> {
     } catch (error) {
       if (!mounted) return;
       showHonooToast(context, message: 'Errore: $error');
+    } finally {
+      if (mounted) setState(() => _isMutating = false);
     }
   }
 
   Future<void> _sendConversationEntryToMoon(ConversationEntry entry) async {
+    if (_isMutating) return;
+    setState(() => _isMutating = true);
     try {
       if (entry.kind == ConversationEntryKind.honoo) {
-        await _sendHonooToMoon(entry.honoo!);
+        final result = await HonooController().sendToMoon(entry.honoo!);
+        if (!mounted) return;
+        showHonooToast(
+          context,
+          message: result == DuplicationResult.inserted
+              ? "L'honoo è anche sulla Luna."
+              : "L'honoo era già presente sulla Luna.",
+        );
       } else {
         final result = await _hinooController.sendToMoon(entry.hinoo!);
         if (!mounted) return;
@@ -356,6 +407,8 @@ class _ChestPageState extends State<ChestPage> {
     } catch (error) {
       if (!mounted) return;
       showHonooToast(context, message: 'Errore: $error');
+    } finally {
+      if (mounted) setState(() => _isMutating = false);
     }
   }
 
@@ -366,6 +419,8 @@ class _ChestPageState extends State<ChestPage> {
     );
     if (confirmed != true) return;
 
+    if (_isMutating) return;
+    setState(() => _isMutating = true);
     try {
       await _chestRepository.deleteHinoo(current.id);
 
@@ -375,6 +430,8 @@ class _ChestPageState extends State<ChestPage> {
     } catch (e) {
       if (!mounted) return;
       showHonooToast(context, message: 'Errore durante l\'eliminazione: $e');
+    } finally {
+      if (mounted) setState(() => _isMutating = false);
     }
   }
 
@@ -663,6 +720,39 @@ class _ChestPageState extends State<ChestPage> {
     );
   }
 
+  Widget _buildLoadError({required bool compact}) {
+    return Material(
+      color: Colors.black.withOpacity(compact ? 0.72 : 0),
+      borderRadius: BorderRadius.circular(12),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              compact
+                  ? 'Scrigno non aggiornato: mostro gli ultimi dati disponibili.'
+                  : 'Non riesco a caricare lo Scrigno.',
+              textAlign: TextAlign.center,
+              style: GoogleFonts.libreFranklin(
+                color: HonooColor.onBackground,
+                fontSize: compact ? 13 : 17,
+              ),
+            ),
+            TextButton.icon(
+              onPressed: () => unawaited(_loadAll()),
+              icon: const Icon(Icons.refresh, color: Colors.white),
+              label: const Text(
+                'Riprova',
+                style: TextStyle(color: Colors.white),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return AnimatedBuilder(
@@ -687,11 +777,15 @@ class _ChestPageState extends State<ChestPage> {
               maxWidth: viewW,
               mode: layoutMode,
             );
-            if (ctrl.isLoading.value || _isHinooLoading) {
+            final items = _itemsNormal;
+            final loadError = _loadError;
+            if ((ctrl.isLoading.value || _isHinooLoading) && items.isEmpty) {
               return const Center(child: LoadingSpinner(color: Colors.white));
             }
-            final items = _itemsNormal;
             if (items.isEmpty) {
+              if (loadError != null) {
+                return Center(child: _buildLoadError(compact: false));
+              }
               return Center(
                 child: Text(
                   'Nessun contenuto nello scrigno',
@@ -732,6 +826,19 @@ class _ChestPageState extends State<ChestPage> {
                 );
               },
             );
+            final visibleSlider = loadError == null
+                ? slider
+                : Stack(
+                    children: [
+                      Positioned.fill(child: slider),
+                      Positioned(
+                        top: 8,
+                        left: 16,
+                        right: 16,
+                        child: Center(child: _buildLoadError(compact: true)),
+                      ),
+                    ],
+                  );
             // Il reveal della conversazione viene gestito da
             // UnifiedThreadView usando i messaggi reali del thread. Qui ogni
             // conversazione occupa ormai una sola slide del carosello.
@@ -739,7 +846,7 @@ class _ChestPageState extends State<ChestPage> {
                 layoutMode == ResponsiveLayoutMode.wideDesktop ||
                 layoutMode == ResponsiveLayoutMode.largeDesktop;
             if (!isDesktop || items.length <= 1) {
-              return slider;
+              return visibleSlider;
             }
             return DesktopCarouselArrows(
               canPrev: _currentIndex > 0,
@@ -755,7 +862,7 @@ class _ChestPageState extends State<ChestPage> {
                 curve: Curves.easeOutCubic,
               ),
               arrowColor: Colors.white,
-              child: slider,
+              child: visibleSlider,
             );
           },
           footerBuilder: (ctx, mode, footerIconSize, footerGap,

--- a/lib/Pages/conversation_page.dart
+++ b/lib/Pages/conversation_page.dart
@@ -1,8 +1,8 @@
-
 import 'package:carousel_slider/carousel_slider.dart' as cs;
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:honoo/Controller/honoo_controller.dart';
+import 'package:honoo/Services/duplication_result.dart';
 import 'package:honoo/UI/honoo_card.dart';
 import 'package:honoo/Utility/honoo_colors.dart';
 import 'package:honoo/Widgets/loading_spinner.dart';
@@ -84,39 +84,39 @@ class _ConversationPageState extends State<ConversationPage> {
           mode: layoutMode,
         );
 
-          final Widget carousel = _isLoading
-              ? const Center(child: LoadingSpinner())
-              : (_thread.isEmpty
-                  ? Center(
-                      child: Text(
-                        'Nessuna conversazione',
-                        style: GoogleFonts.libreFranklin(
-                          color: HonooColor.onBackground,
-                          fontSize: 18,
-                          fontWeight: FontWeight.w400,
-                        ),
+        final Widget carousel = _isLoading
+            ? const Center(child: LoadingSpinner())
+            : (_thread.isEmpty
+                ? Center(
+                    child: Text(
+                      'Nessuna conversazione',
+                      style: GoogleFonts.libreFranklin(
+                        color: HonooColor.onBackground,
+                        fontSize: 18,
+                        fontWeight: FontWeight.w400,
                       ),
-                    )
-                  : cs.CarouselSlider(
-                      carouselController: _carouselController,
-                      options: cs.CarouselOptions(
-                        scrollDirection: Axis.vertical,
+                    ),
+                  )
+                : cs.CarouselSlider(
+                    carouselController: _carouselController,
+                    options: cs.CarouselOptions(
+                      scrollDirection: Axis.vertical,
+                      height: honooMetrics.height,
+                      viewportFraction: 1.0,
+                      enlargeCenterPage: false,
+                      enableInfiniteScroll: false,
+                      onPageChanged: (index, reason) {
+                        setState(() => _currentIndex = index);
+                      },
+                    ),
+                    items: _thread.map((h) {
+                      return SizedBox(
+                        width: honooMetrics.width,
                         height: honooMetrics.height,
-                        viewportFraction: 1.0,
-                        enlargeCenterPage: false,
-                        enableInfiniteScroll: false,
-                        onPageChanged: (index, reason) {
-                          setState(() => _currentIndex = index);
-                        },
-                      ),
-                      items: _thread.map((h) {
-                        return SizedBox(
-                          width: honooMetrics.width,
-                          height: honooMetrics.height,
-                          child: HonooCard(honoo: h),
-                        );
-                      }).toList(),
-                    ));
+                        child: HonooCard(honoo: h),
+                      );
+                    }).toList(),
+                  ));
 
         return carousel;
       },
@@ -164,7 +164,7 @@ class _ConversationPageState extends State<ConversationPage> {
                           if (!context.mounted) return;
                           showHonooToast(
                             context,
-                            message: saved
+                            message: saved == DuplicationResult.inserted
                                 ? 'honoo salvato nel tuo Scrigno.'
                                 : 'Era già nel tuo Scrigno.',
                           );
@@ -202,7 +202,8 @@ class _ConversationPageState extends State<ConversationPage> {
                             builder: (context) => ReplyHonooPage(
                               originalHonoo: honoo,
                               initialHintText: 'Scrivi la tua risposta...',
-                              initialImageHint: 'Aggiungi un’immagine (opzionale)',
+                              initialImageHint:
+                                  'Aggiungi un’immagine (opzionale)',
                             ),
                           ),
                         );

--- a/lib/Pages/moon_page.dart
+++ b/lib/Pages/moon_page.dart
@@ -6,6 +6,7 @@ import 'package:google_fonts/google_fonts.dart';
 import 'package:honoo/Services/content_feed_service.dart';
 import 'package:honoo/Services/admin_service.dart';
 import 'package:honoo/Services/honoo_service.dart';
+import 'package:honoo/Services/duplication_result.dart';
 import 'package:honoo/Services/hinoo_service.dart';
 
 import '../Entities/hinoo.dart';
@@ -525,7 +526,7 @@ class _MoonPageState extends State<MoonPage> {
         if (!mounted) return;
         showHonooToast(
           context,
-          message: saved
+          message: saved == DuplicationResult.inserted
               ? 'honoo salvato nello Scrigno.'
               : 'Era già nel tuo Scrigno.',
         );

--- a/lib/Pages/new_honoo_page.dart
+++ b/lib/Pages/new_honoo_page.dart
@@ -8,6 +8,7 @@ import '../Entities/honoo.dart';
 import '../Services/honoo_image_uploader.dart';
 import '../UI/honoo_builder.dart';
 import 'package:honoo/Services/honoo_service.dart';
+import 'package:honoo/Services/duplication_result.dart';
 
 import 'email_login_page.dart';
 import 'chest_page.dart';
@@ -311,13 +312,14 @@ class _NewHonooPageState extends State<NewHonooPage> {
         null,
       );
 
-      final ok = await HonooService.duplicateToMoon(honooForMoon);
+      final result = await HonooService.duplicateToMoon(honooForMoon);
 
       if (!mounted) return false;
       showHonooToast(
         context,
-        message:
-            ok ? "L'honoo è anche sulla Luna." : 'Già presente sulla Luna.',
+        message: result == DuplicationResult.inserted
+            ? "L'honoo è anche sulla Luna."
+            : 'Già presente sulla Luna.',
       );
       return true;
     } catch (e, st) {

--- a/lib/Services/chest_repository.dart
+++ b/lib/Services/chest_repository.dart
@@ -1,13 +1,18 @@
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 import 'supabase_provider.dart';
+import 'reliability_policy.dart';
 
 /// Accesso dati dello Scrigno. Non contiene stato, mapping UI o ordinamento.
 class ChestRepository {
-  ChestRepository({SupabaseClient? client})
-      : _client = client ?? SupabaseProvider.client;
+  ChestRepository({
+    SupabaseClient? client,
+    ReliabilityPolicy reliabilityPolicy = const ReliabilityPolicy(),
+  })  : _client = client ?? SupabaseProvider.client,
+        _reliability = reliabilityPolicy;
 
   final SupabaseClient _client;
+  final ReliabilityPolicy _reliability;
 
   Future<Set<String>> fetchHinooMoonFingerprints(String userId) async {
     final rows = await _client
@@ -29,8 +34,8 @@ class ChestRepository {
           .select(
               'id,pages,type,reply_to,recipient_tag,created_at,is_from_moon_saved,user_id,conversation_id')
           .eq('user_id', userId)
-          .in_('type', ['personal', 'answer'])
-          .order('created_at', ascending: false);
+          .in_('type', ['personal', 'answer']).order('created_at',
+              ascending: false);
       return _asList(rows);
     } on PostgrestException catch (error) {
       final combined =
@@ -42,8 +47,8 @@ class ChestRepository {
           .select(
               'id,pages,type,reply_to,recipient_tag,created_at,user_id,conversation_id')
           .eq('user_id', userId)
-          .in_('type', ['personal', 'answer'])
-          .order('created_at', ascending: false);
+          .in_('type', ['personal', 'answer']).order('created_at',
+              ascending: false);
       return _asList(rows);
     }
   }
@@ -86,7 +91,9 @@ class ChestRepository {
   }
 
   Future<void> deleteHinoo(String id) async {
-    await _client.from('hinoo').delete().eq('id', id);
+    await _reliability.write(
+      () async => await _client.from('hinoo').delete().eq('id', id),
+    );
   }
 
   static List<dynamic> _asList(dynamic rows) {

--- a/lib/Services/duplication_result.dart
+++ b/lib/Services/duplication_result.dart
@@ -1,0 +1,1 @@
+enum DuplicationResult { inserted, alreadyPresent }

--- a/lib/Services/hinoo_service.dart
+++ b/lib/Services/hinoo_service.dart
@@ -2,9 +2,12 @@ import 'package:flutter/foundation.dart';
 import 'package:honoo/Services/supabase_provider.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import '../Entities/hinoo.dart';
+import 'duplication_result.dart';
+import 'reliability_policy.dart';
 
 class HinooService {
   static const String _table = 'hinoo';
+  static const ReliabilityPolicy _reliability = ReliabilityPolicy();
 
   // Iniezione client per i test
   static SupabaseClient? _testClient;
@@ -54,38 +57,9 @@ class HinooService {
       'created_at': DateTime.now().toIso8601String(),
     };
 
-    try {
-      debugPrint('[HinooService] publishHinoo data=$data');
-      final res =
-          await _client.from(_table).insert(data).select().maybeSingle();
-      if (res == null) throw 'publishHinoo: insert fallita';
-    } on PostgrestException catch (e) {
-      if (_isMissingMoonSavedColumn(e)) {
-        final fallback = Map<String, dynamic>.from(data)
-          ..remove('is_from_moon_saved');
-        final res =
-            await _client.from(_table).insert(fallback).select().maybeSingle();
-        if (res == null) throw 'publishHinoo: insert fallita';
-        return;
-      }
-      debugPrint(
-          '[HinooService] publishHinoo error: ${e.message} details=${e.details} hint=${e.hint} code=${e.code}');
-      String msg = e.message;
-      final details = e.details;
-      final hint = e.hint;
-      final code = e.code;
-      if (msg.isEmpty && code != null && code.isNotEmpty) {
-        msg = code;
-      }
-      if (msg.isEmpty) {
-        msg = 'sconosciuto';
-      }
-      final extra = [
-        if (details != null && details.isNotEmpty) details,
-        if (hint != null && hint.isNotEmpty) 'hint: $hint',
-      ].join(' — ');
-      throw 'Errore salvataggio hinoo: $msg${extra.isNotEmpty ? ' ($extra)' : ''}';
-    }
+    debugPrint('[HinooService] publishHinoo data=$data');
+    final res = await _insertPublished(data);
+    if (res == null) throw 'publishHinoo: insert fallita';
   }
 
   static Future<String> publishHinooAndReturnId(HinooDraft draft) async {
@@ -105,65 +79,36 @@ class HinooService {
       'created_at': DateTime.now().toIso8601String(),
     };
 
-    try {
-      debugPrint('[HinooService] publishHinoo data=$data');
-      final res =
-          await _client.from(_table).insert(data).select().maybeSingle();
-      if (res == null) throw 'publishHinoo: insert fallita';
-      final id = res['id']?.toString() ?? '';
-      if (id.isEmpty) throw 'publishHinoo: id mancante';
-      return id;
-    } on PostgrestException catch (e) {
-      if (_isMissingMoonSavedColumn(e)) {
+    debugPrint('[HinooService] publishHinoo data=$data');
+    final res = await _insertPublished(data);
+    if (res == null) throw 'publishHinoo: insert fallita';
+    final id = res['id']?.toString() ?? '';
+    if (id.isEmpty) throw 'publishHinoo: id mancante';
+    return id;
+  }
+
+  static Future<Map<String, dynamic>?> _insertPublished(
+    Map<String, dynamic> data,
+  ) {
+    return _reliability.write(() async {
+      try {
+        return await _client.from(_table).insert(data).select().maybeSingle();
+      } on PostgrestException catch (error) {
+        if (!_isMissingMoonSavedColumn(error)) rethrow;
         final fallback = Map<String, dynamic>.from(data)
           ..remove('is_from_moon_saved');
-        final res =
-            await _client.from(_table).insert(fallback).select().maybeSingle();
-        if (res == null) throw 'publishHinoo: insert fallita';
-        final id = res['id']?.toString() ?? '';
-        if (id.isEmpty) throw 'publishHinoo: id mancante';
-        return id;
+        return _client.from(_table).insert(fallback).select().maybeSingle();
       }
-      debugPrint(
-          '[HinooService] publishHinoo error: ${e.message} details=${e.details} hint=${e.hint} code=${e.code}');
-      String msg = e.message;
-      final details = e.details;
-      final hint = e.hint;
-      final code = e.code;
-      if (msg.isEmpty && code != null && code.isNotEmpty) {
-        msg = code;
-      }
-      if (msg.isEmpty) {
-        msg = 'sconosciuto';
-      }
-      final extra = [
-        if (details != null && details.isNotEmpty) details,
-        if (hint != null && hint.isNotEmpty) 'hint: $hint',
-      ].join(' — ');
-      throw 'Errore salvataggio hinoo: $msg${extra.isNotEmpty ? ' ($extra)' : ''}';
-    }
+    });
   }
 
   /// Inserisce un record type='moon' se non già presente (dedup su fingerprint)
-  static Future<bool> duplicateToMoon(HinooDraft draft) async {
+  static Future<DuplicationResult> duplicateToMoon(HinooDraft draft) async {
     final userId = _client.auth.currentUser?.id;
     if (userId == null) throw 'Utente non autenticato';
 
     final sanitized = draft.copyWith(type: HinooType.moon);
     final fp = fingerprint(sanitized);
-
-    // Verifica duplicato nella STESSA tabella
-    final existing = await _client
-        .from(_table)
-        .select('id')
-        .eq('user_id', userId)
-        .eq('type', 'moon')
-        .eq('fingerprint', fp)
-        .limit(1);
-
-    if (existing is List && existing.isNotEmpty) {
-      return false;
-    }
 
     final data = {
       'user_id': userId,
@@ -176,38 +121,13 @@ class HinooService {
       'created_at': DateTime.now().toIso8601String(),
     };
 
-    try {
-      debugPrint('[HinooService] duplicateToMoon data=$data');
-      await _client.from(_table).insert(data);
-      return true;
-    } on PostgrestException catch (e) {
-      if (_isMissingMoonSavedColumn(e)) {
-        final fallback = Map<String, dynamic>.from(data)
-          ..remove('is_from_moon_saved');
-        await _client.from(_table).insert(fallback);
-        return true;
-      }
-      debugPrint(
-          '[HinooService] duplicateToMoon error: ${e.message} details=${e.details} hint=${e.hint} code=${e.code}');
-      String msg = e.message;
-      final details = e.details;
-      final hint = e.hint;
-      final code = e.code;
-      if (msg.isEmpty && code != null && code.isNotEmpty) {
-        msg = code;
-      }
-      if (msg.isEmpty) {
-        msg = 'sconosciuto';
-      }
-      final extra = [
-        if (details != null && details.isNotEmpty) details,
-        if (hint != null && hint.isNotEmpty) 'hint: $hint',
-      ].join(' — ');
-      throw 'Errore pubblicazione Luna: $msg${extra.isNotEmpty ? ' ($extra)' : ''}';
-    }
+    debugPrint('[HinooService] duplicateToMoon data=$data');
+    return _insertDuplicate(data);
   }
 
-  static Future<bool> duplicateMoonToChest(HinooDraft draft) async {
+  static Future<DuplicationResult> duplicateMoonToChest(
+    HinooDraft draft,
+  ) async {
     final userId = _client.auth.currentUser?.id;
     if (userId == null) throw 'Utente non autenticato';
 
@@ -216,18 +136,6 @@ class HinooService {
       isFromMoonSaved: true,
     );
     final fp = fingerprint(sanitized);
-
-    final existing = await _client
-        .from(_table)
-        .select('id')
-        .eq('user_id', userId)
-        .eq('type', 'personal')
-        .eq('fingerprint', fp)
-        .limit(1);
-
-    if (existing is List && existing.isNotEmpty) {
-      return false;
-    }
 
     final data = {
       'user_id': userId,
@@ -241,23 +149,39 @@ class HinooService {
       'created_at': DateTime.now().toIso8601String(),
     };
 
-    try {
-      await _client.from(_table).insert(data);
-      return true;
-    } on PostgrestException catch (e) {
-      if (_isMissingMoonSavedColumn(e)) {
+    return _insertDuplicate(data);
+  }
+
+  static Future<DuplicationResult> _insertDuplicate(
+    Map<String, dynamic> data,
+  ) {
+    return _reliability.write(() async {
+      try {
+        await _client.from(_table).insert(data);
+        return DuplicationResult.inserted;
+      } on PostgrestException catch (error) {
+        if (error.code == '23505') return DuplicationResult.alreadyPresent;
+        if (!_isMissingMoonSavedColumn(error)) rethrow;
         final fallback = Map<String, dynamic>.from(data)
           ..remove('is_from_moon_saved');
-        await _client.from(_table).insert(fallback);
-        return true;
+        try {
+          await _client.from(_table).insert(fallback);
+          return DuplicationResult.inserted;
+        } on PostgrestException catch (fallbackError) {
+          if (fallbackError.code == '23505') {
+            return DuplicationResult.alreadyPresent;
+          }
+          rethrow;
+        }
       }
-      rethrow;
-    }
+    });
   }
 
   static Future<void> deleteHinooById(String id) async {
     if (id.trim().isEmpty) return;
-    await _client.from(_table).delete().eq('id', id);
+    await _reliability.write(
+      () => _client.from(_table).delete().eq('id', id),
+    );
   }
 
   static String fingerprint(HinooDraft d) {

--- a/lib/Services/hinoo_storage_uploader.dart
+++ b/lib/Services/hinoo_storage_uploader.dart
@@ -3,10 +3,12 @@ import 'dart:typed_data';
 import 'package:honoo/Services/supabase_provider.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:uuid/uuid.dart';
+import 'reliability_policy.dart';
 
 class HinooStorageUploader {
   static const String bucket = 'hinoo';
   static const Uuid _uuid = Uuid();
+  static const ReliabilityPolicy _reliability = ReliabilityPolicy();
 
   // Getter iniettabile nei test
   static SupabaseClient get _client =>
@@ -67,17 +69,19 @@ class HinooStorageUploader {
     final id = _uuid.v4();
     final path = '$userId/$safeFolder/$id.$safeExt';
 
-    await _client.storage.from(bucket).uploadBinary(
-          path,
-          bytes,
-          fileOptions: FileOptions(
-            upsert: false,
-            // storage_client sends this as a multipart field and Supabase
-            // expects seconds only (not a complete HTTP Cache-Control value).
-            cacheControl: '31536000',
-            contentType: _contentTypeForExt(safeExt),
+    await _reliability.write(
+      () => _client.storage.from(bucket).uploadBinary(
+            path,
+            bytes,
+            fileOptions: FileOptions(
+              upsert: false,
+              // storage_client sends this as a multipart field and Supabase
+              // expects seconds only (not a complete HTTP Cache-Control value).
+              cacheControl: '31536000',
+              contentType: _contentTypeForExt(safeExt),
+            ),
           ),
-        );
+    );
 
     return _client.storage.from(bucket).getPublicUrl(path);
   }

--- a/lib/Services/honoo_image_uploader.dart
+++ b/lib/Services/honoo_image_uploader.dart
@@ -4,10 +4,12 @@ import 'package:flutter/foundation.dart';
 import 'package:honoo/Services/supabase_provider.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:uuid/uuid.dart';
+import 'reliability_policy.dart';
 
 class HonooImageUploader {
   static final _client = SupabaseProvider.client;
   static const String _bucket = 'honoo-images'; // <-- bucket pubblico
+  static const ReliabilityPolicy _reliability = ReliabilityPolicy();
 
   /// Mobile (Android/iOS): carica da path locale e restituisce la public URL.
   static Future<String?> uploadImageFromPath(String path) async {
@@ -25,15 +27,17 @@ class HonooImageUploader {
       final fileName = '${const Uuid().v4()}$ext';
       final storagePath = '$uid/uploads/$fileName'; // per-utente
 
-      await _client.storage.from(_bucket).uploadBinary(
-            storagePath,
-            bytes,
-            fileOptions: FileOptions(
-              upsert: false,
-              cacheControl: '31536000',
-              contentType: _contentTypeFromExt(ext),
+      await _reliability.write(
+        () => _client.storage.from(_bucket).uploadBinary(
+              storagePath,
+              bytes,
+              fileOptions: FileOptions(
+                upsert: false,
+                cacheControl: '31536000',
+                contentType: _contentTypeFromExt(ext),
+              ),
             ),
-          );
+      );
 
       return _client.storage.from(_bucket).getPublicUrl(storagePath);
     } catch (e) {
@@ -56,15 +60,17 @@ class HonooImageUploader {
       final fileName = '${const Uuid().v4()}$ext';
       final storagePath = '$uid/uploads/$fileName'; // per-utente
 
-      await _client.storage.from(_bucket).uploadBinary(
-            storagePath,
-            bytes,
-            fileOptions: FileOptions(
-              upsert: false,
-              cacheControl: '31536000',
-              contentType: _contentTypeFromExt(ext),
+      await _reliability.write(
+        () => _client.storage.from(_bucket).uploadBinary(
+              storagePath,
+              bytes,
+              fileOptions: FileOptions(
+                upsert: false,
+                cacheControl: '31536000',
+                contentType: _contentTypeFromExt(ext),
+              ),
             ),
-          );
+      );
 
       return _client.storage.from(_bucket).getPublicUrl(storagePath);
     } catch (e) {

--- a/lib/Services/honoo_service.dart
+++ b/lib/Services/honoo_service.dart
@@ -1,8 +1,11 @@
 import 'package:honoo/Services/supabase_provider.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import '../Entities/honoo.dart';
+import 'duplication_result.dart';
+import 'reliability_policy.dart';
 
 class HonooService {
+  static const ReliabilityPolicy _reliability = ReliabilityPolicy();
   //sostituisci fuori dal test con il tuo client
   //static final _client = Supabase.instance.client;
 
@@ -18,63 +21,65 @@ class HonooService {
 
   /// Honoo pubblici (Luna)
   static Future<List<Honoo>> fetchPublicHonoo() async {
-    final response = await _client
+    final response = await _reliability.read(() async => await _client
         .from('honoo')
         .select('*')
         .eq('destination', 'moon')
-        .order('created_at', ascending: false);
+        .order('created_at', ascending: false));
     return (response as List).map((e) => Honoo.fromMap(e)).toList();
   }
 
   /// Honoo dell’utente per una certa destination (es. 'chest')
   static Future<List<Honoo>> fetchUserHonoo(
       String userId, String destination) async {
-    final response = await _client
+    final response = await _reliability.read(() async => await _client
         .from('honoo')
         .select('*')
         .eq('destination', destination)
         .eq('user_id', userId)
-        .order('created_at', ascending: false);
+        .order('created_at', ascending: false));
     return (response as List).map((e) => Honoo.fromMap(e)).toList();
   }
 
   /// Radici personali e risposte scritte dall'utente che devono comparire
   /// come un solo accesso alla relativa conversazione nello Scrigno.
   static Future<List<Honoo>> fetchUserChestHonoo(String userId) async {
-    final response = await _client
+    final response = await _reliability.read(() async => await _client
         .from('honoo')
         .select('*')
         .eq('user_id', userId)
         .in_('destination', ['chest', 'reply']).order('created_at',
-            ascending: false);
+            ascending: false));
     return (response as List).map((e) => Honoo.fromMap(e)).toList();
   }
 
   /// Tutte le reply indirizzate a recipientTag (se usi i tag poetici)
   static Future<List<Honoo>> fetchRepliesForUser(String recipientTag) async {
-    final response = await _client
+    final response = await _reliability.read(() async => await _client
         .from('honoo')
         .select('*')
         .eq('destination', 'reply')
         .eq('recipient_tag', recipientTag)
-        .order('created_at', ascending: false);
+        .order('created_at', ascending: false));
     return (response as List).map((e) => Honoo.fromMap(e)).toList();
   }
 
   /// Pubblica un nuovo honoo
   static Future<void> publishHonoo(Honoo honoo) async {
     _validateConversationLink(honoo);
-    await _client.from('honoo').insert(honoo.toInsertMap());
+    await _reliability.write(
+      () async => await _client.from('honoo').insert(honoo.toInsertMap()),
+    );
   }
 
   static Future<String> publishHonooAndReturnId(Honoo honoo) async {
     _validateConversationLink(honoo);
     Map<String, dynamic>? row;
-    row = await _client
+    row = await _reliability.write(() async => await _client
         .from('honoo')
         .insert(honoo.toInsertMap())
         .select('id')
-        .maybeSingle();
+        .maybeSingle());
     final id = row?['id']?.toString() ?? '';
     if (id.isEmpty) {
       throw Exception('publishHonoo: id mancante');
@@ -98,32 +103,19 @@ class HonooService {
     required String id,
     required String destination,
   }) async {
-    await _client.from('honoo').update({
-      'destination': destination,
-    }).eq('id', id);
+    await _reliability.write(() async => await _client.from('honoo').update({
+          'destination': destination,
+        }).eq('id', id));
   }
 
   /// Duplica un honoo salvandolo nello scrigno dell'utente corrente.
-  /// Restituisce true se inserito ora, false se già presente.
-  static Future<bool> duplicateToChest(Honoo h) async {
+  /// L'indice univoco sul fingerprint rende inserimento e deduplica atomici.
+  static Future<DuplicationResult> duplicateToChest(Honoo h) async {
     final session = _client.auth.currentSession;
     if (session == null) {
       throw Exception('Nessuna sessione attiva');
     }
     final uid = session.user.id;
-
-    final existing = await _client
-        .from('honoo')
-        .select('id')
-        .eq('user_id', uid)
-        .eq('destination', 'chest')
-        .eq('text', h.text)
-        .eq('image_url', h.image.isEmpty ? null : h.image)
-        .limit(1);
-
-    if (existing != null && existing.isNotEmpty) {
-      return false;
-    }
 
     final payload = <String, dynamic>{
       'text': h.text,
@@ -133,54 +125,53 @@ class HonooService {
       'recipient_tag': h.recipientTag,
       'user_id': uid,
       'conversation_id': h.conversationId ?? h.dbId,
+      'fingerprint': fingerprint(h),
       if (h.isFromMoonSaved) 'is_from_moon_saved': true,
     };
-
-    final inserted =
-        await _client.from('honoo').insert(payload).select().maybeSingle();
-
-    return inserted != null;
+    return _insertDuplicate(payload);
   }
 
   /// Duplica un honoo dello scrigno pubblicandolo sulla Luna (nuova INSERT).
   /// Non tocca l'originale in 'chest'.
-  static Future<bool> duplicateToMoon(Honoo h) async {
+  static Future<DuplicationResult> duplicateToMoon(Honoo h) async {
     final session = _client.auth.currentSession;
     if (session == null) {
       throw Exception('Nessuna sessione attiva');
     }
     final uid = session.user.id;
 
-    // esiste già?
-    final existing = await _client
-        .from('honoo')
-        .select('id')
-        .eq('user_id', uid)
-        .eq('destination', 'moon')
-        .eq('text', h.text)
-        .eq('image_url', (h.image.isEmpty) ? null : h.image)
-        .limit(1);
-
-    if (existing != null && existing.isNotEmpty) {
-      // già presente
-      return false;
-    }
-
-    // inserisci
     final payload = <String, dynamic>{
       'text': h.text,
       'image_url': (h.image.isEmpty) ? null : h.image,
       'destination': 'moon',
       'reply_to': null,
       'recipient_tag': null,
-      'user_id': uid, // se hai un trigger che lo mette da solo, puoi ometterlo
+      'user_id': uid,
+      'fingerprint': fingerprint(h),
     };
-    await _client.from('honoo').insert(payload);
-    return true;
+    return _insertDuplicate(payload);
+  }
+
+  static String fingerprint(Honoo h) => '${h.text}\u001f${h.image}';
+
+  static Future<DuplicationResult> _insertDuplicate(
+    Map<String, dynamic> payload,
+  ) {
+    return _reliability.write(() async {
+      try {
+        await _client.from('honoo').insert(payload);
+        return DuplicationResult.inserted;
+      } on PostgrestException catch (error) {
+        if (error.code == '23505') return DuplicationResult.alreadyPresent;
+        rethrow;
+      }
+    });
   }
 
   /// Hard delete dal DB (tabella 'honoo')
   static Future<void> deleteHonooById(String id) async {
-    await _client.from('honoo').delete().eq('id', id);
+    await _reliability.write(
+      () async => await _client.from('honoo').delete().eq('id', id),
+    );
   }
 }

--- a/lib/UI/hinoo_viewer.dart
+++ b/lib/UI/hinoo_viewer.dart
@@ -8,6 +8,7 @@ import '../Entities/hinoo.dart';
 import 'hinoo_typography.dart';
 import '../Utility/honoo_colors.dart';
 import '../Utility/network_image_prefetch.dart';
+import '../Widgets/smooth_image.dart';
 import '../Widgets/text_box_download_button.dart';
 
 class HinooViewer extends StatefulWidget {
@@ -318,7 +319,11 @@ class HinooSlideView extends StatelessWidget {
             child: Transform(
               transform: transform,
               alignment: Alignment.center,
-              child: Image(image: bg, fit: BoxFit.cover),
+              child: SmoothImage(
+                image: bg,
+                fit: BoxFit.cover,
+                placeholderColor: HonooColor.background,
+              ),
             ),
           ),
           Positioned.fill(

--- a/lib/UI/honoo_card.dart
+++ b/lib/UI/honoo_card.dart
@@ -5,6 +5,7 @@ import 'package:google_fonts/google_fonts.dart';
 import '../Entities/honoo.dart';
 import 'package:honoo/Services/supabase_provider.dart';
 import '../Utility/honoo_colors.dart';
+import '../Widgets/smooth_image.dart';
 import '../Widgets/text_box_download_button.dart';
 
 class HonooCard extends StatelessWidget {
@@ -64,9 +65,8 @@ class HonooCard extends StatelessWidget {
 
         const double cornerRadius = 5;
 
-        final Color gapColor = honoo.type == HonooType.moon
-            ? HonooColor.tertiary
-            : cardBg;
+        final Color gapColor =
+            honoo.type == HonooType.moon ? HonooColor.tertiary : cardBg;
 
         final Widget content = Card(
           color: cardBg,
@@ -129,20 +129,17 @@ class HonooCard extends StatelessWidget {
                     ),
                   ),
                 ),
-
                 SizedBox(
                   width: imageSize,
                   height: gap,
                   child: ColoredBox(color: gapColor),
                 ),
-
                 SizedBox(
                   width: imageSize,
                   height: imageSize,
                   child: Container(
                     decoration: BoxDecoration(
                       color: HonooColor.tertiary,
-                      border: Border.all(color: Colors.black12),
                       borderRadius: BorderRadius.circular(cornerRadius),
                       boxShadow: [
                         BoxShadow(
@@ -151,15 +148,17 @@ class HonooCard extends StatelessWidget {
                           offset: const Offset(0, 2),
                         ),
                       ],
-                      image: hasImage
-                          ? DecorationImage(
-                              image: NetworkImage(imageUrl),
-                              fit: BoxFit.cover,
-                            )
-                          : null,
                     ),
+                    foregroundDecoration: BoxDecoration(
+                      border: Border.all(color: Colors.black12),
+                      borderRadius: BorderRadius.circular(cornerRadius),
+                    ),
+                    clipBehavior: Clip.antiAlias,
                     child: hasImage
-                        ? const SizedBox.shrink()
+                        ? SmoothImage(
+                            image: NetworkImage(imageUrl),
+                            placeholderColor: HonooColor.tertiary,
+                          )
                         : Column(
                             mainAxisAlignment: MainAxisAlignment.center,
                             children: [
@@ -186,20 +185,22 @@ class HonooCard extends StatelessWidget {
           ),
         );
 
-        final String? currentUserId = SupabaseProvider.client.auth.currentUser?.id;
-        final bool isOwn = currentUserId != null && currentUserId == honoo.userId;
+        final String? currentUserId =
+            SupabaseProvider.client.auth.currentUser?.id;
+        final bool isOwn =
+            currentUserId != null && currentUserId == honoo.userId;
         // La cornice rossa segnala soltanto una risposta ricevuta.
         // I propri messaggi mantengono il rendering normale.
         final bool showReplyBorder = isReply && !isOwn;
-        final bool showMoonSavedBorder = !showReplyBorder && honoo.isFromMoonSaved && !isOwn;
+        final bool showMoonSavedBorder =
+            !showReplyBorder && honoo.isFromMoonSaved && !isOwn;
         final Widget wrapped = (showReplyBorder || showMoonSavedBorder)
             ? DecoratedBox(
                 decoration: BoxDecoration(
                   borderRadius: BorderRadius.circular(12),
                   border: Border.all(
-                    color: showReplyBorder
-                        ? HonooColor.secondary
-                        : Colors.white,
+                    color:
+                        showReplyBorder ? HonooColor.secondary : Colors.white,
                     width: 6,
                   ),
                 ),

--- a/lib/Widgets/background.dart
+++ b/lib/Widgets/background.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import 'smooth_image.dart';
+
 class Background extends StatelessWidget {
   final Widget child;
   final String imagePath;
@@ -13,12 +15,12 @@ class Background extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Stack(
+      fit: StackFit.expand,
       children: <Widget>[
-        Image.asset(
-          imagePath,
-          height: MediaQuery.of(context).size.height,
-          width: MediaQuery.of(context).size.width,
+        SmoothImage(
+          image: AssetImage(imagePath),
           fit: BoxFit.cover,
+          placeholderColor: const Color(0xFF010E22),
         ),
         child,
       ],

--- a/lib/Widgets/smooth_image.dart
+++ b/lib/Widgets/smooth_image.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+
+/// Paints the full-quality image as soon as its first frame is available.
+///
+/// No lower-quality preview is used: until then, only [placeholderColor] is
+/// visible. Images already held by Flutter's cache are painted immediately.
+class SmoothImage extends StatefulWidget {
+  const SmoothImage({
+    super.key,
+    required this.image,
+    this.fit = BoxFit.cover,
+    this.alignment = Alignment.center,
+    this.placeholderColor = Colors.transparent,
+    this.fadeDuration = const Duration(milliseconds: 280),
+    this.cacheWidth,
+    this.cacheHeight,
+  });
+
+  final ImageProvider image;
+  final BoxFit fit;
+  final AlignmentGeometry alignment;
+  final Color placeholderColor;
+  final Duration fadeDuration;
+  final int? cacheWidth;
+  final int? cacheHeight;
+
+  @override
+  State<SmoothImage> createState() => _SmoothImageState();
+}
+
+class _SmoothImageState extends State<SmoothImage> {
+  int _attempt = 0;
+
+  Future<void> _retry() async {
+    await widget.image.evict();
+    if (mounted) setState(() => _attempt++);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final ratio = MediaQuery.devicePixelRatioOf(context);
+        final width = widget.cacheWidth ??
+            (constraints.maxWidth.isFinite
+                ? (constraints.maxWidth * ratio).round().clamp(1, 4096)
+                : null);
+        final height = widget.cacheHeight ??
+            (constraints.maxHeight.isFinite
+                ? (constraints.maxHeight * ratio).round().clamp(1, 4096)
+                : null);
+        final provider = ResizeImage.resizeIfNeeded(
+          width,
+          height,
+          widget.image,
+        );
+        return ColoredBox(
+          color: widget.placeholderColor,
+          child: Image(
+            key: ValueKey(_attempt),
+            image: provider,
+            fit: widget.fit,
+            alignment: widget.alignment,
+            filterQuality: FilterQuality.medium,
+            frameBuilder: (context, child, frame, wasSynchronouslyLoaded) {
+              if (wasSynchronouslyLoaded) return child;
+              return AnimatedOpacity(
+                opacity: frame == null ? 0 : 1,
+                duration: widget.fadeDuration,
+                curve: Curves.easeOutCubic,
+                child: child,
+              );
+            },
+            errorBuilder: (context, error, stackTrace) => Center(
+              child: IconButton(
+                onPressed: _retry,
+                tooltip: 'Riprova a caricare l’immagine',
+                icon: const Icon(Icons.refresh, color: Colors.white70),
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/supabase/migrations/20260721120000_atomic_content_deduplication.sql
+++ b/supabase/migrations/20260721120000_atomic_content_deduplication.sql
@@ -1,0 +1,52 @@
+-- Atomic deduplication for copies saved to the Chest or published to the Moon.
+alter table if exists public.honoo
+  add column if not exists fingerprint text;
+
+update public.honoo
+set fingerprint = text || chr(31) || coalesce(image_url, '')
+where fingerprint is null
+  and destination in ('chest', 'moon');
+
+-- Preserve historical rows while allowing one canonical fingerprint to guard
+-- future inserts. No user content is deleted by this migration.
+with ranked as (
+  select id,
+         row_number() over (
+           partition by user_id, destination, md5(fingerprint)
+           order by created_at, id
+         ) as occurrence
+  from public.honoo
+  where fingerprint is not null
+    and destination in ('chest', 'moon')
+)
+update public.honoo as item
+set fingerprint = null
+from ranked
+where item.id = ranked.id
+  and ranked.occurrence > 1;
+
+create unique index if not exists honoo_user_destination_fingerprint_key
+  on public.honoo (user_id, destination, md5(fingerprint))
+  where fingerprint is not null
+    and destination in ('chest', 'moon');
+
+with ranked as (
+  select id,
+         row_number() over (
+           partition by user_id, type, md5(fingerprint)
+           order by created_at, id
+         ) as occurrence
+  from public.hinoo
+  where fingerprint is not null
+    and type in ('personal', 'moon')
+)
+update public.hinoo as item
+set fingerprint = null
+from ranked
+where item.id = ranked.id
+  and ranked.occurrence > 1;
+
+create unique index if not exists hinoo_user_type_fingerprint_key
+  on public.hinoo (user_id, type, md5(fingerprint))
+  where fingerprint is not null
+    and type in ('personal', 'moon');

--- a/test/controllers/chest_controller_test.dart
+++ b/test/controllers/chest_controller_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:honoo/Controller/chest_controller.dart';
 import 'package:honoo/Entities/chest_item.dart';
@@ -202,5 +204,24 @@ void main() {
 
     await Future<void>.delayed(const Duration(milliseconds: 200));
     verify(() => repository.fetchHonooReplyRows('user-1')).called(1);
+  });
+
+  test('un refresh arrivato durante il caricamento viene accodato', () async {
+    final firstResponse = Completer<List<dynamic>>();
+    var callCount = 0;
+    when(() => repository.fetchHonooReplyRows('user-1')).thenAnswer((_) {
+      callCount++;
+      return callCount == 1 ? firstResponse.future : Future.value(const []);
+    });
+    when(() => repository.fetchHinooReplyRows('user-1', const []))
+        .thenAnswer((_) async => const []);
+
+    final runningRefresh = controller.refreshReplies('user-1');
+    await Future<void>.delayed(Duration.zero);
+    await controller.refreshReplies('user-1');
+    firstResponse.complete(const []);
+    await runningRefresh;
+
+    verify(() => repository.fetchHonooReplyRows('user-1')).called(2);
   });
 }

--- a/test/services/honoo_service_update_duplicate_test.dart
+++ b/test/services/honoo_service_update_duplicate_test.dart
@@ -6,6 +6,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 import 'package:honoo/Services/hinoo_service.dart';
+import 'package:honoo/Services/duplication_result.dart';
 import 'package:honoo/Entities/hinoo.dart';
 
 class _MockClient extends Mock implements SupabaseClient {}
@@ -13,6 +14,12 @@ class _MockClient extends Mock implements SupabaseClient {}
 class _MockAuth extends Mock implements GoTrueClient {}
 
 class _MockUser extends Mock implements User {}
+
+class _QueuedError {
+  const _QueuedError(this.error);
+
+  final Object error;
+}
 
 class _MockQueryChain extends Mock
     implements
@@ -22,6 +29,7 @@ class _MockQueryChain extends Mock
   final Queue<dynamic> _responses = Queue<dynamic>();
 
   void queueResponse(dynamic value) => _responses.add(value);
+  void queueError(Object error) => _responses.add(_QueuedError(error));
 
   @override
   dynamic noSuchMethod(Invocation invocation) {
@@ -30,6 +38,7 @@ class _MockQueryChain extends Mock
       final onValue =
           invocation.positionalArguments[0] as dynamic Function(dynamic);
       final result = _responses.isEmpty ? null : _responses.removeFirst();
+      if (result is _QueuedError) throw result.error;
       return Future.value(onValue(result));
     }
     return super.noSuchMethod(invocation);
@@ -88,38 +97,29 @@ void main() {
           recipientTag: null,
         );
 
-    test('se ESISTE già un duplicato → ritorna false e NON inserisce',
+    test('il conflitto univoco atomico viene riconosciuto come duplicato',
         () async {
-      chain.queueResponse([
-        {'id': 99}
-      ]);
+      chain.queueError(
+        const PostgrestException(message: 'duplicate', code: '23505'),
+      );
 
       final res = await HinooService.duplicateToMoon(sampleDraft());
 
-      expect(res, isFalse);
+      expect(res, DuplicationResult.alreadyPresent);
       verify(() => client.from('hinoo')).called(1);
-      verify(() => chain.select('id')).called(1);
-      verify(() => chain.eq('user_id', 'u-1')).called(1);
-      verify(() => chain.eq('type', 'moon')).called(1);
-      verify(() => chain.eq('fingerprint', any<String>())).called(1);
-      verify(() => chain.limit(1)).called(1);
-      verifyNever(() => chain.insert(any()));
+      verify(() => chain.insert(any())).called(1);
+      verifyNever(() => chain.select(any()));
     });
 
-    test('se NON esiste duplicato → fa insert e ritorna true', () async {
-      chain.queueResponse(<Map<String, dynamic>>[]);
+    test('senza conflitto inserisce e ritorna inserted', () async {
       chain.queueResponse(<String, dynamic>{});
 
       final res = await HinooService.duplicateToMoon(sampleDraft());
 
-      expect(res, isTrue);
-      verify(() => client.from('hinoo')).called(greaterThanOrEqualTo(1));
-      verify(() => chain.select('id')).called(1);
-      verify(() => chain.eq('user_id', 'u-1')).called(1);
-      verify(() => chain.eq('type', 'moon')).called(1);
-      verify(() => chain.eq('fingerprint', any<String>())).called(1);
-      verify(() => chain.limit(1)).called(1);
+      expect(res, DuplicationResult.inserted);
+      verify(() => client.from('hinoo')).called(1);
       verify(() => chain.insert(any())).called(1);
+      verifyNever(() => chain.select(any()));
     });
   });
 }


### PR DESCRIPTION
## What changed

- make Honoo/Hinoo duplication atomic and distinguish duplicates from backend failures
- preserve cached chest content while surfacing load errors with retry
- add backend timeouts, serialize realtime refreshes, and disable duplicate actions while writes are running
- add resilient image loading with decode sizing and retry
- add Supabase uniqueness migration and regression tests

## Why

The chest could report real backend failures as duplicates, race concurrent inserts and realtime refreshes, hide load failures, and leave operations or image placeholders stuck.

## Impact

Users receive accurate feedback, duplicate writes are prevented at the database boundary, cached content remains visible during outages, and long-running operations fail predictably.

## Checks

- fvm flutter analyze
- fvm flutter test: 160 passed, 7 skipped because live credentials or configuration were absent