### PR TITLE
Add privacy-safe production diagnostics

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -31,6 +31,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    outputs:
+      release_sha: ${{ steps.release.outputs.sha }}
     steps:
       - name: Require explicit production confirmation
         env:
@@ -51,6 +53,10 @@ jobs:
           git fetch origin main
           git merge-base --is-ancestor HEAD origin/main
 
+      - name: Resolve immutable release commit
+        id: release
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
       - name: Verify migration structure
         run: bash tool/check_supabase_migrations.sh
 
@@ -64,7 +70,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.release_ref }}
+          ref: ${{ needs.validate-release.outputs.release_sha }}
           fetch-depth: 0
 
       - name: Setup Supabase CLI
@@ -94,14 +100,14 @@ jobs:
 
   build-and-deploy:
     name: Build and deploy web
-    needs: migrate-production
+    needs: [validate-release, migrate-production]
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.release_ref }}
+          ref: ${{ needs.validate-release.outputs.release_sha }}
           fetch-depth: 0
 
       - name: Setup Flutter 3.44.6
@@ -117,6 +123,8 @@ jobs:
           SUPABASE_URL: ${{ secrets.PROD_SUPABASE_URL }}
           SUPABASE_ANON_KEY: ${{ secrets.PROD_SUPABASE_ANON_KEY }}
           DISABLE_PWA: ${{ inputs.disable_pwa }}
+          BUILD_SHA: ${{ needs.validate-release.outputs.release_sha }}
+          BUILD_REF: ${{ inputs.release_ref }}
         run: |
           test -n "$SUPABASE_URL"
           test -n "$SUPABASE_ANON_KEY"
@@ -124,7 +132,9 @@ jobs:
           flutter build web \
             --release $PWA_FLAG \
             --dart-define=SUPABASE_URL="$SUPABASE_URL" \
-            --dart-define=SUPABASE_ANON_KEY="$SUPABASE_ANON_KEY"
+            --dart-define=SUPABASE_ANON_KEY="$SUPABASE_ANON_KEY" \
+            --dart-define=BUILD_SHA="$BUILD_SHA" \
+            --dart-define=BUILD_REF="$BUILD_REF"
 
       - name: Add CNAME for custom domain
         run: echo honoo.it > build/web/CNAME
@@ -134,4 +144,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: build/web
-          commit_message: Deploy web build for ${{ github.sha }}
+          commit_message: Deploy web build for ${{ needs.validate-release.outputs.release_sha }}

--- a/lib/Services/hinoo_service.dart
+++ b/lib/Services/hinoo_service.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/foundation.dart';
 import 'package:honoo/Services/supabase_provider.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import '../Entities/hinoo.dart';
@@ -57,7 +56,6 @@ class HinooService {
       'created_at': DateTime.now().toIso8601String(),
     };
 
-    debugPrint('[HinooService] publishHinoo data=$data');
     final res = await _insertPublished(data);
     if (res == null) throw 'publishHinoo: insert fallita';
   }
@@ -79,7 +77,6 @@ class HinooService {
       'created_at': DateTime.now().toIso8601String(),
     };
 
-    debugPrint('[HinooService] publishHinoo data=$data');
     final res = await _insertPublished(data);
     if (res == null) throw 'publishHinoo: insert fallita';
     final id = res['id']?.toString() ?? '';
@@ -121,7 +118,6 @@ class HinooService {
       'created_at': DateTime.now().toIso8601String(),
     };
 
-    debugPrint('[HinooService] duplicateToMoon data=$data');
     return _insertDuplicate(data);
   }
 

