### PR TITLE
Make chest Realtime self-healing

### DIFF
--- a/lib/Controller/chest_controller.dart
+++ b/lib/Controller/chest_controller.dart
@@ -45,39 +45,105 @@ class ChestController extends ValueNotifier<ChestState> {
     required ChestRepository repository,
     ChestRealtimeGateway? realtimeGateway,
     ReliabilityPolicy reliabilityPolicy = const ReliabilityPolicy(),
+    Duration realtimeReconnectBaseDelay = const Duration(seconds: 1),
+    Duration realtimeReconnectMaxDelay = const Duration(seconds: 30),
   })  : _realtimeGateway = realtimeGateway ?? SupabaseChestRealtimeGateway(),
         _repository = repository,
         _reliability = reliabilityPolicy,
+        _realtimeReconnectBaseDelay = realtimeReconnectBaseDelay,
+        _realtimeReconnectMaxDelay = realtimeReconnectMaxDelay,
         super(ChestState());
 
   final ChestRepository _repository;
   final ChestRealtimeGateway _realtimeGateway;
   final ReliabilityPolicy _reliability;
+  final Duration _realtimeReconnectBaseDelay;
+  final Duration _realtimeReconnectMaxDelay;
   ChestRealtimeSubscription? _realtimeSubscription;
   Timer? _periodicRefreshTimer;
   Timer? _realtimeDebounce;
+  Timer? _realtimeReconnectTimer;
   String? _activeUserId;
