### PR TITLE
Preserve saved Hinoo text layout

### DIFF
--- a/lib/UI/hinoo_typography.dart
+++ b/lib/UI/hinoo_typography.dart
@@ -49,9 +49,12 @@ class HinooTypography {
     );
   }
 
-  /// Returns the base TextStyle for display/viewer (slightly bolder)
+  /// Returns the same TextStyle used by the editor.
+  ///
+  /// Keeping identical font metrics prevents saved text from changing width
+  /// or appearing compressed after publication.
   static TextStyle displayTextStyle({required Color color}) {
-    return textStyle(color: color, fontWeight: FontWeight.w600);
+    return textStyle(color: color);
   }
 
   /// Calculate usable width after padding

--- a/lib/UI/hinoo_viewer.dart
+++ b/lib/UI/hinoo_viewer.dart
@@ -335,11 +335,15 @@ class HinooSlideView extends StatelessWidget {
                 vertical: verticalPadding,
               ),
               child: Center(
-                child: Text(
-                  slide.text,
-                  textAlign: TextAlign.center,
-                  style: effectiveStyle,
-                  softWrap: true,
+                child: FittedBox(
+                  key: const ValueKey('hinoo-fitted-text'),
+                  fit: BoxFit.scaleDown,
+                  child: Text(
+                    slide.text,
+                    textAlign: TextAlign.center,
+                    style: effectiveStyle,
+                    softWrap: false,
+                  ),
                 ),
               ),
             ),

--- a/lib/UI/hinoo_viewer.dart
+++ b/lib/UI/hinoo_viewer.dart
@@ -205,6 +205,8 @@ class _HinooViewerState extends State<HinooViewer> {
                               height: baselineH,
                               gap: 0,
                               gapColor: widget.gapColor,
+                              scaleLegacyTextToFit:
+                                  widget.draft.baseCanvasHeight == null,
                               onDownloadTap: widget.onDownloadTap,
                             );
                           },
