### PR TITLE
Maximize the responsive chest viewer

### DIFF
--- a/lib/Controller/chest_controller.dart
+++ b/lib/Controller/chest_controller.dart
@@ -20,14 +20,14 @@ class ChestState {
     this.isReplyLoading = false,
     this.hinooError,
     this.replyError,
-  })  : hinoo = List.unmodifiable(hinoo),
-        honooLatestReplies = Map.unmodifiable(honooLatestReplies),
-        hinooLatestReplies = Map.unmodifiable(hinooLatestReplies),
-        hinooRepliesByRoot = Map.unmodifiable(
-          hinooRepliesByRoot.map(
-            (key, value) => MapEntry(key, List.unmodifiable(value)),
-          ),
-        );
+  }) : hinoo = List.unmodifiable(hinoo),
+       honooLatestReplies = Map.unmodifiable(honooLatestReplies),
+       hinooLatestReplies = Map.unmodifiable(hinooLatestReplies),
+       hinooRepliesByRoot = Map.unmodifiable(
+         hinooRepliesByRoot.map(
+           (key, value) => MapEntry(key, List.unmodifiable(value)),
+         ),
+       );
 
   final List<ChestHinooItem> hinoo;
   final Map<String, DateTime> honooLatestReplies;
@@ -47,9 +47,9 @@ class ChestController extends ValueNotifier<ChestState> {
     ReliabilityPolicy reliabilityPolicy = const ReliabilityPolicy(),
     this._realtimeReconnectBaseDelay = const Duration(seconds: 1),
     this._realtimeReconnectMaxDelay = const Duration(seconds: 30),
-  })  : _realtimeGateway = realtimeGateway ?? SupabaseChestRealtimeGateway(),
-        _reliability = reliabilityPolicy,
-        super(ChestState());
+  }) : _realtimeGateway = realtimeGateway ?? SupabaseChestRealtimeGateway(),
+       _reliability = reliabilityPolicy,
+       super(ChestState());
 
   final ChestRepository _repository;
   final ChestRealtimeGateway _realtimeGateway;
