### PR TITLE
Handle GNU grep in migration gate

### DIFF
--- a/tool/check_supabase_migrations.sh
+++ b/tool/check_supabase_migrations.sh
@@ -6,7 +6,10 @@ set -euo pipefail
 # this release gate cannot fail only because of the runner image.
 if ! command -v rg >/dev/null 2>&1; then
   rg() {
-    grep -E "$@"
+    case "${1:-}" in
+      *F*) grep "$@" ;;
+      *) grep -E "$@" ;;
+    esac
   }
 fi
 


### PR DESCRIPTION
## Summary
- avoid combining GNU grep's mutually exclusive extended-regex and fixed-string matchers
- preserve extended regex matching for the remaining migration checks

## Verification
- Supabase migration structure checks passed (46 files).
- 

This addresses the Linux-only failure in production release run 29907936502. The run stopped before build or deploy.