@@ -256,6 +258,7 @@ class HinooSlideView extends StatelessWidget {
   final double height;
   final double gap;
   final Color gapColor;
+  final bool scaleLegacyTextToFit;
   final VoidCallback? onDownloadTap;
   const HinooSlideView({
     super.key,
@@ -264,6 +267,7 @@ class HinooSlideView extends StatelessWidget {
     required this.height,
     required this.gap,
     required this.gapColor,
+    this.scaleLegacyTextToFit = false,
     this.onDownloadTap,
   });
 
@@ -308,6 +312,12 @@ class HinooSlideView extends StatelessWidget {
     final Widget? downloadOverlay = onDownloadTap == null
         ? null
         : TextBoxDownloadButton(onPressed: onDownloadTap!, tooltip: 'download');
+    final Widget text = Text(
+      slide.text,
+      textAlign: TextAlign.center,
+      style: effectiveStyle,
+      softWrap: false,
+    );
 
     return SizedBox(
       width: width,
@@ -335,16 +345,13 @@ class HinooSlideView extends StatelessWidget {
                 vertical: verticalPadding,
               ),
               child: Center(
-                child: FittedBox(
-                  key: const ValueKey('hinoo-fitted-text'),
-                  fit: BoxFit.scaleDown,
-                  child: Text(
-                    slide.text,
-                    textAlign: TextAlign.center,
-                    style: effectiveStyle,
-                    softWrap: false,
-                  ),
-                ),
+                child: scaleLegacyTextToFit
+                    ? FittedBox(
+                        key: const ValueKey('hinoo-legacy-fitted-text'),
+                        fit: BoxFit.scaleDown,
+                        child: text,
+                      )
+                    : text,
               ),
             ),
           ),

--- a/test/ui/hinoo_typography_test.dart
+++ b/test/ui/hinoo_typography_test.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:honoo/Entities/hinoo.dart';
 import 'package:honoo/UI/hinoo_typography.dart';
+import 'package:honoo/UI/hinoo_viewer.dart';
 
 void main() {
   testWidgets('creation and publication use the Honoo-equivalent font size',
@@ -27,5 +29,60 @@ void main() {
         HinooTypography.lineHeight;
 
     expect(maximumTextHeight, lessThanOrEqualTo(availableHeight));
+  });
+
+  testWidgets(
+      'historical Hinoo text starts at 18 and scales down only to stay visible',
+      (tester) async {
+    final legacyText = List.generate(
+      21,
+      (index) => 'Riga storica ${index + 1} con testo completo',
+    ).join('\n');
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: HinooSlideView(
+              slide: HinooSlide(
+                backgroundImage: null,
+                text: legacyText,
+                isTextWhite: true,
+              ),
+              width: HinooTypography.baselineCanvasWidth,
+              height: HinooTypography.baselineCanvasHeight,
+              gap: 0,
+              gapColor: Colors.black,
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    final fittedFinder = find.byKey(const ValueKey('hinoo-fitted-text'));
+    final textFinder = find.descendant(
+      of: fittedFinder,
+      matching: find.byType(Text),
+    );
+    final fittedBox = tester.renderObject<RenderBox>(fittedFinder);
+    final textBox = tester.renderObject<RenderBox>(textFinder);
+    final transformedTextBounds = MatrixUtils.transformRect(
+      textBox.getTransformTo(fittedBox),
+      Offset.zero & textBox.size,
+    );
+    final renderedText = tester.widget<Text>(textFinder);
+
+    expect(renderedText.style?.fontSize, HinooTypography.fontSize);
+    expect(renderedText.softWrap, isFalse);
+    expect(transformedTextBounds.left, greaterThanOrEqualTo(0));
+    expect(transformedTextBounds.top, greaterThanOrEqualTo(0));
+    expect(
+        transformedTextBounds.right, lessThanOrEqualTo(fittedBox.size.width));
+    expect(
+      transformedTextBounds.bottom,
+      lessThanOrEqualTo(fittedBox.size.height),
+    );
+    expect(tester.takeException(), isNull);
   });
 }

--- a/test/ui/hinoo_typography_test.dart
+++ b/test/ui/hinoo_typography_test.dart
@@ -16,6 +16,7 @@ void main() {
     expect(publicationStyle.fontSize, HinooTypography.fontSize);
     expect(creationStyle.height, HinooTypography.lineHeight);
     expect(publicationStyle.height, HinooTypography.lineHeight);
+    expect(publicationStyle.fontWeight, creationStyle.fontWeight);
   });
 
   test('twenty lines remain inside the baseline Hinoo text area', () {
@@ -53,6 +54,7 @@ void main() {
               height: HinooTypography.baselineCanvasHeight,
               gap: 0,
               gapColor: Colors.black,
+              scaleLegacyTextToFit: true,
             ),
           ),
         ),
@@ -60,7 +62,8 @@ void main() {
     );
     await tester.pump();
 
-    final fittedFinder = find.byKey(const ValueKey('hinoo-fitted-text'));
+    final fittedFinder =
+        find.byKey(const ValueKey('hinoo-legacy-fitted-text'));
     final textFinder = find.descendant(
       of: fittedFinder,
       matching: find.byType(Text),
@@ -83,6 +86,45 @@ void main() {
       transformedTextBounds.bottom,
       lessThanOrEqualTo(fittedBox.size.height),
     );
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('saved editor text keeps its original size and manual line breaks',
+      (tester) async {
+    const editorText = 'Prima riga\nSeconda riga\nTerza riga';
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: HinooSlideView(
+              slide: HinooSlide(
+                backgroundImage: null,
+                text: editorText,
+                isTextWhite: true,
+              ),
+              width: HinooTypography.baselineCanvasWidth,
+              height: HinooTypography.baselineCanvasHeight,
+              gap: 0,
+              gapColor: Colors.black,
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    final textFinder = find.text(editorText);
+    final renderedText = tester.widget<Text>(textFinder);
+
+    expect(renderedText.data, editorText);
+    expect(renderedText.style?.fontSize, HinooTypography.fontSize);
+    expect(
+      renderedText.style?.fontWeight,
+      HinooTypography.textStyle(color: Colors.white).fontWeight,
+    );
+    expect(renderedText.softWrap, isFalse);
+    expect(find.byType(FittedBox), findsNothing);
     expect(tester.takeException(), isNull);
   });
 }

--- a/test/widgets/hinoo_moon_rendering_test.dart
+++ b/test/widgets/hinoo_moon_rendering_test.dart
@@ -50,5 +50,37 @@ void main() {
     expect(moon.height, saved.height);
     expect(moon.gap, saved.gap);
     expect(moon.gapColor, saved.gapColor);
+    expect(moon.scaleLegacyTextToFit, saved.scaleLegacyTextToFit);
+  });
+
+  testWidgets(
+      'un Hinoo appena salvato mantiene il layout editor senza restringimento',
+      (tester) async {
+    const slide = HinooSlide(
+      backgroundImage: null,
+      text: 'Prima riga\nSeconda riga',
+      isTextWhite: true,
+    );
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: HinooViewer(
+          draft: HinooDraft(
+            pages: [slide],
+            baseCanvasHeight: 640,
+          ),
+          maxHeight: 640,
+          maxWidth: 360,
+        ),
+      ),
+    );
+    await tester.pump();
+
+    final renderedSlide =
+        tester.widget<HinooSlideView>(find.byType(HinooSlideView));
+
+    expect(renderedSlide.scaleLegacyTextToFit, isFalse);
+    expect(find.byKey(const ValueKey('hinoo-legacy-fitted-text')),
+        findsNothing);
   });
 }


### PR DESCRIPTION
## Summary
- keep saved and published Hinoo text visually identical to the editor: same 18pt font metrics, weight, and manual line breaks
- prevent newly saved text from being automatically scaled down
- retain bounded scale-down only for legacy Hinoo without editor canvas metadata, so historical content stays inside its background

## Validation
- fvm flutter analyze lib/UI/hinoo_viewer.dart lib/UI/hinoo_typography.dart test/ui/hinoo_typography_test.dart test/widgets/hinoo_moon_rendering_test.dart
- fvm flutter test test/ui/hinoo_typography_test.dart test/widgets/hinoo_moon_rendering_test.dart test/widgets/conversation_border_test.dart