@@ -66,6 +66,7 @@ class ChestController extends ValueNotifier<ChestState> {
   int _realtimeGeneration = 0;
   bool _isRefreshingReplies = false;
   bool _refreshPending = false;
+  bool _isDisposed = false;
 
   void startRealtime(
     String userId, {
@@ -185,11 +186,13 @@ class ChestController extends ValueNotifier<ChestState> {
 
   @override
   void dispose() {
+    _isDisposed = true;
     stopRealtime();
     super.dispose();
   }
 
   void completeWithoutUser() {
+    if (_isDisposed) return;
     value = ChestState(
       hinoo: value.hinoo,
       honooLatestReplies: value.honooLatestReplies,
@@ -203,6 +206,7 @@ class ChestController extends ValueNotifier<ChestState> {
   }
 
   void removeHinoo(String id) {
+    if (_isDisposed) return;
     value = ChestState(
       hinoo: value.hinoo.where((item) => item.id != id).toList(),
       honooLatestReplies: value.honooLatestReplies,
@@ -216,6 +220,7 @@ class ChestController extends ValueNotifier<ChestState> {
   }
 
   void markHinooOnMoon(String id) {
+    if (_isDisposed) return;
     value = ChestState(
       hinoo: value.hinoo
           .map(
@@ -243,6 +248,7 @@ class ChestController extends ValueNotifier<ChestState> {
   }
 
   Future<void> loadHinoo(String userId) async {
+    if (_isDisposed) return;
     value = ChestState(
       hinoo: value.hinoo,
       honooLatestReplies: value.honooLatestReplies,
@@ -257,6 +263,7 @@ class ChestController extends ValueNotifier<ChestState> {
       final rows = await _reliability.read<List<dynamic>>(
         () => _repository.fetchHinooRows(userId),
       );
+      if (_isDisposed) return;
       Set<String> moonFingerprints = const {};
       try {
         moonFingerprints = await _reliability.read<Set<String>>(
@@ -266,25 +273,27 @@ class ChestController extends ValueNotifier<ChestState> {
         // Il contenuto dello Scrigno resta utilizzabile anche se il controllo
         // dello stato Luna non è temporaneamente disponibile.
       }
+      if (_isDisposed) return;
       final hinoo = rows
           .whereType<Map>()
           .map(ChestHinooItem.fromDatabaseRow)
           .whereType<ChestHinooItem>()
           .map((item) {
-        final fingerprint = HinooService.fingerprint(
-          item.draft.copyWith(type: HinooType.moon),
-        );
-        if (!moonFingerprints.contains(fingerprint)) return item;
-        return ChestHinooItem(
-          id: item.id,
-          draft: item.draft,
-          createdAt: item.createdAt,
-          isFromMoonSaved: item.isFromMoonSaved,
-          ownerId: item.ownerId,
-          isOnMoon: true,
-          conversationId: item.conversationId,
-        );
-      }).toList(growable: false);
+            final fingerprint = HinooService.fingerprint(
+              item.draft.copyWith(type: HinooType.moon),
+            );
+            if (!moonFingerprints.contains(fingerprint)) return item;
+            return ChestHinooItem(
+              id: item.id,
+              draft: item.draft,
+              createdAt: item.createdAt,
+              isFromMoonSaved: item.isFromMoonSaved,
+              ownerId: item.ownerId,
+              isOnMoon: true,
+              conversationId: item.conversationId,
+            );
+          })
+          .toList(growable: false);
       value = ChestState(
         hinoo: List.unmodifiable(hinoo),
         honooLatestReplies: value.honooLatestReplies,
@@ -295,6 +304,7 @@ class ChestController extends ValueNotifier<ChestState> {
         replyError: value.replyError,
       );
     } catch (error) {
+      if (_isDisposed) return;
       value = ChestState(
         hinoo: value.hinoo,
         honooLatestReplies: value.honooLatestReplies,
@@ -309,6 +319,7 @@ class ChestController extends ValueNotifier<ChestState> {
   }
 
   Future<void> loadReplies(String userId) async {
+    if (_isDisposed) return;
     value = ChestState(
       hinoo: value.hinoo,
       honooLatestReplies: value.honooLatestReplies,
@@ -324,6 +335,7 @@ class ChestController extends ValueNotifier<ChestState> {
       final honooRows = await _reliability.refresh<List<dynamic>>(
         () => _repository.fetchHonooReplyRows(userId),
       );
+      if (_isDisposed) return;
       final seenHonooKeys = <String>{};
       for (final row in honooRows.whereType<Map>()) {
         final rootId = row['reply_to']?.toString() ?? '';
@@ -344,6 +356,7 @@ class ChestController extends ValueNotifier<ChestState> {
       final rows = await _reliability.refresh<List<dynamic>>(
         () => _repository.fetchHinooReplyRows(userId, rootIds),
       );
+      if (_isDisposed) return;
       final seenHinooIds = <String>{};
       for (final row in rows.whereType<Map>()) {
         final id = row['id']?.toString() ?? '';
@@ -353,7 +366,7 @@ class ChestController extends ValueNotifier<ChestState> {
         if (rootId.isEmpty || pages is! List) continue;
         final created =
             DateTime.tryParse((row['created_at'] ?? '').toString()) ??
-                DateTime.fromMillisecondsSinceEpoch(0);
+            DateTime.fromMillisecondsSinceEpoch(0);
         final draft = HinooDraft(
           pages: pages
               .whereType<Map<String, dynamic>>()
@@ -363,7 +376,9 @@ class ChestController extends ValueNotifier<ChestState> {
           recipientTag: row['recipient_tag'] as String?,
           replyTo: rootId,
         );
-        hinooReplies.putIfAbsent(rootId, () => []).add(
+        hinooReplies
+            .putIfAbsent(rootId, () => [])
+            .add(
               HinooThreadEntry(
                 draft: draft,
                 authorId: row['user_id']?.toString(),
@@ -387,6 +402,7 @@ class ChestController extends ValueNotifier<ChestState> {
         hinooError: value.hinooError,
       );
     } catch (error) {
+      if (_isDisposed) return;
       value = ChestState(
         hinoo: value.hinoo,
         honooLatestReplies: value.honooLatestReplies,

--- a/lib/Pages/chest_page.dart
+++ b/lib/Pages/chest_page.dart
@@ -25,7 +25,6 @@ import '../Utility/network_image_prefetch.dart';
 import '../Widgets/honoo_dialogs.dart';
 import '../Widgets/loading_spinner.dart';
 import '../Widgets/honoo_app_title.dart';
-import '../Widgets/luna_fissa.dart';
 import '../Widgets/chest_footer.dart';
 import '../Widgets/chest_item_view.dart';
 import '../Widgets/chest_info_dialog.dart';
@@ -817,11 +816,6 @@ class _ChestPageState extends State<ChestPage> with WidgetsBindingObserver {
               );
             },
           ),
-          overlayBuilder: (ctx, mode) => const LunaFissa(),
-          bodyTopInsetBuilder: (ctx, mode) =>
-              (LunaFissa.reserveTopPadding(ctx) -
-                      ThreadLayoutScaffold.headerHeight)
-                  .clamp(0.0, double.infinity),
           bodyBuilder: (ctx, viewW, availableH, layoutMode) {
             final HonooBuilderMetrics honooMetrics =
                 ResponsiveLayout.honooBuilderMetrics(

--- a/test/controllers/chest_controller_test.dart
+++ b/test/controllers/chest_controller_test.dart
@@ -77,16 +77,17 @@ void main() {
               'backgroundImage': 'background.png',
               'text': 'Testo',
               'isTextWhite': true,
-            }
+            },
           ],
           'type': 'personal',
           'created_at': '2024-01-01T00:00:00Z',
           'user_id': 'user-1',
-        }
+        },
       ],
     );
-    when(() => repository.fetchHinooMoonFingerprints('user-1'))
-        .thenAnswer((_) async => const {});
+    when(
+      () => repository.fetchHinooMoonFingerprints('user-1'),
+    ).thenAnswer((_) async => const {});
 
     await controller.loadHinoo('user-1');
 
@@ -107,7 +108,7 @@ void main() {
           'backgroundImage': 'background.png',
           'text': 'Testo',
           'isTextWhite': true,
-        }
+        },
       ],
       'type': 'personal',
       'created_at': '2024-01-01T00:00:00Z',
@@ -117,10 +118,12 @@ void main() {
     final fingerprint = HinooService.fingerprint(
       draft.copyWith(type: HinooType.moon),
     );
-    when(() => repository.fetchHinooRows('user-1'))
-        .thenAnswer((_) async => [row]);
-    when(() => repository.fetchHinooMoonFingerprints('user-1'))
-        .thenAnswer((_) async => {fingerprint});
+    when(
+      () => repository.fetchHinooRows('user-1'),
+    ).thenAnswer((_) async => [row]);
+    when(
+      () => repository.fetchHinooMoonFingerprints('user-1'),
+    ).thenAnswer((_) async => {fingerprint});
 
     await controller.loadHinoo('user-1');
 
@@ -135,8 +138,9 @@ void main() {
         {'reply_to': 'root-1', 'created_at': '2024-01-01T12:00:00Z'},
       ],
     );
-    when(() => repository.fetchHinooReplyRows('user-1', const []))
-        .thenAnswer((_) async => const []);
+    when(
+      () => repository.fetchHinooReplyRows('user-1', const []),
+    ).thenAnswer((_) async => const []);
 
     await controller.loadReplies('user-1');
 
@@ -151,16 +155,37 @@ void main() {
     );
   });
 
-  test('un errore conserva i dati precedenti e termina il caricamento',
-      () async {
-    when(() => repository.fetchHinooRows('user-1'))
-        .thenThrow(Exception('offline'));
+  test(
+    'un errore conserva i dati precedenti e termina il caricamento',
+    () async {
+      when(
+        () => repository.fetchHinooRows('user-1'),
+      ).thenThrow(Exception('offline'));
 
-    await controller.loadHinoo('user-1');
+      await controller.loadHinoo('user-1');
 
-    expect(controller.value.isHinooLoading, isFalse);
-    expect(controller.value.hinoo, isEmpty);
-    expect(controller.value.error, isA<Exception>());
+      expect(controller.value.isHinooLoading, isFalse);
+      expect(controller.value.hinoo, isEmpty);
+      expect(controller.value.error, isA<Exception>());
+    },
+  );
+
+  test('loadHinoo non aggiorna lo stato dopo dispose', () async {
+    final pendingRows = Completer<List<dynamic>>();
+    final disposableController = ChestController(
+      repository: repository,
+      realtimeGateway: realtimeGateway,
+    );
+    when(
+      () => repository.fetchHinooRows('user-1'),
+    ).thenAnswer((_) => pendingRows.future);
+
+    final loading = disposableController.loadHinoo('user-1');
+    await Future<void>.delayed(Duration.zero);
+    disposableController.dispose();
+    pendingRows.complete(const []);
+
+    await expectLater(loading, completes);
   });
 
   test('start e stop gestiscono il ciclo di vita Realtime', () {
@@ -201,19 +226,21 @@ void main() {
     expect(firstSubscription.closed, isTrue);
   });
 
-  test('la riconciliazione periodica può aggiornare tutto lo Scrigno',
-      () async {
-    var reconciliations = 0;
-    controller.startRealtime(
-      'user-1',
-      refreshInterval: const Duration(milliseconds: 5),
-      onPeriodicReconcile: () async => reconciliations++,
-    );
+  test(
+    'la riconciliazione periodica può aggiornare tutto lo Scrigno',
+    () async {
+      var reconciliations = 0;
+      controller.startRealtime(
+        'user-1',
+        refreshInterval: const Duration(milliseconds: 5),
+        onPeriodicReconcile: () async => reconciliations++,
+      );
 
-    await Future<void>.delayed(const Duration(milliseconds: 18));
+      await Future<void>.delayed(const Duration(milliseconds: 18));
 
-    expect(reconciliations, greaterThanOrEqualTo(1));
-  });
+      expect(reconciliations, greaterThanOrEqualTo(1));
+    },
+  );
 
   test('un errore Realtime non impedisce l’avvio del controller', () {
     final resilientController = ChestController(
@@ -232,10 +259,12 @@ void main() {
   });
 
   test('gli eventi Realtime ravvicinati producono un solo refresh', () async {
-    when(() => repository.fetchHonooReplyRows('user-1'))
-        .thenAnswer((_) async => const []);
-    when(() => repository.fetchHinooReplyRows('user-1', const []))
-        .thenAnswer((_) async => const []);
+    when(
+      () => repository.fetchHonooReplyRows('user-1'),
+    ).thenAnswer((_) async => const []);
+    when(
+      () => repository.fetchHinooReplyRows('user-1', const []),
+    ).thenAnswer((_) async => const []);
 
     controller.startRealtime(
       'user-1',
@@ -258,8 +287,9 @@ void main() {
       callCount++;
       return callCount == 1 ? firstResponse.future : Future.value(const []);
     });
-    when(() => repository.fetchHinooReplyRows('user-1', const []))
-        .thenAnswer((_) async => const []);
+    when(
+      () => repository.fetchHinooReplyRows('user-1', const []),
+    ).thenAnswer((_) async => const []);
 
     final runningRefresh = controller.refreshReplies('user-1');
     await Future<void>.delayed(Duration.zero);

--- a/test/widgets/thread_layout_scaffold_responsive_test.dart
+++ b/test/widgets/thread_layout_scaffold_responsive_test.dart
@@ -16,99 +16,151 @@ void main() {
   ];
 
   for (final viewport in viewportCases) {
-    for (final kind in _CardKind.values) {
-      testWidgets(
-        '${kind.name} centrato e separato da Luna/footer a '
-        '${viewport.size.width.toInt()}x${viewport.size.height.toInt()}',
-        (tester) async {
-          tester.view.devicePixelRatio = 1;
-          tester.view.physicalSize = viewport.size;
-          addTearDown(tester.view.resetDevicePixelRatio);
-          addTearDown(tester.view.resetPhysicalSize);
+    testWidgets('senza Luna il viewer usa tutta l area tra header e footer a '
+        '${viewport.size.width.toInt()}x${viewport.size.height.toInt()}', (
+      tester,
+    ) async {
+      tester.view.devicePixelRatio = 1;
+      tester.view.physicalSize = viewport.size;
+      addTearDown(tester.view.resetDevicePixelRatio);
+      addTearDown(tester.view.resetPhysicalSize);
 
-          final media = MediaQueryData(
-            size: viewport.size,
-            padding: EdgeInsets.only(
-              top: viewport.safeTop,
-              bottom: viewport.safeBottom,
-            ),
-            viewPadding: EdgeInsets.only(
-              top: viewport.safeTop,
-              bottom: viewport.safeBottom,
-            ),
-          );
+      final media = MediaQueryData(
+        size: viewport.size,
+        padding: EdgeInsets.only(
+          top: viewport.safeTop,
+          bottom: viewport.safeBottom,
+        ),
+        viewPadding: EdgeInsets.only(
+          top: viewport.safeTop,
+          bottom: viewport.safeBottom,
+        ),
+      );
 
-          await tester.pumpWidget(
-            MaterialApp(
-              home: MediaQuery(
-                data: media,
-                child: ThreadLayoutScaffold(
-                  backgroundColor: Colors.black,
-                  header: const SizedBox(key: Key('header')),
-                  bodyTopInsetBuilder: (context, mode) =>
-                      (LunaFissa.reserveTopPadding(context) -
-                              ThreadLayoutScaffold.headerHeight)
-                          .clamp(0.0, double.infinity),
-                  bodyBuilder: (context, width, height, mode) => ColoredBox(
-                    key: const Key('safe-body'),
-                    color: Colors.black,
-                    child: Center(
-                      child: _ResponsiveTestCard(
-                        kind: kind,
-                        maxWidth: width,
-                        maxHeight: height,
+      await tester.pumpWidget(
+        MaterialApp(
+          home: MediaQuery(
+            data: media,
+            child: ThreadLayoutScaffold(
+              backgroundColor: Colors.black,
+              header: const SizedBox(key: Key('header')),
+              bodyBuilder: (context, width, height, mode) => const ColoredBox(
+                key: Key('full-viewer-area'),
+                color: Colors.black,
+              ),
+              footerBuilder:
+                  (context, mode, iconSize, gap, topSpacing, bottomSpacing) =>
+                      SizedBox(
+                        key: const Key('footer'),
+                        height: iconSize + bottomSpacing,
                       ),
+            ),
+          ),
+        ),
+      );
+
+      final bodyRect = tester.getRect(
+        find.byKey(const Key('full-viewer-area')),
+      );
+      final footerRect = tester.getRect(find.byKey(const Key('footer')));
+      final mode = ResponsiveLayout.modeForWidth(viewport.size.width);
+      final footerSpacing =
+          ResponsiveLayout.footerBottomPaddingForMode(mode) +
+          viewport.safeBottom;
+      final footerTopSpacing = footerSpacing / 2;
+
+      expect(bodyRect.top, ThreadLayoutScaffold.headerHeight);
+      expect(bodyRect.bottom + footerTopSpacing, footerRect.top);
+      expect(bodyRect.left, 0);
+      expect(bodyRect.right, viewport.size.width);
+    });
+
+    for (final kind in _CardKind.values) {
+      testWidgets('${kind.name} centrato e separato da Luna/footer a '
+          '${viewport.size.width.toInt()}x${viewport.size.height.toInt()}', (
+        tester,
+      ) async {
+        tester.view.devicePixelRatio = 1;
+        tester.view.physicalSize = viewport.size;
+        addTearDown(tester.view.resetDevicePixelRatio);
+        addTearDown(tester.view.resetPhysicalSize);
+
+        final media = MediaQueryData(
+          size: viewport.size,
+          padding: EdgeInsets.only(
+            top: viewport.safeTop,
+            bottom: viewport.safeBottom,
+          ),
+          viewPadding: EdgeInsets.only(
+            top: viewport.safeTop,
+            bottom: viewport.safeBottom,
+          ),
+        );
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: MediaQuery(
+              data: media,
+              child: ThreadLayoutScaffold(
+                backgroundColor: Colors.black,
+                header: const SizedBox(key: Key('header')),
+                bodyTopInsetBuilder: (context, mode) =>
+                    (LunaFissa.reserveTopPadding(context) -
+                            ThreadLayoutScaffold.headerHeight)
+                        .clamp(0.0, double.infinity),
+                bodyBuilder: (context, width, height, mode) => ColoredBox(
+                  key: const Key('safe-body'),
+                  color: Colors.black,
+                  child: Center(
+                    child: _ResponsiveTestCard(
+                      kind: kind,
+                      maxWidth: width,
+                      maxHeight: height,
                     ),
                   ),
-                  footerBuilder: (
-                    context,
-                    mode,
-                    iconSize,
-                    gap,
-                    topSpacing,
-                    bottomSpacing,
-                  ) =>
-                      SizedBox(
-                    key: const Key('footer'),
-                    height: iconSize + bottomSpacing,
-                  ),
-                  overlayBuilder: (context, mode) {
-                    final width = MediaQuery.sizeOf(context).width;
-                    final iconSize = LunaFissa.iconSizeForWidth(width);
-                    final margin = width >= 1200 ? 16.0 : 8.0;
-                    return Positioned(
-                      key: const Key('moon'),
-                      top: viewport.safeTop + margin,
-                      right: margin,
-                      width: iconSize,
-                      height: iconSize,
-                      child: const ColoredBox(color: Colors.white),
-                    );
-                  },
                 ),
+                footerBuilder:
+                    (context, mode, iconSize, gap, topSpacing, bottomSpacing) =>
+                        SizedBox(
+                          key: const Key('footer'),
+                          height: iconSize + bottomSpacing,
+                        ),
+                overlayBuilder: (context, mode) {
+                  final width = MediaQuery.sizeOf(context).width;
+                  final iconSize = LunaFissa.iconSizeForWidth(width);
+                  final margin = width >= 1200 ? 16.0 : 8.0;
+                  return Positioned(
+                    key: const Key('moon'),
+                    top: viewport.safeTop + margin,
+                    right: margin,
+                    width: iconSize,
+                    height: iconSize,
+                    child: const ColoredBox(color: Colors.white),
+                  );
+                },
               ),
             ),
-          );
+          ),
+        );
 
-          final bodyRect = tester.getRect(find.byKey(const Key('safe-body')));
-          final cardRect = tester.getRect(find.byKey(const Key('card')));
-          final moonRect = tester.getRect(find.byKey(const Key('moon')));
-          final footerRect = tester.getRect(find.byKey(const Key('footer')));
+        final bodyRect = tester.getRect(find.byKey(const Key('safe-body')));
+        final cardRect = tester.getRect(find.byKey(const Key('card')));
+        final moonRect = tester.getRect(find.byKey(const Key('moon')));
+        final footerRect = tester.getRect(find.byKey(const Key('footer')));
 
-          expect(moonRect.bottom, lessThanOrEqualTo(bodyRect.top));
-          expect(bodyRect.bottom, lessThanOrEqualTo(footerRect.top));
-          expect(cardRect.center.dx, closeTo(bodyRect.center.dx, 0.01));
-          expect(cardRect.center.dy, closeTo(bodyRect.center.dy, 0.01));
-          expect(cardRect.left, greaterThanOrEqualTo(bodyRect.left - 0.01));
-          expect(cardRect.top, greaterThanOrEqualTo(bodyRect.top - 0.01));
-          expect(cardRect.right, lessThanOrEqualTo(bodyRect.right + 0.01));
-          expect(cardRect.bottom, lessThanOrEqualTo(bodyRect.bottom + 0.01));
+        expect(moonRect.bottom, lessThanOrEqualTo(bodyRect.top));
+        expect(bodyRect.bottom, lessThanOrEqualTo(footerRect.top));
+        expect(cardRect.center.dx, closeTo(bodyRect.center.dx, 0.01));
+        expect(cardRect.center.dy, closeTo(bodyRect.center.dy, 0.01));
+        expect(cardRect.left, greaterThanOrEqualTo(bodyRect.left - 0.01));
+        expect(cardRect.top, greaterThanOrEqualTo(bodyRect.top - 0.01));
+        expect(cardRect.right, lessThanOrEqualTo(bodyRect.right + 0.01));
+        expect(cardRect.bottom, lessThanOrEqualTo(bodyRect.bottom + 0.01));
 
-          final expected = _cardSize(kind, bodyRect.width, bodyRect.height);
-          expect(cardRect.width, closeTo(expected.width, 0.01));
-          expect(cardRect.height, closeTo(expected.height, 0.01));
-        },
-      );
+        final expected = _cardSize(kind, bodyRect.width, bodyRect.height);
+        expect(cardRect.width, closeTo(expected.width, 0.01));
+        expect(cardRect.height, closeTo(expected.height, 0.01));
+      });
     }
   }
 }


### PR DESCRIPTION
## Cosa cambia

- rimuove la Luna fissa dalla pagina Scrigno
- restituisce al viewer tutto lo spazio verticale prima riservato all’overlay
- mantiene invariati header, footer e relativa spaziatura
- aggiunge verifiche responsive per telefono, tablet e desktop

## Verifica

- `fvm flutter test test/widgets/thread_layout_scaffold_responsive_test.dart test/widgets/chest_item_view_animation_test.dart`
- `fvm flutter analyze`