--- a/lib/Utility/app_diagnostics.dart
+++ b/lib/Utility/app_diagnostics.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/foundation.dart';
+
+import 'app_logger.dart';
+import 'build_metadata.dart';
+
+@immutable
+class DiagnosticEvent {
+  const DiagnosticEvent({
+    required this.code,
+    required this.scope,
+    required this.errorType,
+    required this.buildSha,
+    required this.occurredAt,
+  });
+
+  final String code;
+  final String scope;
+  final String errorType;
+  final String buildSha;
+  final DateTime occurredAt;
+}
+
+/// Diagnostica locale e limitata: non memorizza messaggi, payload o ID utente.
+class AppDiagnostics {
+  const AppDiagnostics._();
+
+  static const _maxEvents = 40;
+  static final List<DiagnosticEvent> _events = <DiagnosticEvent>[];
+
+  static List<DiagnosticEvent> get recentEvents => List.unmodifiable(_events);
+
+  static void installGlobalHandlers() {
+    final previousFlutterHandler = FlutterError.onError;
+    FlutterError.onError = (details) {
+      record(
+        code: 'flutter_framework_error',
+        scope: 'global',
+        error: details.exception,
+      );
+      previousFlutterHandler?.call(details);
+    };
+
+    final previousPlatformHandler = PlatformDispatcher.instance.onError;
+    PlatformDispatcher.instance.onError = (error, stackTrace) {
+      record(code: 'unhandled_platform_error', scope: 'global', error: error);
+      return previousPlatformHandler?.call(error, stackTrace) ?? false;
+    };
+  }
+
+  static void record({
+    required String code,
+    required String scope,
+    Object? error,
+  }) {
+    final event = DiagnosticEvent(
+      code: code,
+      scope: scope,
+      errorType: error?.runtimeType.toString() ?? 'none',
+      buildSha: BuildMetadata.shortSha,
+      occurredAt: DateTime.now().toUtc(),
+    );
+    _events.add(event);
+    if (_events.length > _maxEvents) _events.removeAt(0);
+
+    AppLogger.error(
+      '$code [build=${event.buildSha}, type=${event.errorType}]',
+      scope: scope,
+    );
+  }
+
+  @visibleForTesting
+  static void clearForTests() => _events.clear();
+}

--- a/lib/Utility/app_logger.dart
+++ b/lib/Utility/app_logger.dart
@@ -1,5 +1,7 @@
 import 'dart:developer' as developer;
 
