### PR TITLE
Update Home copy with interactive inline icons

### DIFF
--- a/lib/Pages/home_page.dart
+++ b/lib/Pages/home_page.dart
@@ -143,7 +143,8 @@ class _HomeIntro extends StatelessWidget {
   const _HomeIntro();
 
   static const double _designWidth = 360;
-  static const double _iconSize = 22;
+  static const double _moonIconSize = 22;
+  static const double _largeIconSize = 26;
 
   @override
   Widget build(BuildContext context) {
@@ -165,7 +166,7 @@ class _HomeIntro extends StatelessWidget {
             style: regularStyle,
             children: [
               TextSpan(
-                text: 'Ti regaliamo la Luna\nPer sempre\n',
+                text: 'Ti regaliamo la Luna\nPer sempre\n\n',
                 style: regularStyle.copyWith(fontWeight: FontWeight.w700),
               ),
               const TextSpan(
@@ -180,6 +181,7 @@ class _HomeIntro extends StatelessWidget {
               _inlineAction(
                 key: const Key('home_inline_bottle'),
                 asset: 'assets/icons/bottle.svg',
+                size: _largeIconSize,
                 tooltip: 'Scrivi',
                 onPressed: () => SeaFooterBar.openComposer(context),
               ),
@@ -187,6 +189,7 @@ class _HomeIntro extends StatelessWidget {
               _inlineAction(
                 key: const Key('home_inline_moon'),
                 asset: 'assets/icons/moon.svg',
+                size: _moonIconSize,
                 tooltip: 'Vai sulla Luna',
                 onPressed: () => LunaFissa.openMoon(context),
               ),
@@ -194,6 +197,7 @@ class _HomeIntro extends StatelessWidget {
               _inlineAction(
                 key: const Key('home_inline_island'),
                 asset: 'assets/icons/isoladellestorie/island.svg',
+                size: _largeIconSize,
                 tooltip: "Vai all'Isola delle Storie",
                 onPressed: () => SeaFooterBar.openIsland(context),
                 tint: HonooColor.onBackground,
@@ -213,26 +217,25 @@ class _HomeIntro extends StatelessWidget {
   static WidgetSpan _inlineAction({
     required Key key,
     required String asset,
+    required double size,
     required String tooltip,
     required VoidCallback onPressed,
     Color? tint,
   }) {
     return WidgetSpan(
-      alignment: PlaceholderAlignment.middle,
+      alignment: PlaceholderAlignment.baseline,
+      baseline: TextBaseline.alphabetic,
       child: IconButton(
         key: key,
-        constraints: const BoxConstraints.tightFor(
-          width: _iconSize,
-          height: _iconSize,
-        ),
+        constraints: BoxConstraints.tightFor(width: size, height: size),
         padding: EdgeInsets.zero,
         visualDensity: VisualDensity.compact,
         tooltip: tooltip,
         onPressed: onPressed,
         icon: SvgPicture.asset(
           asset,
-          width: _iconSize,
-          height: _iconSize,
+          width: size,
+          height: size,
           colorFilter: tint == null
               ? null
               : ColorFilter.mode(tint, BlendMode.srcIn),

--- a/lib/Pages/home_page.dart
+++ b/lib/Pages/home_page.dart
@@ -143,7 +143,7 @@ class _HomeIntro extends StatelessWidget {
   const _HomeIntro();
 
   static const double _designWidth = 360;
-  static const double _iconSize = 20;
+  static const double _iconSize = 22;
 
   @override
   Widget build(BuildContext context) {
@@ -165,15 +165,15 @@ class _HomeIntro extends StatelessWidget {
             style: regularStyle,
             children: [
               TextSpan(
-                text: 'Ti regaliamo la Luna.\nPer sempre.\n',
+                text: 'Ti regaliamo la Luna\nPer sempre\n',
                 style: regularStyle.copyWith(fontWeight: FontWeight.w700),
               ),
               const TextSpan(
                 text:
-                    'Niente è per sempre.\n'
-                    'E nessuno può regalarti la Luna.\n\n'
-                    'È vero.\n'
-                    'Ma non per i poeti.\n\n'
+                    'Niente è per sempre\n'
+                    'E nessuno può regalarti la Luna\n\n'
+                    'È vero\n'
+                    'Ma non per i poeti\n\n'
                     'Vuoi essere un poeta di honoo?\n\n'
                     'Clicca su ',
               ),
@@ -183,14 +183,14 @@ class _HomeIntro extends StatelessWidget {
                 tooltip: 'Scrivi',
                 onPressed: () => SeaFooterBar.openComposer(context),
               ),
-              const TextSpan(text: '.\n\nOppure su '),
+              const TextSpan(text: '\n\nOppure su '),
               _inlineAction(
                 key: const Key('home_inline_moon'),
                 asset: 'assets/icons/moon.svg',
                 tooltip: 'Vai sulla Luna',
                 onPressed: () => LunaFissa.openMoon(context),
               ),
-              const TextSpan(text: ',\ne guarda le vite degli altri.\n\nO su '),
+              const TextSpan(text: '\ne guarda le vite degli altri\n\nO su '),
               _inlineAction(
                 key: const Key('home_inline_island'),
                 asset: 'assets/icons/isoladellestorie/island.svg',
@@ -199,7 +199,7 @@ class _HomeIntro extends StatelessWidget {
                 tint: HonooColor.onBackground,
               ),
               const TextSpan(
-                text: ',\ne inizia il viaggio\nverso le tue storie.',
+                text: '\ne inizia il viaggio\nverso le tue storie',
               ),
             ],
           ),

--- a/lib/Pages/home_page.dart
+++ b/lib/Pages/home_page.dart
@@ -1,12 +1,12 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:honoo/Utility/honoo_colors.dart';
+import 'package:flutter_svg/flutter_svg.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:honoo/Services/supabase_provider.dart';
 import 'package:honoo/Services/home_service.dart';
 import 'package:honoo/Utility/app_logger.dart';
-import '../Utility/utility.dart';
+import 'package:honoo/Utility/honoo_colors.dart';
 import '../Widgets/honoo_app_title.dart';
 import 'placeholder_page.dart';
 
@@ -56,8 +56,12 @@ class _HomePageState extends State<HomePage> {
         setState(() => _replyCount = count);
       }
     } catch (error, stackTrace) {
-      AppLogger.warning('Impossibile aggiornare il contatore risposte',
-          scope: 'HomePage', error: error, stackTrace: stackTrace);
+      AppLogger.warning(
+        'Impossibile aggiornare il contatore risposte',
+        scope: 'HomePage',
+        error: error,
+        stackTrace: stackTrace,
+      );
     }
   }
 
@@ -67,8 +71,12 @@ class _HomePageState extends State<HomePage> {
     try {
       await _homeService.recordVisit();
     } catch (error, stackTrace) {
-      AppLogger.warning('Impossibile registrare la visita',
-          scope: 'HomePage', error: error, stackTrace: stackTrace);
+      AppLogger.warning(
+        'Impossibile registrare la visita',
+        scope: 'HomePage',
+        error: error,
+        stackTrace: stackTrace,
+      );
       _visitRecorded = false;
     }
   }
@@ -81,10 +89,8 @@ class _HomePageState extends State<HomePage> {
       body: LayoutBuilder(
         builder: (context, constraints) {
           final double maxWidth = constraints.maxWidth;
-          final double maxHeight = constraints.maxHeight;
           final bool isPhone = maxWidth < 600;
           final double contentWidth = isPhone ? maxWidth : maxWidth * 0.5;
-          final double introLift = (maxHeight * 0.012).clamp(6.0, 10.0);
 
           return Stack(
             fit: StackFit.expand,
@@ -99,83 +105,20 @@ class _HomePageState extends State<HomePage> {
                       onTap: () {
                         Navigator.of(context).pushAndRemoveUntil(
                           MaterialPageRoute(
-                              builder: (_) => const PlaceholderPage()),
+                            builder: (_) => const PlaceholderPage(),
+                          ),
                           (route) => false,
                         );
                       },
                     ),
                   ),
                   Expanded(
-                    child: SingleChildScrollView(
-                      child: SizedBox(
-                        width: maxWidth,
-                        child: Row(
-                          children: [
-                            Expanded(child: Container()),
-                            Container(
-                              constraints:
-                                  BoxConstraints(maxWidth: contentWidth),
-                              child: Column(
-                                children: [
-                                  SizedBox(
-                                    height: maxHeight * 0.8,
-                                    child: Stack(
-                                      clipBehavior: Clip.none,
-                                      children: [
-                                        Positioned.fill(
-                                          top: 0,
-                                          child: Align(
-                                            alignment: Alignment.topCenter,
-                                            child: SingleChildScrollView(
-                                              child: Column(
-                                                children: [
-                                                  const SizedBox(height: 32),
-                                                  Transform.translate(
-                                                    key: const Key(
-                                                      'home_intro_lift',
-                                                    ),
-                                                    offset: Offset(
-                                                      0,
-                                                      -introLift,
-                                                    ),
-                                                    child: Text(
-                                                      Utility().textHome1,
-                                                      style: GoogleFonts.arvo(
-                                                        color: HonooColor
-                                                            .onBackground,
-                                                        fontSize: 18,
-                                                        fontWeight:
-                                                            FontWeight.w700,
-                                                      ),
-                                                      textAlign:
-                                                          TextAlign.center,
-                                                    ),
-                                                  ),
-                                                  const SizedBox(height: 24),
-                                                  Text(
-                                                    Utility().textHome2,
-                                                    style: GoogleFonts.arvo(
-                                                      color: HonooColor
-                                                          .onBackground,
-                                                      fontSize: 18,
-                                                      fontWeight:
-                                                          FontWeight.w400,
-                                                    ),
-                                                    textAlign: TextAlign.center,
-                                                  ),
-                                                ],
-                                              ),
-                                            ),
-                                          ),
-                                        ),
-                                      ],
-                                    ),
-                                  ),
-                                ],
-                              ),
-                            ),
-                            Expanded(child: Container()),
-                          ],
+                    child: Center(
+                      child: ConstrainedBox(
+                        constraints: BoxConstraints(maxWidth: contentWidth),
+                        child: const Padding(
+                          padding: EdgeInsets.fromLTRB(16, 8, 16, 4),
+                          child: _HomeIntro(),
                         ),
                       ),
                     ),
@@ -191,6 +134,109 @@ class _HomePageState extends State<HomePage> {
             ],
           );
         },
+      ),
+    );
+  }
+}
+
+class _HomeIntro extends StatelessWidget {
+  const _HomeIntro();
+
+  static const double _designWidth = 360;
+  static const double _iconSize = 20;
+
+  @override
+  Widget build(BuildContext context) {
+    final regularStyle = GoogleFonts.arvo(
+      color: HonooColor.onBackground,
+      fontSize: 18,
+      height: 1.22,
+      fontWeight: FontWeight.w400,
+    );
+
+    return FittedBox(
+      key: const Key('home_intro_fitted'),
+      fit: BoxFit.scaleDown,
+      alignment: Alignment.topCenter,
+      child: SizedBox(
+        width: _designWidth,
+        child: Text.rich(
+          TextSpan(
+            style: regularStyle,
+            children: [
+              TextSpan(
+                text: 'Ti regaliamo la Luna.\nPer sempre.\n',
+                style: regularStyle.copyWith(fontWeight: FontWeight.w700),
+              ),
+              const TextSpan(
+                text:
+                    'Niente è per sempre.\n'
+                    'E nessuno può regalarti la Luna.\n\n'
+                    'È vero.\n'
+                    'Ma non per i poeti.\n\n'
+                    'Vuoi essere un poeta di honoo?\n\n'
+                    'Clicca su ',
+              ),
+              _inlineAction(
+                key: const Key('home_inline_bottle'),
+                asset: 'assets/icons/bottle.svg',
+                tooltip: 'Scrivi',
+                onPressed: () => SeaFooterBar.openComposer(context),
+              ),
+              const TextSpan(text: '.\n\nOppure su '),
+              _inlineAction(
+                key: const Key('home_inline_moon'),
+                asset: 'assets/icons/moon.svg',
+                tooltip: 'Vai sulla Luna',
+                onPressed: () => LunaFissa.openMoon(context),
+              ),
+              const TextSpan(text: ',\ne guarda le vite degli altri.\n\nO su '),
+              _inlineAction(
+                key: const Key('home_inline_island'),
+                asset: 'assets/icons/isoladellestorie/island.svg',
+                tooltip: "Vai all'Isola delle Storie",
+                onPressed: () => SeaFooterBar.openIsland(context),
+                tint: HonooColor.onBackground,
+              ),
+              const TextSpan(
+                text: ',\ne inizia il viaggio\nverso le tue storie.',
+              ),
+            ],
+          ),
+          key: const Key('home_intro_text'),
+          textAlign: TextAlign.center,
+        ),
+      ),
+    );
+  }
+
+  static WidgetSpan _inlineAction({
+    required Key key,
+    required String asset,
+    required String tooltip,
+    required VoidCallback onPressed,
+    Color? tint,
+  }) {
+    return WidgetSpan(
+      alignment: PlaceholderAlignment.middle,
+      child: IconButton(
+        key: key,
+        constraints: const BoxConstraints.tightFor(
+          width: _iconSize,
+          height: _iconSize,
+        ),
+        padding: EdgeInsets.zero,
+        visualDensity: VisualDensity.compact,
+        tooltip: tooltip,
+        onPressed: onPressed,
+        icon: SvgPicture.asset(
+          asset,
+          width: _iconSize,
+          height: _iconSize,
+          colorFilter: tint == null
+              ? null
+              : ColorFilter.mode(tint, BlendMode.srcIn),
+        ),
       ),
     );
   }

--- a/lib/Pages/home_page.dart
+++ b/lib/Pages/home_page.dart
@@ -145,7 +145,7 @@ class _HomeIntro extends StatelessWidget {
   static const double _designWidth = 360;
   static const double _moonIconSize = 22;
   static const double _largeIconSize = 29;
-  static const double _largeIconVerticalOffset = 3;
+  static const double _largeIconVerticalOffset = 6;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/Pages/home_page.dart
+++ b/lib/Pages/home_page.dart
@@ -145,7 +145,8 @@ class _HomeIntro extends StatelessWidget {
   static const double _designWidth = 360;
   static const double _moonIconSize = 22;
   static const double _largeIconSize = 29;
-  static const double _largeIconVerticalOffset = 6;
+  static const double _bottleIconVerticalOffset = 6;
+  static const double _islandIconVerticalOffset = 9;
 
   @override
   Widget build(BuildContext context) {
@@ -183,7 +184,7 @@ class _HomeIntro extends StatelessWidget {
                 key: const Key('home_inline_bottle'),
                 asset: 'assets/icons/bottle.svg',
                 size: _largeIconSize,
-                verticalOffset: _largeIconVerticalOffset,
+                verticalOffset: _bottleIconVerticalOffset,
                 tooltip: 'Scrivi',
                 onPressed: () => SeaFooterBar.openComposer(context),
               ),
@@ -200,7 +201,7 @@ class _HomeIntro extends StatelessWidget {
                 key: const Key('home_inline_island'),
                 asset: 'assets/icons/isoladellestorie/island.svg',
                 size: _largeIconSize,
-                verticalOffset: _largeIconVerticalOffset,
+                verticalOffset: _islandIconVerticalOffset,
                 tooltip: "Vai all'Isola delle Storie",
                 onPressed: () => SeaFooterBar.openIsland(context),
                 tint: HonooColor.onBackground,

--- a/lib/Pages/home_page.dart
+++ b/lib/Pages/home_page.dart
@@ -84,6 +84,7 @@ class _HomePageState extends State<HomePage> {
           final double maxHeight = constraints.maxHeight;
           final bool isPhone = maxWidth < 600;
           final double contentWidth = isPhone ? maxWidth : maxWidth * 0.5;
+          final double introLift = (maxHeight * 0.012).clamp(6.0, 10.0);
 
           return Stack(
             fit: StackFit.expand,
@@ -129,16 +130,26 @@ class _HomePageState extends State<HomePage> {
                                               child: Column(
                                                 children: [
                                                   const SizedBox(height: 32),
-                                                  Text(
-                                                    Utility().textHome1,
-                                                    style: GoogleFonts.arvo(
-                                                      color: HonooColor
-                                                          .onBackground,
-                                                      fontSize: 18,
-                                                      fontWeight:
-                                                          FontWeight.w700,
+                                                  Transform.translate(
+                                                    key: const Key(
+                                                      'home_intro_lift',
                                                     ),
-                                                    textAlign: TextAlign.center,
+                                                    offset: Offset(
+                                                      0,
+                                                      -introLift,
+                                                    ),
+                                                    child: Text(
+                                                      Utility().textHome1,
+                                                      style: GoogleFonts.arvo(
+                                                        color: HonooColor
+                                                            .onBackground,
+                                                        fontSize: 18,
+                                                        fontWeight:
+                                                            FontWeight.w700,
+                                                      ),
+                                                      textAlign:
+                                                          TextAlign.center,
+                                                    ),
                                                   ),
                                                   const SizedBox(height: 24),
                                                   Text(

--- a/lib/Pages/home_page.dart
+++ b/lib/Pages/home_page.dart
@@ -144,7 +144,8 @@ class _HomeIntro extends StatelessWidget {
 
   static const double _designWidth = 360;
   static const double _moonIconSize = 22;
-  static const double _largeIconSize = 26;
+  static const double _largeIconSize = 29;
+  static const double _largeIconVerticalOffset = 3;
 
   @override
   Widget build(BuildContext context) {
@@ -182,6 +183,7 @@ class _HomeIntro extends StatelessWidget {
                 key: const Key('home_inline_bottle'),
                 asset: 'assets/icons/bottle.svg',
                 size: _largeIconSize,
+                verticalOffset: _largeIconVerticalOffset,
                 tooltip: 'Scrivi',
                 onPressed: () => SeaFooterBar.openComposer(context),
               ),
@@ -198,6 +200,7 @@ class _HomeIntro extends StatelessWidget {
                 key: const Key('home_inline_island'),
                 asset: 'assets/icons/isoladellestorie/island.svg',
                 size: _largeIconSize,
+                verticalOffset: _largeIconVerticalOffset,
                 tooltip: "Vai all'Isola delle Storie",
                 onPressed: () => SeaFooterBar.openIsland(context),
                 tint: HonooColor.onBackground,
@@ -218,6 +221,7 @@ class _HomeIntro extends StatelessWidget {
     required Key key,
     required String asset,
     required double size,
+    double verticalOffset = 0,
     required String tooltip,
     required VoidCallback onPressed,
     Color? tint,
@@ -225,20 +229,23 @@ class _HomeIntro extends StatelessWidget {
     return WidgetSpan(
       alignment: PlaceholderAlignment.baseline,
       baseline: TextBaseline.alphabetic,
-      child: IconButton(
-        key: key,
-        constraints: BoxConstraints.tightFor(width: size, height: size),
-        padding: EdgeInsets.zero,
-        visualDensity: VisualDensity.compact,
-        tooltip: tooltip,
-        onPressed: onPressed,
-        icon: SvgPicture.asset(
-          asset,
-          width: size,
-          height: size,
-          colorFilter: tint == null
-              ? null
-              : ColorFilter.mode(tint, BlendMode.srcIn),
+      child: Transform.translate(
+        offset: Offset(0, verticalOffset),
+        child: IconButton(
+          key: key,
+          constraints: BoxConstraints.tightFor(width: size, height: size),
+          padding: EdgeInsets.zero,
+          visualDensity: VisualDensity.compact,
+          tooltip: tooltip,
+          onPressed: onPressed,
+          icon: SvgPicture.asset(
+            asset,
+            width: size,
+            height: size,
+            colorFilter: tint == null
+                ? null
+                : ColorFilter.mode(tint, BlendMode.srcIn),
+          ),
         ),
       ),
     );

--- a/lib/Widgets/luna_fissa.dart
+++ b/lib/Widgets/luna_fissa.dart
@@ -27,6 +27,21 @@ class LunaFissa extends StatefulWidget {
     return 68;
   }
 
+  static void openMoon(BuildContext context) {
+    final user = SupabaseProvider.client.auth.currentUser;
+    if (user == null) {
+      Navigator.push(
+        context,
+        MaterialPageRoute(builder: (context) => const EmailLoginPage()),
+      );
+      return;
+    }
+    Navigator.push(
+      context,
+      MaterialPageRoute(builder: (context) => const MoonPage()),
+    );
+  }
+
   /// Padding verticale di riserva da applicare al contenuto
   /// per evitare qualunque sovrapposizione nel bordo alto.
   /// (top safe-area + dimensione icona + margini)
@@ -132,36 +147,17 @@ class _LunaFissaState extends State<LunaFissa> with WidgetsBindingObserver {
     final w = MediaQuery.of(context).size.width;
     final topSafe = MediaQuery.of(context).viewPadding.top;
     final iconSize = LunaFissa.iconSizeForWidth(w);
-    final double margin =
-        w >= 1200 ? LunaFissa._largeDesktopMargin : LunaFissa._margin;
+    final double margin = w >= 1200
+        ? LunaFissa._largeDesktopMargin
+        : LunaFissa._margin;
 
     final List<Widget> actions = [
       IconButton(
-        icon: SvgPicture.asset(
-          "assets/icons/moon.svg",
-          semanticsLabel: 'Moon',
-        ),
+        icon: SvgPicture.asset("assets/icons/moon.svg", semanticsLabel: 'Moon'),
         iconSize: iconSize,
         splashRadius: (iconSize / 2) + 6,
         tooltip: 'Vai sulla Luna',
-        onPressed: () {
-          final user = SupabaseProvider.client.auth.currentUser;
-          if (user == null) {
-            Navigator.push(
-              context,
-              MaterialPageRoute(
-                builder: (context) => const EmailLoginPage(),
-              ),
-            );
-            return;
-          }
-          Navigator.push(
-            context,
-            MaterialPageRoute(
-              builder: (context) => const MoonPage(),
-            ),
-          );
-        },
+        onPressed: () => LunaFissa.openMoon(context),
       ),
     ];
 

--- a/lib/Widgets/sea_footer_bar.dart
+++ b/lib/Widgets/sea_footer_bar.dart
@@ -19,6 +19,17 @@ class SeaFooterBar extends StatelessWidget {
   /// Altezza fissa come in HomePage
   static const double height = 105;
 
+  static void openComposer(BuildContext context) {
+    ComposerLauncher.open(context);
+  }
+
+  static void openIsland(BuildContext context) {
+    Navigator.push(
+      context,
+      MaterialPageRoute(builder: (context) => const IslandPage()),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return SizedBox(
@@ -99,7 +110,7 @@ class SeaFooterBar extends StatelessWidget {
                     iconSize: bottleSize,
                     splashRadius: 40,
                     tooltip: 'Scrivi',
-                    onPressed: () => ComposerLauncher.open(context),
+                    onPressed: () => SeaFooterBar.openComposer(context),
                   ),
                 ),
               ),
@@ -144,14 +155,7 @@ class SeaFooterBar extends StatelessWidget {
                     iconSize: islandSize,
                     splashRadius: 1,
                     tooltip: "Vai all'Isola delle Storie",
-                    onPressed: () {
-                      Navigator.push(
-                        context,
-                        MaterialPageRoute(
-                          builder: (context) => const IslandPage(),
-                        ),
-                      );
-                    },
+                    onPressed: () => SeaFooterBar.openIsland(context),
                   ),
                 ),
               ),

--- a/test/pages/home_page_layout_test.dart
+++ b/test/pages/home_page_layout_test.dart
@@ -48,15 +48,16 @@ void main() {
     expect(find.byKey(const Key('home_inline_moon')), findsOneWidget);
     expect(find.byKey(const Key('home_inline_island')), findsOneWidget);
 
-    for (final key in const [
-      Key('home_inline_bottle'),
-      Key('home_inline_moon'),
-      Key('home_inline_island'),
+    for (final entry in const [
+      (Key('home_inline_bottle'), 26.0),
+      (Key('home_inline_moon'), 22.0),
+      (Key('home_inline_island'), 26.0),
     ]) {
+      final key = entry.$1;
       final button = tester.widget<IconButton>(find.byKey(key));
       expect(button.onPressed, isNotNull);
-      expect(button.constraints!.maxWidth, 22);
-      expect(button.constraints!.maxHeight, 22);
+      expect(button.constraints!.maxWidth, entry.$2);
+      expect(button.constraints!.maxHeight, entry.$2);
     }
 
     await pumpHomeAtSize(tester, const Size(1440, 1000));

--- a/test/pages/home_page_layout_test.dart
+++ b/test/pages/home_page_layout_test.dart
@@ -41,8 +41,8 @@ void main() {
 
     final intro = find.byKey(const Key('home_intro_text'));
     expect(intro, findsOneWidget);
-    expect(find.textContaining('Ti regaliamo la Luna.'), findsOneWidget);
-    expect(find.textContaining('verso le tue storie.'), findsOneWidget);
+    expect(find.textContaining('Ti regaliamo la Luna'), findsOneWidget);
+    expect(find.textContaining('verso le tue storie'), findsOneWidget);
     expect(find.byType(Scrollable), findsNothing);
     expect(find.byKey(const Key('home_inline_bottle')), findsOneWidget);
     expect(find.byKey(const Key('home_inline_moon')), findsOneWidget);
@@ -55,8 +55,8 @@ void main() {
     ]) {
       final button = tester.widget<IconButton>(find.byKey(key));
       expect(button.onPressed, isNotNull);
-      expect(button.constraints!.maxWidth, 20);
-      expect(button.constraints!.maxHeight, 20);
+      expect(button.constraints!.maxWidth, 22);
+      expect(button.constraints!.maxHeight, 22);
     }
 
     await pumpHomeAtSize(tester, const Size(1440, 1000));

--- a/test/pages/home_page_layout_test.dart
+++ b/test/pages/home_page_layout_test.dart
@@ -34,18 +34,35 @@ void main() {
     await tester.pump();
   }
 
-  testWidgets('solleva solo il testo introduttivo in modo responsive', (
+  testWidgets('mostra il nuovo testo e le azioni inline senza scroll', (
     tester,
   ) async {
     await pumpHomeAtSize(tester, const Size(320, 500));
 
-    Transform intro = tester.widget(find.byKey(const Key('home_intro_lift')));
-    expect(intro.transform.getTranslation().y, -6);
+    final intro = find.byKey(const Key('home_intro_text'));
+    expect(intro, findsOneWidget);
+    expect(find.textContaining('Ti regaliamo la Luna.'), findsOneWidget);
+    expect(find.textContaining('verso le tue storie.'), findsOneWidget);
+    expect(find.byType(Scrollable), findsNothing);
+    expect(find.byKey(const Key('home_inline_bottle')), findsOneWidget);
+    expect(find.byKey(const Key('home_inline_moon')), findsOneWidget);
+    expect(find.byKey(const Key('home_inline_island')), findsOneWidget);
+
+    for (final key in const [
+      Key('home_inline_bottle'),
+      Key('home_inline_moon'),
+      Key('home_inline_island'),
+    ]) {
+      final button = tester.widget<IconButton>(find.byKey(key));
+      expect(button.onPressed, isNotNull);
+      expect(button.constraints!.maxWidth, 20);
+      expect(button.constraints!.maxHeight, 20);
+    }
 
     await pumpHomeAtSize(tester, const Size(1440, 1000));
 
-    intro = tester.widget(find.byKey(const Key('home_intro_lift')));
-    expect(intro.transform.getTranslation().y, -10);
+    expect(find.byKey(const Key('home_intro_text')), findsOneWidget);
+    expect(find.byType(Scrollable), findsNothing);
 
     await tester.pumpWidget(const SizedBox.shrink());
   });

--- a/test/pages/home_page_layout_test.dart
+++ b/test/pages/home_page_layout_test.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:honoo/Pages/home_page.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../test_supabase_helper.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late SupabaseTestHarness harness;
+
+  setUpAll(registerSupabaseFallbacks);
+
+  setUp(() {
+    harness = SupabaseTestHarness();
+    harness.enableOverrides();
+    final visit = MockQueryChain();
+    when(
+      () => harness.client.rpc('increment_site_visit'),
+    ).thenAnswer((_) => visit);
+  });
+
+  tearDown(() {
+    harness.disableOverrides();
+  });
+
+  Future<void> pumpHomeAtSize(WidgetTester tester, Size size) async {
+    tester.view.devicePixelRatio = 1;
+    tester.view.physicalSize = size;
+    addTearDown(tester.view.reset);
+
+    await tester.pumpWidget(const MaterialApp(home: HomePage()));
+    await tester.pump();
+  }
+
+  testWidgets('solleva solo il testo introduttivo in modo responsive', (
+    tester,
+  ) async {
+    await pumpHomeAtSize(tester, const Size(320, 500));
+
+    Transform intro = tester.widget(find.byKey(const Key('home_intro_lift')));
+    expect(intro.transform.getTranslation().y, -6);
+
+    await pumpHomeAtSize(tester, const Size(1440, 1000));
+
+    intro = tester.widget(find.byKey(const Key('home_intro_lift')));
+    expect(intro.transform.getTranslation().y, -10);
+
+    await tester.pumpWidget(const SizedBox.shrink());
+  });
+}

--- a/test/pages/home_page_layout_test.dart
+++ b/test/pages/home_page_layout_test.dart
@@ -49,9 +49,9 @@ void main() {
     expect(find.byKey(const Key('home_inline_island')), findsOneWidget);
 
     for (final entry in const [
-      (Key('home_inline_bottle'), 26.0),
+      (Key('home_inline_bottle'), 29.0),
       (Key('home_inline_moon'), 22.0),
-      (Key('home_inline_island'), 26.0),
+      (Key('home_inline_island'), 29.0),
     ]) {
       final key = entry.$1;
       final button = tester.widget<IconButton>(find.byKey(key));


### PR DESCRIPTION
## Summary
- replaces the Home introduction with the requested Italian copy
- embeds smaller responsive bottle, Moon, and Island icons directly in the text
- reuses the same navigation actions as the persistent page icons
- keeps the complete introduction visible without scrolling on mobile and desktop

## Verification
- `fvm flutter analyze lib/Pages/home_page.dart lib/Widgets/luna_fissa.dart lib/Widgets/sea_footer_bar.dart test/pages/home_page_layout_test.dart`
- `fvm flutter test test/pages/home_page_layout_test.dart`
- mobile preview at 390×844: document height equals viewport height (no page scroll)