+  Future<void> Function()? _onPeriodicReconcile;
+  int _realtimeReconnectAttempt = 0;
+  int _realtimeGeneration = 0;
   bool _isRefreshingReplies = false;
   bool _refreshPending = false;
 
   void startRealtime(
     String userId, {
     Duration refreshInterval = const Duration(seconds: 60),
+    Future<void> Function()? onPeriodicReconcile,
   }) {
     stopRealtime();
     _activeUserId = userId;
+    _onPeriodicReconcile = onPeriodicReconcile;
+    _connectRealtime(userId);
+    _periodicRefreshTimer = Timer.periodic(
+      refreshInterval,
+      (_) => _runPeriodicReconcile(userId),
+    );
+  }
+
+  void _connectRealtime(String userId) {
+    if (_activeUserId != userId) return;
+    _realtimeReconnectTimer?.cancel();
+    _realtimeReconnectTimer = null;
+    final previous = _realtimeSubscription;
+    _realtimeSubscription = null;
+    if (previous != null) unawaited(previous.close());
+
+    final generation = ++_realtimeGeneration;
     try {
       _realtimeSubscription = _realtimeGateway.subscribe(
         userId: userId,
         onChange: _scheduleRealtimeRefresh,
+        onStatus: (status, error) =>
+            _handleRealtimeStatus(userId, generation, status),
       );
     } catch (_) {
-      _realtimeSubscription = null;
+      _scheduleRealtimeReconnect(userId, generation);
     }
-    _periodicRefreshTimer = Timer.periodic(
-      refreshInterval,
-      (_) => refreshReplies(userId),
+  }
+
+  void _handleRealtimeStatus(
+    String userId,
+    int generation,
+    ChestRealtimeConnectionStatus status,
+  ) {
+    if (_activeUserId != userId || generation != _realtimeGeneration) return;
+    if (status == ChestRealtimeConnectionStatus.subscribed) {
+      _realtimeReconnectAttempt = 0;
+      _realtimeReconnectTimer?.cancel();
+      _realtimeReconnectTimer = null;
+      _scheduleRealtimeRefresh();
+      return;
+    }
+    _scheduleRealtimeReconnect(userId, generation);
+  }
+
+  void _scheduleRealtimeReconnect(String userId, int generation) {
+    if (_activeUserId != userId || generation != _realtimeGeneration) return;
+    if (_realtimeReconnectTimer?.isActive ?? false) return;
+    final multiplier = 1 << _realtimeReconnectAttempt.clamp(0, 10);
+    final requestedMs = _realtimeReconnectBaseDelay.inMilliseconds * multiplier;
+    final delay = Duration(
+      milliseconds: requestedMs.clamp(
+        _realtimeReconnectBaseDelay.inMilliseconds,
+        _realtimeReconnectMaxDelay.inMilliseconds,
+      ),
     );
+    _realtimeReconnectAttempt++;
+    _realtimeReconnectTimer = Timer(delay, () => _connectRealtime(userId));
+  }
+
+  Future<void> _runPeriodicReconcile(String userId) async {
+    final reconcile = _onPeriodicReconcile;
+    if (reconcile != null) {
+      await reconcile();
+      return;
+    }
+    await refreshReplies(userId);
   }
 
   void _scheduleRealtimeRefresh() {
@@ -105,13 +171,19 @@ class ChestController extends ValueNotifier<ChestState> {
   }
 
   void stopRealtime() {
+    _activeUserId = null;
+    _onPeriodicReconcile = null;
+    _realtimeGeneration++;
+    _realtimeReconnectAttempt = 0;
     _periodicRefreshTimer?.cancel();
     _periodicRefreshTimer = null;
     _realtimeDebounce?.cancel();
     _realtimeDebounce = null;
-    _realtimeSubscription?.close();
+    _realtimeReconnectTimer?.cancel();
+    _realtimeReconnectTimer = null;
+    final subscription = _realtimeSubscription;
     _realtimeSubscription = null;
-    _activeUserId = null;
+    if (subscription != null) unawaited(subscription.close());
   }
 
   @override

--- a/lib/Pages/chest_page.dart
+++ b/lib/Pages/chest_page.dart
@@ -55,7 +55,7 @@ class ChestPage extends StatefulWidget {
   State<ChestPage> createState() => _ChestPageState();
 }
 
-class _ChestPageState extends State<ChestPage> {
+class _ChestPageState extends State<ChestPage> with WidgetsBindingObserver {
   // Conversational mode support
   // Structural only: no layout/axis/animation changes.
   // Two modes: normal chest vs conversation view fed into the same builder.
@@ -77,6 +77,8 @@ class _ChestPageState extends State<ChestPage> {
   int _conversationRefreshToken = 0;
   Object? _honooLoadError;
   bool _isMutating = false;
+  bool _isReconciling = false;
+  bool _reconcilePending = false;
   // Data lists for normal vs conversation mode
   List<ChestItem> _itemsNormal = const [];
   List<ChestHinooItem> get _hinoo => _chestController.value.hinoo;
@@ -108,6 +110,7 @@ class _ChestPageState extends State<ChestPage> {
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addObserver(this);
     _chestController.addListener(_onChestStateChanged);
     unawaited(_initialize());
     _maybeShowScrignoHint();
@@ -115,9 +118,28 @@ class _ChestPageState extends State<ChestPage> {
 
   @override
   void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
     _chestController.removeListener(_onChestStateChanged);
     _chestController.dispose();
     super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state != AppLifecycleState.resumed) return;
+    unawaited(_resumeRealtimeAndReconcile());
+  }
+
+  Future<void> _resumeRealtimeAndReconcile() async {
+    await _reconcileAll();
+    if (!mounted) return;
+    final uid = SupabaseProvider.client.auth.currentUser?.id;
+    if (uid != null) {
+      _chestController.startRealtime(
+        uid,
+        onPeriodicReconcile: _reconcileAll,
+      );
+    }
   }
 
   void _onChestStateChanged() {
@@ -160,10 +182,31 @@ class _ChestPageState extends State<ChestPage> {
   }
 
   Future<void> _initialize() async {
-    await _loadAll();
+    await _reconcileAll();
     if (!mounted) return;
     final uid = SupabaseProvider.client.auth.currentUser?.id;
-    if (uid != null) _chestController.startRealtime(uid);
+    if (uid != null) {
+      _chestController.startRealtime(
+        uid,
+        onPeriodicReconcile: _reconcileAll,
+      );
+    }
+  }
+
+  Future<void> _reconcileAll() async {
+    if (_isReconciling) {
+      _reconcilePending = true;
+      return;
+    }
+    _isReconciling = true;
+    try {
+      do {
+        _reconcilePending = false;
+        await _loadAll();
+      } while (_reconcilePending && mounted);
+    } finally {
+      _isReconciling = false;
+    }
   }
 
   Object? get _loadError =>

--- a/lib/Services/chest_realtime_service.dart
+++ b/lib/Services/chest_realtime_service.dart
@@ -5,13 +5,22 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 import 'supabase_provider.dart';
 
 abstract class ChestRealtimeSubscription {
-  void close();
+  Future<void> close();
+}
+
+enum ChestRealtimeConnectionStatus {
+  subscribed,
+  disconnected,
 }
 
 abstract class ChestRealtimeGateway {
   ChestRealtimeSubscription subscribe({
     required String userId,
     required void Function() onChange,
+    required void Function(
+      ChestRealtimeConnectionStatus status,
+      Object? error,
+    ) onStatus,
   });
 }
 
@@ -25,23 +34,37 @@ class SupabaseChestRealtimeGateway implements ChestRealtimeGateway {
   ChestRealtimeSubscription subscribe({
     required String userId,
     required void Function() onChange,
+    required void Function(
+      ChestRealtimeConnectionStatus status,
+      Object? error,
+    ) onStatus,
   }) {
     void notify(dynamic _, [dynamic __]) => onChange();
     final accessToken = _client.auth.currentSession?.accessToken;
     if (accessToken != null) _client.realtime.setAuth(accessToken);
 
-    final channel = _client.channel('chest-replies-$userId')
-      ..on(
-        RealtimeListenTypes.postgresChanges,
-        ChannelFilter(event: '*', schema: 'public', table: 'honoo'),
-        notify,
-      )
-      ..on(
-        RealtimeListenTypes.postgresChanges,
-        ChannelFilter(event: '*', schema: 'public', table: 'hinoo'),
-        notify,
-      )
-      ..subscribe();
+    final channel = _client.channel('chest-replies-$userId');
+    channel.on(
+      RealtimeListenTypes.postgresChanges,
+      ChannelFilter(event: '*', schema: 'public', table: 'honoo'),
+      notify,
+    );
+    channel.on(
+      RealtimeListenTypes.postgresChanges,
+      ChannelFilter(event: '*', schema: 'public', table: 'hinoo'),
+      notify,
+    );
+    channel.subscribe((status, [error]) {
+      if (status == 'SUBSCRIBED') {
+        onStatus(ChestRealtimeConnectionStatus.subscribed, null);
+        return;
+      }
+      if (status == 'CHANNEL_ERROR' ||
+          status == 'CLOSED' ||
+          status == 'TIMED_OUT') {
+        onStatus(ChestRealtimeConnectionStatus.disconnected, error ?? status);
+      }
+    });
     return _SupabaseChestRealtimeSubscription(channel);
   }
 }
@@ -52,7 +75,7 @@ class _SupabaseChestRealtimeSubscription implements ChestRealtimeSubscription {
   final RealtimeChannel _channel;
 
   @override
-  void close() {
-    unawaited(_channel.unsubscribe());
+  Future<void> close() async {
+    await _channel.unsubscribe();
   }
 }

--- a/test/controllers/chest_controller_test.dart
+++ b/test/controllers/chest_controller_test.dart
@@ -15,21 +15,27 @@ class _FakeRealtimeSubscription implements ChestRealtimeSubscription {
   bool closed = false;
 
   @override
-  void close() => closed = true;
+  Future<void> close() async => closed = true;
 }
 
 class _FakeRealtimeGateway implements ChestRealtimeGateway {
   String? userId;
   void Function()? onChange;
-  final subscription = _FakeRealtimeSubscription();
+  void Function(ChestRealtimeConnectionStatus, Object?)? onStatus;
+  final subscriptions = <_FakeRealtimeSubscription>[];
+  _FakeRealtimeSubscription get subscription => subscriptions.last;
 
   @override
   ChestRealtimeSubscription subscribe({
     required String userId,
     required void Function() onChange,
+    required void Function(ChestRealtimeConnectionStatus, Object?) onStatus,
   }) {
     this.userId = userId;
     this.onChange = onChange;
+    this.onStatus = onStatus;
+    final subscription = _FakeRealtimeSubscription();
+    subscriptions.add(subscription);
     return subscription;
   }
 }
@@ -39,6 +45,7 @@ class _FailingRealtimeGateway implements ChestRealtimeGateway {
   ChestRealtimeSubscription subscribe({
     required String userId,
     required void Function() onChange,
+    required void Function(ChestRealtimeConnectionStatus, Object?) onStatus,
   }) {
     throw StateError('Realtime non disponibile');
   }
@@ -168,6 +175,44 @@ void main() {
     controller.stopRealtime();
 
     expect(realtimeGateway.subscription.closed, isTrue);
+  });
+
+  test('una disconnessione Realtime crea una nuova sottoscrizione', () async {
+    final reconnectingController = ChestController(
+      repository: repository,
+      realtimeGateway: realtimeGateway,
+      realtimeReconnectBaseDelay: const Duration(milliseconds: 5),
+      realtimeReconnectMaxDelay: const Duration(milliseconds: 10),
+    );
+    addTearDown(reconnectingController.dispose);
+
+    reconnectingController.startRealtime(
+      'user-1',
+      refreshInterval: const Duration(hours: 1),
+    );
+    final firstSubscription = realtimeGateway.subscription;
+    realtimeGateway.onStatus!(
+      ChestRealtimeConnectionStatus.disconnected,
+      StateError('offline'),
+    );
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+
+    expect(realtimeGateway.subscriptions, hasLength(2));
+    expect(firstSubscription.closed, isTrue);
+  });
+
+  test('la riconciliazione periodica può aggiornare tutto lo Scrigno',
+      () async {
+    var reconciliations = 0;
+    controller.startRealtime(
+      'user-1',
+      refreshInterval: const Duration(milliseconds: 5),
+      onPeriodicReconcile: () async => reconciliations++,
+    );
+
+    await Future<void>.delayed(const Duration(milliseconds: 18));
+
+    expect(reconciliations, greaterThanOrEqualTo(1));
   });
 
   test('un errore Realtime non impedisce l’avvio del controller', () {


### PR DESCRIPTION
## Cosa cambia

- osserva gli stati della sottoscrizione Supabase Realtime
- ricrea il canale con backoff limitato dopo errori, timeout o chiusure
- effettua una riconciliazione completa periodica dello Scrigno
- risincronizza dati e canale quando l'app torna in primo piano
- accoda una riconciliazione arrivata durante un caricamento già attivo

## Perché

Il client riceveva gli eventi ma ignorava lo stato del canale. Una disconnessione poteva lasciare lo Scrigno obsoleto fino alla riapertura della pagina.

## Verifiche

- `fvm flutter test test/controllers/chest_controller_test.dart` (10 test)
- `fvm flutter analyze`
- `git diff --check`
