### PR TITLE
Limit chest animations to conversations

### DIFF
--- a/lib/Widgets/chest_item_view.dart
+++ b/lib/Widgets/chest_item_view.dart
@@ -7,7 +7,7 @@ import '../Entities/honoo.dart';
 import '../UI/hinoo_thread_view.dart';
 import '../UI/hinoo_typography.dart';
 import '../UI/hinoo_viewer.dart';
-import '../UI/honoo_thread_view.dart';
+import '../UI/honoo_card.dart';
 import '../UI/unified_thread_view.dart';
 import '../Utility/responsive_layout.dart';
 
@@ -66,11 +66,21 @@ class ChestItemView extends StatelessWidget {
       honoo: (honoo) => _buildHonoo(honoo),
       hinoo: (hinoo) => _buildHinoo(hinoo, cardWidth, cardHeight),
     );
-    final isThread = item.when(
-      honoo: (_) => true,
-      hinoo: (hinoo) => hinooRepliesByRoot[hinoo.id]?.isNotEmpty ?? false,
+    final isConversation = item.when(
+      honoo: (honoo) =>
+          isNormalMode &&
+          honoo.conversationId != null &&
+          honoo.conversationId!.isNotEmpty,
+      hinoo: (hinoo) {
+        final conversationId =
+            hinoo.conversationId ?? hinoo.draft.conversationId;
+        return (isNormalMode &&
+                conversationId != null &&
+                conversationId.isNotEmpty) ||
+            (hinooRepliesByRoot[hinoo.id]?.isNotEmpty ?? false);
+      },
     );
-    final card = isThread
+    final card = isConversation
         ? RepaintBoundary(key: repaintKey, child: content)
         : ClipRRect(
             borderRadius: BorderRadius.circular(12),
@@ -79,16 +89,14 @@ class ChestItemView extends StatelessWidget {
               child: RepaintBoundary(key: repaintKey, child: content),
             ),
           );
+    final keyedCard = KeyedSubtree(
+      key: ValueKey(identity),
+      child: SizedBox(width: maxWidth, height: availableHeight, child: card),
+    );
+    if (!isConversation) return keyedCard;
     return AnimatedSwitcher(
       duration: const Duration(milliseconds: 250),
-      child: KeyedSubtree(
-        key: ValueKey(identity),
-        child: SizedBox(
-          width: maxWidth,
-          height: availableHeight,
-          child: card,
-        ),
-      ),
+      child: keyedCard,
     );
   }
 
@@ -97,15 +105,10 @@ class ChestItemView extends StatelessWidget {
     if (isNormalMode && conversationId != null && conversationId.isNotEmpty) {
       return _unifiedThread(conversationId);
     }
-    final effectiveRoot = honoo.type == HonooType.answer &&
-            honoo.replyTo != null &&
-            honoo.replyTo!.isNotEmpty
-        ? honoo.copyWith(dbId: honoo.replyTo)
-        : honoo;
     return SizedBox(
       width: maxWidth,
       height: availableHeight,
-      child: HonooThreadView(root: effectiveRoot, onDownloadTap: onDownload),
+      child: HonooCard(honoo: honoo, onDownloadTap: onDownload),
     );
   }
 
@@ -139,14 +142,13 @@ class ChestItemView extends StatelessWidget {
   }
 
   Widget _unifiedThread(String conversationId) => UnifiedThreadView(
-        conversationId: conversationId,
-        maxWidth: maxWidth,
-        maxHeight: availableHeight,
-        isActive: isActive,
-        onSelect: onSelectConversationEntry,
-        highlightLatest:
-            highlightLatest && focusConversationId == conversationId,
-        onDownloadTap: onDownload,
-        refreshToken: conversationRefreshToken,
-      );
+    conversationId: conversationId,
+    maxWidth: maxWidth,
+    maxHeight: availableHeight,
+    isActive: isActive,
+    onSelect: onSelectConversationEntry,
+    highlightLatest: highlightLatest && focusConversationId == conversationId,
+    onDownloadTap: onDownload,
+    refreshToken: conversationRefreshToken,
+  );
 }

--- a/test/widgets/chest_item_view_animation_test.dart
+++ b/test/widgets/chest_item_view_animation_test.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:honoo/Entities/chest_item.dart';
+import 'package:honoo/Entities/conversation_entry.dart';
+import 'package:honoo/Entities/honoo.dart';
+import 'package:honoo/UI/honoo_card.dart';
+import 'package:honoo/UI/honoo_thread_view.dart';
+import 'package:honoo/UI/unified_thread_view.dart';
+import 'package:honoo/Utility/responsive_layout.dart';
+import 'package:honoo/Widgets/chest_item_view.dart';
+
+import '../test_supabase_helper.dart';
+
+void main() {
+  setUpAll(registerSupabaseFallbacks);
+
+  late SupabaseTestHarness harness;
+
+  setUp(() {
+    harness = SupabaseTestHarness(withAuthenticatedUser: true)
+      ..enableOverrides();
+  });
+
+  tearDown(() => harness.disableOverrides());
+
+  testWidgets('un Honoo singolo non usa viste o transizioni di conversazione', (
+    tester,
+  ) async {
+    final honoo = Honoo(
+      0,
+      'Honoo singolo',
+      '',
+      '2026-07-25T10:00:00Z',
+      '2026-07-25T10:00:00Z',
+      'test_user',
+      HonooType.personal,
+    )..dbId = 'honoo-single';
+    final item = ChestItem.honoo(honoo, DateTime.parse('2026-07-25T10:00:00Z'));
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: ChestItemView(
+            item: item,
+            availableHeight: 700,
+            maxWidth: 390,
+            honooMetrics: ResponsiveLayout.honooBuilderMetrics(
+              availableHeight: 700,
+              maxWidth: 390,
+              mode: ResponsiveLayoutMode.mobile,
+            ),
+            repaintKey: GlobalKey(),
+            hinooRepliesByRoot: const {},
+            isNormalMode: true,
+            isActive: true,
+            highlightLatest: false,
+            focusConversationId: null,
+            onSelectConversationEntry: (ConversationEntry _) {},
+            onDownload: () {},
+            conversationRefreshToken: 0,
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.byType(HonooCard), findsOneWidget);
+    expect(find.byType(HonooThreadView), findsNothing);
+    expect(find.byType(UnifiedThreadView), findsNothing);
+    final chestItem = find.byType(ChestItemView);
+    expect(
+      find.descendant(of: chestItem, matching: find.byType(AnimatedSwitcher)),
+      findsNothing,
+    );
+    expect(
+      find.descendant(of: chestItem, matching: find.byType(SlideTransition)),
+      findsNothing,
+    );
+    expect(
+      find.descendant(of: chestItem, matching: find.byType(ScaleTransition)),
+      findsNothing,
+    );
+    expect(
+      find.descendant(of: chestItem, matching: find.byType(FadeTransition)),
+      findsNothing,
+    );
+  });
+}


### PR DESCRIPTION
## Sintesi
- mostra direttamente HonooCard per gli Honoo senza conversazione
- mantiene UnifiedThreadView e le animazioni soltanto per conversazioni reali
- aggiunge un test di regressione che esclude viste e transizioni di thread sui contenuti singoli

## Verifica
- fvm flutter analyze
- fvm flutter test (181 superati, 7 esclusi)
- 30 test mirati su layout responsive, cornici, reveal e deduplicazione