### PR TITLE
Increase Hinoo text size

### DIFF
--- a/lib/UI/hinoo_typography.dart
+++ b/lib/UI/hinoo_typography.dart
@@ -12,7 +12,7 @@ class HinooTypography {
   static const int maxCharsPerLine = 33;
 
   /// Fixed font size in dp/points (does not scale)
-  static const double fontSize = 17.0;
+  static const double fontSize = 18.0;
 
   /// Fixed line height multiplier (approximately 1.35-1.4 from image analysis)
   static const double lineHeight = 1.375;

--- a/test/ui/hinoo_typography_test.dart
+++ b/test/ui/hinoo_typography_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:honoo/UI/hinoo_typography.dart';
+
+void main() {
+  testWidgets('creation and publication use the Honoo-equivalent font size',
+      (tester) async {
+    final creationStyle = HinooTypography.textStyle(color: Colors.white);
+    final publicationStyle =
+        HinooTypography.displayTextStyle(color: Colors.white);
+
+    expect(HinooTypography.fontSize, 18.0);
+    expect(creationStyle.fontSize, HinooTypography.fontSize);
+    expect(publicationStyle.fontSize, HinooTypography.fontSize);
+    expect(creationStyle.height, HinooTypography.lineHeight);
+    expect(publicationStyle.height, HinooTypography.lineHeight);
+  });
+
+  test('twenty lines remain inside the baseline Hinoo text area', () {
+    final availableHeight = HinooTypography.baselineCanvasHeight -
+        HinooTypography.verticalPadding(
+              HinooTypography.baselineCanvasWidth,
+            ) *
+            2;
+    const maximumTextHeight = HinooTypography.maxLines *
+        HinooTypography.fontSize *
+        HinooTypography.lineHeight;
+
+    expect(maximumTextHeight, lessThanOrEqualTo(availableHeight));
+  });
+}


### PR DESCRIPTION
## Cosa cambia

- aumenta il font Hinoo da 17 a 18, allineandone la grandezza nominale a Honoo
- mantiene invariati interlinea, limite di 20 righe, limite di 33 caratteri per riga e controlli di larghezza
- aggiunge test sulla coerenza tra creazione e pubblicazione e sul limite verticale del canvas Hinoo

## Impatto

Il testo risulta più grande durante la creazione, nella visualizzazione pubblicata, nelle anteprime e negli export, perché tutti i flussi usano la tipografia Hinoo centralizzata.

## Verifiche

- `fvm flutter analyze lib/UI/hinoo_typography.dart test/ui/hinoo_typography_test.dart`
- `fvm flutter test test/ui/hinoo_typography_test.dart test/widgets/hinoo_moon_rendering_test.dart`
