### PR TITLE
Harden content fingerprint deduplication

### DIFF
--- a/supabase/migrations/20260722100000_strengthen_content_fingerprints.sql
+++ b/supabase/migrations/20260722100000_strengthen_content_fingerprints.sql
@@ -1,0 +1,72 @@
+-- Replace MD5-based deduplication keys with SHA-256 while preserving the
+-- existing raw fingerprints used by the client and maintenance tooling.
+create extension if not exists pgcrypto with schema extensions;
+
+do $$
+declare
+  crypto_schema text;
+begin
+  select namespace.nspname
+  into strict crypto_schema
+  from pg_extension as extension
+  join pg_namespace as namespace
+    on namespace.oid = extension.extnamespace
+  where extension.extname = 'pgcrypto';
+
+  execute format(
+    $index$
+      create unique index if not exists honoo_user_destination_fingerprint_sha256_key
+        on public.honoo (
+          user_id,
+          destination,
+          %I.digest(fingerprint, 'sha256')
+        )
+        where fingerprint is not null
+          and destination in ('chest', 'moon')
+    $index$,
+    crypto_schema
+  );
+
+  execute format(
+    $index$
+      create unique index if not exists hinoo_user_type_fingerprint_sha256_key
+        on public.hinoo (
+          user_id,
+          type,
+          %I.digest(fingerprint, 'sha256')
+        )
+        where fingerprint is not null
+          and type in ('personal', 'moon')
+    $index$,
+    crypto_schema
+  );
+end;
+$$;
+
+-- Create and validate both replacements before removing either legacy guard.
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_index
+    where indexrelid = 'public.honoo_user_destination_fingerprint_sha256_key'::regclass
+      and indisvalid
+      and indisunique
+  ) then
+    raise exception 'Honoo SHA-256 fingerprint index is not valid';
+  end if;
+
+  if not exists (
+    select 1
+    from pg_index
+    where indexrelid = 'public.hinoo_user_type_fingerprint_sha256_key'::regclass
+      and indisvalid
+      and indisunique
+  ) then
+    raise exception 'Hinoo SHA-256 fingerprint index is not valid';
+  end if;
+end;
+$$;
+
+drop index if exists public.honoo_user_destination_fingerprint_key;
+drop index if exists public.hinoo_user_type_fingerprint_key;

--- a/tool/check_supabase_migrations.sh
+++ b/tool/check_supabase_migrations.sh
@@ -105,4 +105,30 @@ for required_fragment in \
   fi
 done
 
+fingerprint_hardening="$migrations_dir/20260722100000_strengthen_content_fingerprints.sql"
+for required_fragment in \
+  'create extension if not exists pgcrypto with schema extensions' \
+  'honoo_user_destination_fingerprint_sha256_key' \
+  'hinoo_user_type_fingerprint_sha256_key' \
+  "digest(fingerprint, 'sha256')" \
+  'and indisvalid' \
+  'and indisunique'; do
+  if ! rg -Fq "$required_fragment" "$fingerprint_hardening"; then
+    echo "Fingerprint hardening is missing: $required_fragment" >&2
+    exit 1
+  fi
+done
+if rg -qi '^\s*(update|delete)\b' "$fingerprint_hardening"; then
+  echo "Fingerprint hardening must not rewrite user content" >&2
+  exit 1
+fi
+honoo_create_line="$(rg -n -m 1 'create unique index if not exists honoo_user_destination_fingerprint_sha256_key' "$fingerprint_hardening" | cut -d: -f1)"
+hinoo_create_line="$(rg -n -m 1 'create unique index if not exists hinoo_user_type_fingerprint_sha256_key' "$fingerprint_hardening" | cut -d: -f1)"
+honoo_drop_line="$(rg -n -m 1 'drop index if exists public.honoo_user_destination_fingerprint_key' "$fingerprint_hardening" | cut -d: -f1)"
+hinoo_drop_line="$(rg -n -m 1 'drop index if exists public.hinoo_user_type_fingerprint_key' "$fingerprint_hardening" | cut -d: -f1)"
+if (( honoo_create_line >= honoo_drop_line || hinoo_create_line >= hinoo_drop_line )); then
+  echo "SHA-256 fingerprint guards must be created before legacy indexes are removed" >&2
+  exit 1
+fi
+
 echo "Supabase migration structure checks passed (${#migrations[@]} files)."


### PR DESCRIPTION
## Sintesi
- sostituisce gli indici univoci MD5 di Honoo e Hinoo con SHA-256 tramite pgcrypto
- crea e valida entrambi i nuovi indici prima di rimuovere le protezioni precedenti
- aggiunge controlli CI che impediscono riscritture dei contenuti e un ordine di migrazione non sicuro

## Verifica
- bash tool/check_supabase_migrations.sh
- supabase db push --linked --dry-run
- migrazione applicata con successo allo staging collegato
- tool/run_live_conversation_test.sh: tutti i test passati (CRUD, RLS, ordinamento, Realtime e cleanup)