+import 'package:flutter/foundation.dart';
+
 /// Logging centralizzato. Non passare token, password o payload sensibili.
 class AppLogger {
   const AppLogger._();
@@ -17,8 +19,8 @@ class AppLogger {
     developer.log(
       message,
       name: scope,
-      error: error,
-      stackTrace: stackTrace,
+      error: kReleaseMode ? error?.runtimeType : error,
+      stackTrace: kReleaseMode ? null : stackTrace,
       level: 900,
     );
   }
@@ -32,8 +34,8 @@ class AppLogger {
     developer.log(
       message,
       name: scope,
-      error: error,
-      stackTrace: stackTrace,
+      error: kReleaseMode ? error?.runtimeType : error,
+      stackTrace: kReleaseMode ? null : stackTrace,
       level: 1000,
     );
   }

--- a/lib/Utility/build_metadata.dart
+++ b/lib/Utility/build_metadata.dart
@@ -1,0 +1,19 @@
+class BuildMetadata {
+  const BuildMetadata._();
+
+  static const version = '1.1.0+2';
+  static const sha = String.fromEnvironment(
+    'BUILD_SHA',
+    defaultValue: 'development',
+  );
+  static const ref = String.fromEnvironment('BUILD_REF', defaultValue: 'local');
+
+  static String get shortSha => abbreviateSha(sha);
+
+  static String get displayLabel => 'v$version · $shortSha';
+
+  static String abbreviateSha(String value) {
+    if (value == 'development' || value.isEmpty) return 'development';
+    return value.length <= 8 ? value : value.substring(0, 8);
+  }
+}

--- a/lib/Utility/build_metadata.dart
+++ b/lib/Utility/build_metadata.dart
@@ -1,12 +1,15 @@
+const _buildSha = String.fromEnvironment(
+  'BUILD_SHA',
+  defaultValue: 'development',
+);
+const _buildRef = String.fromEnvironment('BUILD_REF', defaultValue: 'local');
+
 class BuildMetadata {
   const BuildMetadata._();
 
   static const version = '1.1.0+2';
-  static const sha = String.fromEnvironment(
-    'BUILD_SHA',
-    defaultValue: 'development',
-  );
-  static const ref = String.fromEnvironment('BUILD_REF', defaultValue: 'local');
+  static const sha = _buildSha;
+  static const ref = _buildRef;
 
   static String get shortSha => abbreviateSha(sha);
 

--- a/lib/Widgets/chest_info_dialog.dart
+++ b/lib/Widgets/chest_info_dialog.dart
@@ -3,9 +3,11 @@ import 'dart:ui' show ImageFilter;
 import 'package:flutter/material.dart';
 
 import '../Utility/honoo_colors.dart';
+import '../Utility/build_metadata.dart';
 import 'honoo_dialogs.dart';
 
-const chestInfoText = "Questo è il tuo Scrigno.\n\n"
+const chestInfoText =
+    "Questo è il tuo Scrigno.\n\n"
     "Qui sono custoditi\n"
     "gli honoo e gli hinoo\n"
     "che hai scritto,\n\n"
@@ -33,74 +35,91 @@ const chestInfoText = "Questo è il tuo Scrigno.\n\n"
     "alla tua risposta.\n";
 
 Future<void> showChestInfoDialog(BuildContext context) => showDialog<void>(
-      context: context,
-      barrierDismissible: true,
-      builder: (_) => const ChestInfoDialog(),
-    );
+  context: context,
+  barrierDismissible: true,
+  builder: (_) => const ChestInfoDialog(),
+);
 
 class ChestInfoDialog extends StatelessWidget {
   const ChestInfoDialog({super.key});
 
   @override
   Widget build(BuildContext context) => Dialog(
-        backgroundColor: Colors.transparent,
-        insetPadding: const EdgeInsets.symmetric(horizontal: 24, vertical: 24),
-        child: LayoutBuilder(
-          builder: (context, constraints) {
-            final maxWidth =
-                (constraints.maxWidth * 0.8).clamp(0.0, constraints.maxWidth);
-            final maxHeight =
-                (constraints.maxHeight * 0.8).clamp(0.0, constraints.maxHeight);
-            return Center(
-              child: ConstrainedBox(
-                constraints: BoxConstraints(
-                  maxWidth: maxWidth,
-                  maxHeight: maxHeight,
-                ),
-                child: Stack(
-                  children: [
-                    ClipRect(
-                      child: BackdropFilter(
-                        filter: ImageFilter.blur(sigmaX: 10, sigmaY: 10),
-                        child: Container(
-                          width: maxWidth,
-                          height: maxHeight,
-                          padding: const EdgeInsets.fromLTRB(16, 40, 16, 16),
-                          decoration: BoxDecoration(
-                            color: HonooColor.wave1.withValues(alpha: 0.6),
-                            borderRadius: BorderRadius.circular(8),
-                          ),
-                          child: SingleChildScrollView(
-                            physics: const BouncingScrollPhysics(),
-                            child: Text(
+    backgroundColor: Colors.transparent,
+    insetPadding: const EdgeInsets.symmetric(horizontal: 24, vertical: 24),
+    child: LayoutBuilder(
+      builder: (context, constraints) {
+        final maxWidth = (constraints.maxWidth * 0.8).clamp(
+          0.0,
+          constraints.maxWidth,
+        );
+        final maxHeight = (constraints.maxHeight * 0.8).clamp(
+          0.0,
+          constraints.maxHeight,
+        );
+        return Center(
+          child: ConstrainedBox(
+            constraints: BoxConstraints(
+              maxWidth: maxWidth,
+              maxHeight: maxHeight,
+            ),
+            child: Stack(
+              children: [
+                ClipRect(
+                  child: BackdropFilter(
+                    filter: ImageFilter.blur(sigmaX: 10, sigmaY: 10),
+                    child: Container(
+                      width: maxWidth,
+                      height: maxHeight,
+                      padding: const EdgeInsets.fromLTRB(16, 40, 16, 16),
+                      decoration: BoxDecoration(
+                        color: HonooColor.wave1.withValues(alpha: 0.6),
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                      child: SingleChildScrollView(
+                        physics: const BouncingScrollPhysics(),
+                        child: Column(
+                          children: [
+                            Text(
                               chestInfoText,
                               style: HonooDialogStyles.body(
                                 color: HonooColor.onBackground,
                               ),
                               textAlign: TextAlign.center,
                             ),
-                          ),
+                            const SizedBox(height: 16),
+                            Text(
+                              BuildMetadata.displayLabel,
+                              style: const TextStyle(
+                                color: HonooColor.onBackground,
+                                fontSize: 11,
+                              ),
+                              textAlign: TextAlign.center,
+                            ),
+                          ],
                         ),
                       ),
                     ),
-                    Positioned(
-                      top: 0,
-                      right: 0,
-                      child: IconButton(
-                        icon: const Icon(
-                          Icons.close,
-                          color: HonooColor.onBackground,
-                        ),
-                        iconSize: 40,
-                        tooltip: 'Chiudi',
-                        onPressed: () => Navigator.of(context).pop(),
-                      ),
-                    ),
-                  ],
+                  ),
                 ),
-              ),
-            );
-          },
-        ),
-      );
+                Positioned(
+                  top: 0,
+                  right: 0,
+                  child: IconButton(
+                    icon: const Icon(
+                      Icons.close,
+                      color: HonooColor.onBackground,
+                    ),
+                    iconSize: 40,
+                    tooltip: 'Chiudi',
+                    onPressed: () => Navigator.of(context).pop(),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    ),
+  );
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:sizer/sizer.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'env/env.dart';
 import 'Utility/app_logger.dart';
+import 'Utility/app_diagnostics.dart';
 
 import 'Pages/auth_gate.dart';
 import 'Pages/chest_page.dart';
@@ -14,6 +15,7 @@ import 'Widgets/global_reply_notification_listener.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  AppDiagnostics.installGlobalHandlers();
   try {
     final supabaseUrl = readEnv('SUPABASE_URL');
     final supabaseAnon = readEnv('SUPABASE_ANON_KEY');
@@ -28,15 +30,20 @@ Future<void> main() async {
     runApp(const MyApp());
     unawaited(_refreshSessionInBackground());
   } catch (e) {
+    AppDiagnostics.record(
+      code: 'bootstrap_failed',
+      scope: 'bootstrap',
+      error: e,
+    );
     runApp(_BootErrorApp(message: 'Errore inizializzazione: $e'));
   }
 }
 
 Future<void> _refreshSessionInBackground() async {
   try {
-    await Supabase.instance.client.auth
-        .refreshSession()
-        .timeout(const Duration(seconds: 5));
+    await Supabase.instance.client.auth.refreshSession().timeout(
+      const Duration(seconds: 5),
+    );
   } catch (error, stackTrace) {
     AppLogger.warning(
       'Refresh iniziale della sessione non riuscito',
@@ -102,9 +109,7 @@ class _MyAppState extends State<MyApp> {
             ),
           ),
           home: const AuthGate(),
-          routes: {
-            '/chest': (context) => const ChestPage(),
-          },
+          routes: {'/chest': (context) => const ChestPage()},
         );
         return GlobalReplyNotificationListener(
           navigatorKey: _navigatorKey,
@@ -133,10 +138,7 @@ class _BootErrorApp extends StatelessWidget {
         body: Center(
           child: Padding(
             padding: const EdgeInsets.all(24),
-            child: Text(
-              message,
-              textAlign: TextAlign.center,
-            ),
+            child: Text(message, textAlign: TextAlign.center),
           ),
         ),
       ),

--- a/test/utility/app_diagnostics_test.dart
+++ b/test/utility/app_diagnostics_test.dart
@@ -1,0 +1,29 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:honoo/Utility/app_diagnostics.dart';
+import 'package:honoo/Utility/build_metadata.dart';
+
+void main() {
+  tearDown(AppDiagnostics.clearForTests);
+
+  test('build SHA is abbreviated without changing development label', () {
+    expect(BuildMetadata.abbreviateSha('1234567890abcdef'), '12345678');
+    expect(BuildMetadata.abbreviateSha('development'), 'development');
+  });
+
+  test('diagnostics retain only bounded, privacy-safe metadata', () {
+    for (var index = 0; index < 45; index++) {
+      AppDiagnostics.record(
+        code: 'operation_failed',
+        scope: 'test',
+        error: StateError('sensitive-payload-$index'),
+      );
+    }
+
+    expect(AppDiagnostics.recentEvents, hasLength(40));
+    final event = AppDiagnostics.recentEvents.last;
+    expect(event.code, 'operation_failed');
+    expect(event.scope, 'test');
+    expect(event.errorType, 'StateError');
+    expect(event.toString(), isNot(contains('sensitive-payload')));
+  });
+}

--- a/tool/verify_web_compat.sh
+++ b/tool/verify_web_compat.sh
@@ -22,9 +22,10 @@ if [[ -n "$STRING_MATCHES" ]]; then
   FILTERED=$(echo "$STRING_MATCHES" |
     grep -v "lib/env/env_web.dart" |
     grep -v "lib/env/env_io.dart" |
+    grep -v "lib/Utility/build_metadata.dart" |
     grep -v "lib/testing/live_config.dart" || true)
   if [[ -n "$FILTERED" ]]; then
-    echo "❌ Found direct String.fromEnvironment(...) in lib/ (solo top-level const consentiti)"
+    echo "❌ Found String.fromEnvironment(...) outside an approved compile-time config file"
     echo "$FILTERED"
     FAIL=1
   fi


### PR DESCRIPTION
## Cosa cambia
- installa handler globali Flutter/platform e conserva un buffer locale limitato a metadati non sensibili
- rimuove errori e stack trace completi dai log release
- espone versione e SHA breve nello Scrigno
- risolve una volta lo SHA di release e usa lo stesso commit per migrazioni, build e deploy
- passa BUILD_SHA e BUILD_REF alla build web

## Verifiche
- fvm flutter analyze
- fvm flutter test (160 test passati, 7 live opzionali saltati)
- test/utility/app_diagnostics_test.dart
- build web release con SHA verificato nel bundle