### PR TITLE
Preserve saved Hinoo text and image layout

### DIFF
--- a/lib/Pages/new_hinoo_page.dart
+++ b/lib/Pages/new_hinoo_page.dart
@@ -378,7 +378,9 @@ class _NewHinooPageState extends State<NewHinooPage>
     for (final p in rawPages) {
       if (p is Map) {
         final bgUrl = p['bgUrl'] as String?;
-        final txt = ((p['text'] as String?) ?? '').trim();
+        // Preserve the editor string verbatim: leading/trailing manual line
+        // breaks are part of the text's visual position on the canvas.
+        final txt = (p['text'] as String?) ?? '';
         final textColorVal = (p['textColor'] as int?) ?? 0xFFFFFFFF;
         final isTextWhite = textColorVal == const Color(0xFFFFFFFF).toARGB32();
 

--- a/lib/UI/HinooBuilder/overlays/scrivi_hinoo.dart
+++ b/lib/UI/HinooBuilder/overlays/scrivi_hinoo.dart
@@ -32,11 +32,10 @@ class _ScriviHinooOverlayState extends State<ScriviHinooOverlay> {
 
           const double horizontalPad = HinooTypography.horizontalPadding;
 
-          final double baseVerticalPad =
-              HinooTypography.verticalPadding(canvasWidth);
-
-          final double topPad = baseVerticalPad * 0.45;
-          const double bottomPad = 6.0;
+          final double topPad = HinooTypography.editorTextTopPadding(
+            canvasWidth,
+          );
+          const double bottomPad = HinooTypography.editorTextBottomPadding;
 
           final TextStyle effectiveStyle = HinooTypography.textStyle(
             color: widget.textColor,

--- a/lib/UI/hinoo_typography.dart
+++ b/lib/UI/hinoo_typography.dart
@@ -29,6 +29,14 @@ class HinooTypography {
   /// Vertical padding - can be proportional or fixed
   static const double verticalPaddingBase = 40.0;
 
+  /// The editor uses an asymmetric text viewport so the keyboard/cursor do not
+  /// make the saved text jump when switching to the viewer.
+  static double editorTextTopPadding(double canvasWidth) {
+    return verticalPadding(canvasWidth) * 0.45;
+  }
+
+  static const double editorTextBottomPadding = 6.0;
+
   /// Maximum number of lines allowed
   static const int maxLines = 20;
 

--- a/lib/UI/hinoo_viewer.dart
+++ b/lib/UI/hinoo_viewer.dart
@@ -303,7 +303,9 @@ class HinooSlideView extends StatelessWidget {
     final Matrix4 transform = buildTransform();
 
     const double horizontalPadding = HinooTypography.horizontalPadding;
-    final double verticalPadding = HinooTypography.verticalPadding(width);
+    final double textTopPadding = HinooTypography.editorTextTopPadding(width);
+    const double textBottomPadding = HinooTypography.editorTextBottomPadding;
+    final double actionVerticalPadding = HinooTypography.verticalPadding(width);
     final TextStyle effectiveStyle = HinooTypography.displayTextStyle(
       color: textColor,
     );
@@ -320,6 +322,7 @@ class HinooSlideView extends StatelessWidget {
     );
 
     return SizedBox(
+      key: const ValueKey('hinoo-slide-canvas'),
       width: width,
       height: height,
       child: Stack(
@@ -327,6 +330,7 @@ class HinooSlideView extends StatelessWidget {
         children: [
           ClipRect(
             child: Transform(
+              key: const ValueKey('hinoo-saved-background-transform'),
               transform: transform,
               alignment: Alignment.center,
               child: SmoothImage(
@@ -340,11 +344,14 @@ class HinooSlideView extends StatelessWidget {
             top: gap / 2,
             bottom: gap / 2,
             child: Padding(
-              padding: EdgeInsets.symmetric(
-                horizontal: horizontalPadding,
-                vertical: verticalPadding,
+              padding: EdgeInsets.fromLTRB(
+                horizontalPadding,
+                textTopPadding,
+                horizontalPadding,
+                textBottomPadding,
               ),
               child: Center(
+                key: const ValueKey('hinoo-saved-text-position'),
                 child: scaleLegacyTextToFit
                     ? FittedBox(
                         key: const ValueKey('hinoo-legacy-fitted-text'),
@@ -357,7 +364,7 @@ class HinooSlideView extends StatelessWidget {
           ),
           if (downloadOverlay != null)
             Positioned(
-              top: halfGap + verticalPadding + actionInset,
+              top: halfGap + actionVerticalPadding + actionInset,
               right: horizontalPadding + actionInset,
               child: downloadOverlay,
             ),

--- a/lib/UI/honoo_card.dart
+++ b/lib/UI/honoo_card.dart
@@ -157,7 +157,10 @@ class HonooCard extends StatelessWidget {
                     clipBehavior: Clip.antiAlias,
                     child: hasImage
                         ? SmoothImage(
+                            key: const ValueKey('honoo-saved-image'),
                             image: NetworkImage(imageUrl),
+                            fit: BoxFit.cover,
+                            alignment: Alignment.center,
                             placeholderColor: HonooColor.tertiary,
                           )
                         : Column(

--- a/test/ui/hinoo_typography_test.dart
+++ b/test/ui/hinoo_typography_test.dart
@@ -91,7 +91,7 @@ void main() {
 
   testWidgets('saved editor text keeps its original size and manual line breaks',
       (tester) async {
-    const editorText = 'Prima riga\nSeconda riga\nTerza riga';
+    const editorText = '\nPrima riga\nSeconda riga\nTerza riga\n';
 
     await tester.pumpWidget(
       const MaterialApp(
@@ -125,6 +125,22 @@ void main() {
     );
     expect(renderedText.softWrap, isFalse);
     expect(find.byType(FittedBox), findsNothing);
+    final savedPosition = tester.getRect(
+      find.byKey(const ValueKey('hinoo-saved-text-position')),
+    );
+    final slidePosition = tester.getRect(
+      find.byKey(const ValueKey('hinoo-slide-canvas')),
+    );
+    final expectedCenterY = (HinooTypography.editorTextTopPadding(
+                  HinooTypography.baselineCanvasWidth,
+                ) +
+                slidePosition.height -
+                HinooTypography.editorTextBottomPadding) /
+            2;
+    expect(
+      savedPosition.center.dy - slidePosition.top,
+      closeTo(expectedCenterY, 0.01),
+    );
     expect(tester.takeException(), isNull);
   });
 }

--- a/test/widgets/hinoo_moon_rendering_test.dart
+++ b/test/widgets/hinoo_moon_rendering_test.dart
@@ -83,4 +83,43 @@ void main() {
     expect(find.byKey(const ValueKey('hinoo-legacy-fitted-text')),
         findsNothing);
   });
+
+  testWidgets('Luna e Scrigno riapplicano il ritaglio salvato dello sfondo',
+      (tester) async {
+    const transform = <double>[
+      1.4, 0, 0, 0,
+      0, 1.4, 0, 0,
+      0, 0, 1.4, 0,
+      120, -90, 0, 1,
+    ];
+    const slide = HinooSlide(
+      backgroundImage: null,
+      text: 'Inquadratura invariata',
+      isTextWhite: true,
+      bgTransform: transform,
+    );
+    final roundTrip = HinooSlide.fromJson(slide.toJson());
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: HinooSlideView(
+          slide: roundTrip,
+          width: 360,
+          height: 640,
+          gap: 0,
+          gapColor: Colors.black,
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(roundTrip.bgTransform, transform);
+    final backgroundTransform = tester.widget<Transform>(
+      find.byKey(const ValueKey('hinoo-saved-background-transform')),
+    );
+    expect(backgroundTransform.transform.storage[0], closeTo(1.4, 0.001));
+    expect(backgroundTransform.transform.storage[5], closeTo(1.4, 0.001));
+    expect(backgroundTransform.transform.storage[12], closeTo(40, 0.001));
+    expect(backgroundTransform.transform.storage[13], closeTo(-30, 0.001));
+  });
 }

--- a/test/widgets/honoo_card_layout_test.dart
+++ b/test/widgets/honoo_card_layout_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:honoo/Entities/honoo.dart';
 import 'package:honoo/UI/honoo_card.dart';
 import 'package:honoo/Utility/honoo_colors.dart';
+import 'package:honoo/Widgets/smooth_image.dart';
 
 import '../test_supabase_helper.dart';
 
@@ -51,4 +52,42 @@ void main() {
     );
     expect(gap.color, HonooColor.tertiary);
   });
+
+  testWidgets(
+    'Luna e Scrigno mostrano il ritaglio Honoo senza trasformazioni',
+    (tester) async {
+      final honoo = Honoo(
+        1,
+        'Ritaglio salvato',
+        'https://example.com/saved-square.png',
+        '2026-01-01T00:00:00Z',
+        '2026-01-01T00:00:00Z',
+        'user-id',
+        HonooType.personal,
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 300,
+              height: 459,
+              child: HonooCard(honoo: honoo),
+            ),
+          ),
+        ),
+      );
+
+      final image = tester.widget<SmoothImage>(
+        find.byKey(const ValueKey('honoo-saved-image')),
+      );
+      expect(image.fit, BoxFit.cover);
+      expect(image.alignment, Alignment.center);
+      final renderedSize = tester.getSize(
+        find.byKey(const ValueKey('honoo-saved-image')),
+      );
+      expect(renderedSize.width, closeTo(renderedSize.height, 0.01));
+      expect(renderedSize.width, closeTo(300, 0.5));
+    },
+  );
 }


### PR DESCRIPTION
## Cosa cambia
- conserva il testo Hinoo esattamente come nell’editor, inclusi gli a capo manuali iniziali e finali
- usa nella visualizzazione salvata la stessa area e posizione verticale del testo dell’editor
- rende esplicito e coperto da test il mantenimento di scala, ritaglio e posizione delle immagini Hinoo in Luna/Scrigno
- rende esplicito e coperto da test il rendering quadrato `cover` delle immagini Honoo

## Causa
Durante la conversione del draft veniva applicato `trim()`, che eliminava gli a capo usati per la posizione visiva. Inoltre editor e viewer Hinoo usavano spaziature verticali diverse, producendo un apparente autocentramento al salvataggio.

## Impatto
Hinoo mantiene testo e sfondo come al momento del salvataggio; Honoo mantiene il ritaglio quadrato salvato nelle viste Luna e Scrigno. Le validazioni esistenti restano invariate.

## Verifiche
- 15 test widget/unit mirati superati
- analisi statica mirata: nessun problema
- `git diff --check`: superato