### PR TITLE
Fix Moon conversation rendering

### DIFF
--- a/lib/Pages/moon_page.dart
+++ b/lib/Pages/moon_page.dart
@@ -696,8 +696,6 @@ class _MoonPageState extends State<MoonPage> {
 
     if (choice == null || !mounted) return;
     if (choice == _ReplyChoice.honoo && current.honoo != null) {
-      await _ensureMoonItemInChest(current);
-      if (!mounted) return;
       final sent = await Navigator.push<bool>(
         context,
         MaterialPageRoute(

--- a/lib/Services/conversation_service.dart
+++ b/lib/Services/conversation_service.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:honoo/Entities/hinoo.dart';
 import 'package:honoo/Entities/honoo.dart';
 import 'package:honoo/Entities/conversation_entry.dart';
@@ -10,24 +12,25 @@ class ConversationService {
   static SupabaseClient get _client => SupabaseProvider.client;
 
   static Future<List<ConversationEntry>> fetchConversation(
-          String conversationId) =>
-      const ReliabilityPolicy().read(
-        () => _fetchConversation(conversationId),
-      );
+    String conversationId,
+  ) => const ReliabilityPolicy().read(() => _fetchConversation(conversationId));
 
   static Future<List<ConversationEntry>> _fetchConversation(
-      String conversationId) async {
+    String conversationId,
+  ) async {
     final honooRows = await _client
         .from('honoo')
         .select(
-            'id,text,image_url,destination,reply_to,recipient_tag,created_at,updated_at,user_id,conversation_id,is_from_moon_saved')
+          'id,text,image_url,destination,reply_to,recipient_tag,created_at,updated_at,user_id,conversation_id,is_from_moon_saved',
+        )
         .eq('conversation_id', conversationId)
         .order('created_at', ascending: true);
 
     final hinooRows = await _client
         .from('hinoo')
         .select(
-            'id,pages,type,recipient_tag,reply_to,created_at,user_id,conversation_id,is_from_moon_saved')
+          'id,pages,type,recipient_tag,reply_to,created_at,user_id,conversation_id,is_from_moon_saved',
+        )
         .eq('conversation_id', conversationId)
         .order('created_at', ascending: true);
 
@@ -46,7 +49,8 @@ class ConversationService {
       // Compatibilita con risposte create quando reply_to non veniva
       // persistito: destinatario + conversation_id identificano comunque
       // inequivocabilmente un messaggio della conversazione.
-      final bool isReply = replyTo?.isNotEmpty == true ||
+      final bool isReply =
+          replyTo?.isNotEmpty == true ||
           (!isFromMoonSaved &&
               recipientTag?.isNotEmpty == true &&
               conversationId?.isNotEmpty == true);
@@ -62,32 +66,57 @@ class ConversationService {
         isFromMoonSaved: isFromMoonSaved,
       );
       final ownerId = r['user_id']?.toString();
-      entries.add(_Entry.hinoo(
-        draft,
-        createdAt: DateTime.tryParse(r['created_at']?.toString() ?? '') ??
-            DateTime.fromMillisecondsSinceEpoch(0),
-        ownerId: ownerId,
-        id: r['id']?.toString(),
-        isFromMoonSaved: isFromMoonSaved,
-      ));
+      entries.add(
+        _Entry.hinoo(
+          draft,
+          createdAt:
+              DateTime.tryParse(r['created_at']?.toString() ?? '') ??
+              DateTime.fromMillisecondsSinceEpoch(0),
+          ownerId: ownerId,
+          id: r['id']?.toString(),
+          isFromMoonSaved: isFromMoonSaved,
+        ),
+      );
     }
-    entries.sort((a, b) => a.createdAt.compareTo(b.createdAt));
-    return entries
-        .map((e) => e.when(
-              honoo: (h) => ConversationEntry.honoo(h),
-              hinoo: (d) => ConversationEntry.hinoo(
-                d,
-                createdAt: e.createdAt,
-                ownerId: e.ownerId,
-                id: e.id,
-                isFromMoonSaved: e.isFromMoonSaved,
-              ),
-            ))
+    final deduplicatedEntries = _deduplicateMoonRoots(entries)
+      ..sort((a, b) => a.createdAt.compareTo(b.createdAt));
+    return deduplicatedEntries
+        .map(
+          (e) => e.when(
+            honoo: (h) => ConversationEntry.honoo(h),
+            hinoo: (d) => ConversationEntry.hinoo(
+              d,
+              createdAt: e.createdAt,
+              ownerId: e.ownerId,
+              id: e.id,
+              isFromMoonSaved: e.isFromMoonSaved,
+            ),
+          ),
+        )
         .toList();
   }
 
+  static List<_Entry> _deduplicateMoonRoots(List<_Entry> entries) {
+    final moonSavedRootKeys = entries
+        .where((entry) => entry.isFromMoonSaved && !entry.isReply)
+        .map((entry) => entry.contentKey)
+        .toSet();
+    if (moonSavedRootKeys.isEmpty) return List<_Entry>.of(entries);
+
+    final retainedMoonSavedRoots = <String>{};
+    return entries.where((entry) {
+      if (entry.isReply || !moonSavedRootKeys.contains(entry.contentKey)) {
+        return true;
+      }
+      if (!entry.isFromMoonSaved) return false;
+      return retainedMoonSavedRoots.add(entry.contentKey);
+    }).toList();
+  }
+
   static RealtimeChannel subscribeConversation(
-      String conversationId, void Function() onChange) {
+    String conversationId,
+    void Function() onChange,
+  ) {
     void refresh(dynamic _, [dynamic __]) => onChange();
     final accessToken = _client.auth.currentSession?.accessToken;
     if (accessToken != null) _client.realtime.setAuth(accessToken);
@@ -95,20 +124,12 @@ class ConversationService {
     chan
         .on(
           RealtimeListenTypes.postgresChanges,
-          ChannelFilter(
-            event: '*',
-            schema: 'public',
-            table: 'honoo',
-          ),
+          ChannelFilter(event: '*', schema: 'public', table: 'honoo'),
           refresh,
         )
         .on(
           RealtimeListenTypes.postgresChanges,
-          ChannelFilter(
-            event: '*',
-            schema: 'public',
-            table: 'hinoo',
-          ),
+          ChannelFilter(event: '*', schema: 'public', table: 'hinoo'),
           refresh,
         )
         .subscribe();
@@ -130,24 +151,53 @@ class _Entry {
   final String? id;
   final bool isFromMoonSaved;
 
-  _Entry._(this.honoo, this.hinoo, this.createdAt,
-      {this.ownerId, this.id, this.isFromMoonSaved = false});
-  factory _Entry.honoo(Honoo h) =>
-      _Entry._(h, null, DateTime.tryParse(h.createdAt) ?? DateTime.now(),
-          ownerId: h.userId, id: h.dbId, isFromMoonSaved: h.isFromMoonSaved);
+  _Entry._(
+    this.honoo,
+    this.hinoo,
+    this.createdAt, {
+    this.ownerId,
+    this.id,
+    this.isFromMoonSaved = false,
+  });
+  factory _Entry.honoo(Honoo h) => _Entry._(
+    h,
+    null,
+    DateTime.tryParse(h.createdAt) ?? DateTime.now(),
+    ownerId: h.userId,
+    id: h.dbId,
+    isFromMoonSaved: h.isFromMoonSaved,
+  );
   factory _Entry.hinoo(
     HinooDraft d, {
     required DateTime createdAt,
     String? ownerId,
     String? id,
     bool isFromMoonSaved = false,
-  }) =>
-      _Entry._(null, d, createdAt,
-          ownerId: ownerId, id: id, isFromMoonSaved: isFromMoonSaved);
+  }) => _Entry._(
+    null,
+    d,
+    createdAt,
+    ownerId: ownerId,
+    id: id,
+    isFromMoonSaved: isFromMoonSaved,
+  );
 
-  T when<T>(
-      {required T Function(Honoo) honoo,
-      required T Function(HinooDraft) hinoo}) {
+  bool get isReply => honoo != null
+      ? honoo!.type == HonooType.answer
+      : hinoo!.type == HinooType.answer;
+
+  String get contentKey {
+    if (honoo != null) {
+      return 'honoo\u001f${honoo!.text}\u001f${honoo!.image}';
+    }
+    final pages = hinoo!.pages.map((page) => page.toJson()).toList();
+    return 'hinoo\u001f${jsonEncode(pages)}';
+  }
+
+  T when<T>({
+    required T Function(Honoo) honoo,
+    required T Function(HinooDraft) hinoo,
+  }) {
     if (this.honoo != null) return honoo(this.honoo!);
     return hinoo(this.hinoo!);
   }

--- a/lib/UI/hinoo_viewer.dart
+++ b/lib/UI/hinoo_viewer.dart
@@ -146,7 +146,7 @@ class _HinooViewerState extends State<HinooViewer> {
                       border: Border.all(color: HonooColor.secondary, width: 6),
                       borderRadius: BorderRadius.circular(12),
                     )
-                  : (widget.draft.isFromMoonSaved && !isOwn)
+                  : widget.draft.isFromMoonSaved && !widget.isReply
                   ? BoxDecoration(
                       border: Border.all(color: Colors.white, width: 6),
                       borderRadius: BorderRadius.circular(12),

--- a/lib/UI/honoo_card.dart
+++ b/lib/UI/honoo_card.dart
@@ -193,8 +193,7 @@ class HonooCard extends StatelessWidget {
         // La cornice rossa segnala soltanto una risposta ricevuta.
         // I propri messaggi mantengono il rendering normale.
         final bool showReplyBorder = isReply && !isOwn;
-        final bool showMoonSavedBorder =
-            !showReplyBorder && honoo.isFromMoonSaved && !isOwn;
+        final bool showMoonSavedBorder = !isReply && honoo.isFromMoonSaved;
         final Widget wrapped = (showReplyBorder || showMoonSavedBorder)
             ? DecoratedBox(
                 decoration: BoxDecoration(

--- a/lib/UI/unified_thread_view.dart
+++ b/lib/UI/unified_thread_view.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:honoo/Entities/hinoo.dart';
 import 'package:honoo/Entities/honoo.dart';
 import 'package:honoo/Entities/conversation_entry.dart';
-import 'package:honoo/Services/supabase_provider.dart';
 import 'package:honoo/Services/conversation_service.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:honoo/UI/hinoo_viewer.dart';
@@ -36,7 +35,7 @@ class UnifiedThreadView extends StatefulWidget {
   final VoidCallback? onDownloadTap;
   final int refreshToken;
   final Future<List<ConversationEntry>> Function(String conversationId)?
-      conversationLoader;
+  conversationLoader;
   final String? currentUserId;
 
   @override
@@ -58,26 +57,36 @@ class _UnifiedThreadViewState extends State<UnifiedThreadView>
   void initState() {
     super.initState();
     _controller = AnimationController(
-        vsync: this, duration: const Duration(milliseconds: 900));
+      vsync: this,
+      duration: const Duration(milliseconds: 900),
+    );
     _liftAnimation = TweenSequence<double>([
       TweenSequenceItem(
-        tween: Tween(begin: 0.0, end: -1.0)
-            .chain(CurveTween(curve: Curves.easeOutCubic)),
+        tween: Tween(
+          begin: 0.0,
+          end: -1.0,
+        ).chain(CurveTween(curve: Curves.easeOutCubic)),
         weight: 40,
       ),
       TweenSequenceItem(
-        tween: Tween(begin: -1.0, end: -0.84)
-            .chain(CurveTween(curve: Curves.easeOut)),
+        tween: Tween(
+          begin: -1.0,
+          end: -0.84,
+        ).chain(CurveTween(curve: Curves.easeOut)),
         weight: 12,
       ),
       TweenSequenceItem(
-        tween: Tween(begin: -0.84, end: -1.0)
-            .chain(CurveTween(curve: Curves.easeIn)),
+        tween: Tween(
+          begin: -0.84,
+          end: -1.0,
+        ).chain(CurveTween(curve: Curves.easeIn)),
         weight: 12,
       ),
       TweenSequenceItem(
-        tween: Tween(begin: -1.0, end: 0.0)
-            .chain(CurveTween(curve: Curves.easeInOutCubic)),
+        tween: Tween(
+          begin: -1.0,
+          end: 0.0,
+        ).chain(CurveTween(curve: Curves.easeInOutCubic)),
         weight: 36,
       ),
     ]).animate(CurvedAnimation(parent: _controller, curve: Curves.easeInOut));
@@ -200,17 +209,13 @@ class _UnifiedThreadViewState extends State<UnifiedThreadView>
   }
 
   bool _shouldReveal(ConversationEntry e) {
-    final String? myId =
-        widget.currentUserId ?? SupabaseProvider.client.auth.currentUser?.id;
     // Moon-saved: non rivelare
-    final bool isMoon = e.isFromMoonSaved == true ||
+    final bool isMoon =
+        e.isFromMoonSaved == true ||
         (e.honoo != null && (e.honoo!.isFromMoonSaved == true));
     if (isMoon) return false;
 
-    // Creato da me: non rivelare
-    if (e.ownerId != null && myId != null && e.ownerId == myId) return false;
-
-    // Reply?
+    // Il bounce accompagna sia le risposte ricevute sia quelle inviate.
     final bool isReply = e.honoo != null
         ? (e.honoo!.type == HonooType.answer)
         : (e.hinoo != null && e.hinoo!.type == HinooType.answer);
@@ -301,10 +306,7 @@ class _UnifiedThreadViewState extends State<UnifiedThreadView>
                       if (answeredPage != null) answeredPage,
                       Transform.translate(
                         key: const Key('reply_reveal_foreground'),
-                        offset: Offset(
-                          0,
-                          _liftAnimation.value * revealHeight,
-                        ),
+                        offset: Offset(0, _liftAnimation.value * revealHeight),
                         child: childWidget,
                       ),
                     ],

--- a/test/services/conversation_service_test.dart
+++ b/test/services/conversation_service_test.dart
@@ -39,11 +39,7 @@ void main() {
       {
         'id': 'hinoo-1',
         'pages': <Map<String, dynamic>>[
-          {
-            'text': 'seconda',
-            'backgroundImage': 'bg.png',
-            'isTextWhite': true,
-          },
+          {'text': 'seconda', 'backgroundImage': 'bg.png', 'isTextWhite': true},
         ],
         'type': 'answer',
         'created_at': '2026-01-01T11:00:00Z',
@@ -52,8 +48,9 @@ void main() {
       },
     ]);
 
-    final result =
-        await ConversationService.fetchConversation('conversation-1');
+    final result = await ConversationService.fetchConversation(
+      'conversation-1',
+    );
 
     expect(result.map((entry) => entry.kind), [
       ConversationEntryKind.honoo,
@@ -88,9 +85,121 @@ void main() {
       },
     ]);
 
-    final result =
-        await ConversationService.fetchConversation('conversation-1');
+    final result = await ConversationService.fetchConversation(
+      'conversation-1',
+    );
 
     expect(result.single.hinoo!.type.name, 'answer');
   });
+
+  test(
+    'preferisce una sola copia Honoo salvata dalla Luna alla radice',
+    () async {
+      final honoo = harness.stubTable('honoo');
+      final hinoo = harness.stubTable('hinoo');
+      honoo.queueResponse(<Map<String, dynamic>>[
+        {
+          'id': 'moon-root',
+          'text': 'stesso contenuto',
+          'image_url': 'image.png',
+          'destination': 'moon',
+          'created_at': '2026-01-01T09:00:00Z',
+          'updated_at': '2026-01-01T09:00:00Z',
+          'user_id': 'author',
+          'conversation_id': 'conversation-1',
+          'is_from_moon_saved': false,
+        },
+        {
+          'id': 'saved-root',
+          'text': 'stesso contenuto',
+          'image_url': 'image.png',
+          'destination': 'chest',
+          'created_at': '2026-01-01T10:00:00Z',
+          'updated_at': '2026-01-01T10:00:00Z',
+          'user_id': 'test_user',
+          'conversation_id': 'conversation-1',
+          'is_from_moon_saved': true,
+        },
+        {
+          'id': 'reply',
+          'text': 'risposta',
+          'image_url': '',
+          'destination': 'reply',
+          'reply_to': 'moon-root',
+          'created_at': '2026-01-01T11:00:00Z',
+          'updated_at': '2026-01-01T11:00:00Z',
+          'user_id': 'test_user',
+          'conversation_id': 'conversation-1',
+          'is_from_moon_saved': false,
+        },
+      ]);
+      hinoo.queueResponse(<Map<String, dynamic>>[]);
+
+      final result = await ConversationService.fetchConversation(
+        'conversation-1',
+      );
+
+      expect(result.map((entry) => entry.id), ['saved-root', 'reply']);
+      expect(result.first.isFromMoonSaved, isTrue);
+    },
+  );
+
+  test(
+    'preferisce una sola copia Hinoo salvata dalla Luna alla radice',
+    () async {
+      final honoo = harness.stubTable('honoo');
+      final hinoo = harness.stubTable('hinoo');
+      honoo.queueResponse(<Map<String, dynamic>>[]);
+      final pages = <Map<String, dynamic>>[
+        {
+          'text': 'stesso contenuto',
+          'backgroundImage': 'bg.png',
+          'isTextWhite': true,
+        },
+      ];
+      hinoo.queueResponse(<Map<String, dynamic>>[
+        {
+          'id': 'moon-root',
+          'pages': pages,
+          'type': 'moon',
+          'created_at': '2026-01-01T09:00:00Z',
+          'user_id': 'author',
+          'conversation_id': 'conversation-1',
+          'is_from_moon_saved': false,
+        },
+        {
+          'id': 'saved-root',
+          'pages': pages,
+          'type': 'personal',
+          'created_at': '2026-01-01T10:00:00Z',
+          'user_id': 'test_user',
+          'conversation_id': 'conversation-1',
+          'is_from_moon_saved': true,
+        },
+        {
+          'id': 'reply',
+          'pages': <Map<String, dynamic>>[
+            {
+              'text': 'risposta',
+              'backgroundImage': 'reply.png',
+              'isTextWhite': true,
+            },
+          ],
+          'type': 'answer',
+          'reply_to': 'moon-root',
+          'created_at': '2026-01-01T11:00:00Z',
+          'user_id': 'test_user',
+          'conversation_id': 'conversation-1',
+          'is_from_moon_saved': false,
+        },
+      ]);
+
+      final result = await ConversationService.fetchConversation(
+        'conversation-1',
+      );
+
+      expect(result.map((entry) => entry.id), ['saved-root', 'reply']);
+      expect(result.first.isFromMoonSaved, isTrue);
+    },
+  );
 }

--- a/test/widgets/conversation_border_test.dart
+++ b/test/widgets/conversation_border_test.dart
@@ -23,20 +23,20 @@ void main() {
   });
 
   Finder borderWithColor(Color color) => find.byWidgetPredicate((widget) {
-        final Decoration? decoration = switch (widget) {
-          Container(:final decoration) => decoration,
-          DecoratedBox(:final decoration) => decoration,
-          _ => null,
-        };
-        if (decoration is! BoxDecoration) return false;
-        final border = decoration.border;
-        return border is Border &&
-            border.top.color == color &&
-            border.right.color == color &&
-            border.bottom.color == color &&
-            border.left.color == color &&
-            border.top.width == 6;
-      });
+    final Decoration? decoration = switch (widget) {
+      Container(:final decoration) => decoration,
+      DecoratedBox(:final decoration) => decoration,
+      _ => null,
+    };
+    if (decoration is! BoxDecoration) return false;
+    final border = decoration.border;
+    return border is Border &&
+        border.top.color == color &&
+        border.right.color == color &&
+        border.bottom.color == color &&
+        border.left.color == color &&
+        border.top.width == 6;
+  });
 
   Honoo honoo({
     required HonooType type,
@@ -55,16 +55,16 @@ void main() {
   }
 
   HinooDraft hinoo({bool fromMoon = false}) => HinooDraft(
-        pages: const [
-          HinooSlide(
-            backgroundImage: null,
-            text: 'Test conversazione',
-            isTextWhite: true,
-          ),
-        ],
-        type: HinooType.personal,
-        isFromMoonSaved: fromMoon,
-      );
+    pages: const [
+      HinooSlide(
+        backgroundImage: null,
+        text: 'Test conversazione',
+        isTextWhite: true,
+      ),
+    ],
+    type: HinooType.personal,
+    isFromMoonSaved: fromMoon,
+  );
 
   Future<void> pumpHonoo(WidgetTester tester, Honoo value) async {
     tester.view.devicePixelRatio = 1;
@@ -112,30 +112,25 @@ void main() {
   }
 
   testWidgets('Honoo di risposta proprio non ha cornice', (tester) async {
-    await pumpHonoo(
-      tester,
-      honoo(type: HonooType.answer, owner: 'test_user'),
-    );
+    await pumpHonoo(tester, honoo(type: HonooType.answer, owner: 'test_user'));
 
     expect(borderWithColor(HonooColor.secondary), findsNothing);
     expect(borderWithColor(Colors.white), findsNothing);
   });
 
   testWidgets('Honoo ricevuto in risposta ha cornice rossa', (tester) async {
-    await pumpHonoo(
-      tester,
-      honoo(type: HonooType.answer),
-    );
+    await pumpHonoo(tester, honoo(type: HonooType.answer));
 
     expect(borderWithColor(HonooColor.secondary), findsWidgets);
     expect(borderWithColor(Colors.white), findsNothing);
   });
 
-  testWidgets('Honoo salvato dalla Luna ha solo cornice bianca',
-      (tester) async {
+  testWidgets('Honoo salvato dalla Luna ha solo cornice bianca', (
+    tester,
+  ) async {
     await pumpHonoo(
       tester,
-      honoo(type: HonooType.personal, fromMoon: true),
+      honoo(type: HonooType.personal, owner: 'test_user', fromMoon: true),
     );
 
     expect(borderWithColor(Colors.white), findsWidgets);
@@ -166,13 +161,14 @@ void main() {
     expect(borderWithColor(Colors.white), findsNothing);
   });
 
-  testWidgets('Hinoo salvato dalla Luna ha solo cornice bianca',
-      (tester) async {
+  testWidgets('Hinoo salvato dalla Luna ha solo cornice bianca', (
+    tester,
+  ) async {
     await pumpHinoo(
       tester,
       draft: hinoo(fromMoon: true),
       isReply: false,
-      authorId: 'other_user',
+      authorId: 'test_user',
     );
 
     expect(borderWithColor(Colors.white), findsWidgets);

--- a/test/widgets/unified_thread_reveal_test.dart
+++ b/test/widgets/unified_thread_reveal_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:honoo/Entities/conversation_entry.dart';
 import 'package:honoo/Entities/honoo.dart';
 import 'package:honoo/UI/unified_thread_view.dart';
+import 'package:honoo/Utility/honoo_colors.dart';
 
 import '../test_supabase_helper.dart';
 
@@ -25,35 +26,55 @@ void main() {
     required String createdAt,
     HonooType type = HonooType.personal,
     String? replyTo,
+    bool fromMoon = false,
   }) {
     final value = Honoo(0, text, '', createdAt, createdAt, owner, type)
       ..dbId = id
       ..replyTo = replyTo
+      ..isFromMoonSaved = fromMoon
       ..conversationId = 'conversation-1';
     return value;
   }
 
-  testWidgets('il bounce rivela il messaggio padre fino a metà schermo',
-      (tester) async {
+  Finder borderWithColor(Color color) => find.byWidgetPredicate((widget) {
+    final Decoration? decoration = switch (widget) {
+      Container(:final decoration) => decoration,
+      DecoratedBox(:final decoration) => decoration,
+      _ => null,
+    };
+    if (decoration is! BoxDecoration) return false;
+    final border = decoration.border;
+    return border is Border &&
+        border.top.color == color &&
+        border.top.width == 6;
+  });
+
+  testWidgets('il bounce rivela il messaggio padre fino a metà schermo', (
+    tester,
+  ) async {
     tester.view.devicePixelRatio = 1;
     tester.view.physicalSize = const Size(600, 900);
     addTearDown(tester.view.resetDevicePixelRatio);
     addTearDown(tester.view.resetPhysicalSize);
 
-    final root = ConversationEntry.honoo(honoo(
-      id: 'root-1',
-      text: 'Messaggio padre',
-      owner: 'me',
-      createdAt: '2026-07-20T10:00:00Z',
-    ));
-    final reply = ConversationEntry.honoo(honoo(
-      id: 'reply-1',
-      text: 'Ultima risposta ricevuta',
-      owner: 'other',
-      createdAt: '2026-07-20T11:00:00Z',
-      type: HonooType.answer,
-      replyTo: 'root-1',
-    ));
+    final root = ConversationEntry.honoo(
+      honoo(
+        id: 'root-1',
+        text: 'Messaggio padre',
+        owner: 'me',
+        createdAt: '2026-07-20T10:00:00Z',
+      ),
+    );
+    final reply = ConversationEntry.honoo(
+      honoo(
+        id: 'reply-1',
+        text: 'Ultima risposta ricevuta',
+        owner: 'other',
+        createdAt: '2026-07-20T11:00:00Z',
+        type: HonooType.answer,
+        replyTo: 'root-1',
+      ),
+    );
 
     await tester.pumpWidget(
       MaterialApp(
@@ -82,4 +103,55 @@ void main() {
     expect(foreground.transform.getTranslation().y, lessThan(0));
     expect(foreground.transform.getTranslation().y, greaterThanOrEqualTo(-336));
   });
+
+  testWidgets(
+    'il bounce mostra la risposta propria senza bordo e il padre Luna bianco',
+    (tester) async {
+      tester.view.devicePixelRatio = 1;
+      tester.view.physicalSize = const Size(600, 900);
+      addTearDown(tester.view.resetDevicePixelRatio);
+      addTearDown(tester.view.resetPhysicalSize);
+
+      final root = ConversationEntry.honoo(
+        honoo(
+          id: 'saved-root-1',
+          text: 'Messaggio salvato dalla Luna',
+          owner: 'test_user',
+          createdAt: '2026-07-20T10:00:00Z',
+          fromMoon: true,
+        ),
+      );
+      final reply = ConversationEntry.honoo(
+        honoo(
+          id: 'reply-1',
+          text: 'La mia risposta',
+          owner: 'test_user',
+          createdAt: '2026-07-20T11:00:00Z',
+          type: HonooType.answer,
+          replyTo: 'moon-root-1',
+        ),
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: UnifiedThreadView(
+              conversationId: 'conversation-1',
+              maxWidth: 600,
+              maxHeight: 700,
+              isActive: true,
+              currentUserId: 'test_user',
+              conversationLoader: (_) async => [root, reply],
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 600));
+
+      expect(find.byKey(const Key('reply_reveal_parent')), findsOneWidget);
+      expect(borderWithColor(Colors.white), findsWidgets);
+      expect(borderWithColor(HonooColor.secondary), findsNothing);
+    },
+  );
 }


### PR DESCRIPTION
## Cosa cambia

- evita il doppio salvataggio dell’Honoo originale quando la risposta parte dalla Luna
- mantiene la cornice bianca sulla copia salvata dalla Luna anche nello scrigno del proprietario
- lascia senza cornice la risposta propria e applica la cornice rossa solo nello scrigno del destinatario
- applica il bounce dal basso anche alle risposte inviate
- deduplica le vecchie radici Honoo/Hinoo già salvate due volte, preferendo la copia marcata come proveniente dalla Luna

## Causa

Il salvataggio dell’elemento Luna veniva eseguito sia prima di aprire il composer sia durante l’invio. Inoltre la cornice bianca e il bounce dipendevano dall’autore corrente invece che dal ruolo dell’elemento nella conversazione.

## Verifica

- `fvm flutter analyze`
- `fvm flutter test test/widgets/conversation_border_test.dart test/widgets/unified_thread_reveal_test.dart test/services/conversation_service_test.dart`
- `fvm flutter test test/services/conversation_service_test.dart`
- `fvm flutter test test/pages/reply_honoo_flow_test.dart`