### PR TITLE
Allinea testo e icone del selettore di composizione

### DIFF
--- a/lib/Widgets/composer_onboarding.dart
+++ b/lib/Widgets/composer_onboarding.dart
@@ -65,11 +65,13 @@ class ComposerOnboardingPage extends StatelessWidget {
                 180.0,
                 280.0,
               );
-              final iconSize = (constraints.maxWidth * 0.15).clamp(48.0, 72.0);
-              final bottleIconSize = (iconSize * 0.65).clamp(32.0, 44.0);
+              final fontSize = constraints.maxWidth < 360 ? 17.0 : 19.0;
+              final scaledFontSize = textScaler.scale(fontSize);
+              final iconSize = scaledFontSize * 2.25;
+              final bottleIconSize = iconSize * 0.72;
               final textStyle = GoogleFonts.arvo(
                 color: HonooColor.onBackground,
-                fontSize: constraints.maxWidth < 360 ? 17 : 19,
+                fontSize: fontSize,
                 height: 1.3,
               );
 
@@ -89,30 +91,18 @@ class ComposerOnboardingPage extends StatelessWidget {
                           constraints: const BoxConstraints(maxWidth: 560),
                           child: Column(
                             children: [
-                              Text(
-                                'Clicca qui',
-                                style: textStyle,
-                                textAlign: TextAlign.center,
-                              ),
-                              const SizedBox(height: 8),
-                              IconButton(
-                                key: const Key('composer_onboarding_bottle'),
+                              _InlineComposerAction(
+                                actionKey: const Key(
+                                  'composer_onboarding_bottle',
+                                ),
+                                textStyle: textStyle,
+                                iconAsset: 'assets/icons/bottle.svg',
+                                iconSemanticsLabel: 'Bottiglia',
                                 tooltip: 'Componi il tuo honoo',
                                 onPressed: () => _openHonooComposer(context),
                                 iconSize: bottleIconSize,
-                                padding: const EdgeInsets.all(4),
-                                constraints: const BoxConstraints(
-                                  minWidth: 48,
-                                  minHeight: 48,
-                                ),
-                                icon: SvgPicture.asset(
-                                  'assets/icons/bottle.svg',
-                                  width: bottleIconSize,
-                                  height: bottleIconSize,
-                                  semanticsLabel: 'Bottiglia',
-                                ),
                               ),
-                              const SizedBox(height: 8),
+                              const SizedBox(height: 4),
                               Text(
                                 'per comporre il tuo honoo',
                                 style: textStyle,
@@ -126,30 +116,18 @@ class ComposerOnboardingPage extends StatelessWidget {
                                 semanticsLabel: 'Esempio di honoo',
                               ),
                               const SizedBox(height: 56),
-                              Text(
-                                'Clicca qui',
-                                style: textStyle,
-                                textAlign: TextAlign.center,
-                              ),
-                              const SizedBox(height: 8),
-                              IconButton(
-                                key: const Key('composer_onboarding_feather'),
+                              _InlineComposerAction(
+                                actionKey: const Key(
+                                  'composer_onboarding_feather',
+                                ),
+                                textStyle: textStyle,
+                                iconAsset: 'assets/icons/piuma.svg',
+                                iconSemanticsLabel: 'Piuma',
                                 tooltip: 'Componi il tuo hinoo',
                                 onPressed: () => _openHinooComposer(context),
                                 iconSize: iconSize,
-                                padding: EdgeInsets.zero,
-                                constraints: BoxConstraints.tightFor(
-                                  width: iconSize,
-                                  height: iconSize,
-                                ),
-                                icon: SvgPicture.asset(
-                                  'assets/icons/piuma.svg',
-                                  width: iconSize,
-                                  height: iconSize,
-                                  semanticsLabel: 'Piuma',
-                                ),
                               ),
-                              const SizedBox(height: 8),
+                              const SizedBox(height: 4),
                               Text(
                                 'per comporre il tuo hinoo',
                                 style: textStyle,
@@ -200,6 +178,52 @@ class ComposerOnboardingPage extends StatelessWidget {
           ),
         ),
       ),
+    );
+  }
+}
+
+class _InlineComposerAction extends StatelessWidget {
+  const _InlineComposerAction({
+    required this.actionKey,
+    required this.textStyle,
+    required this.iconAsset,
+    required this.iconSemanticsLabel,
+    required this.tooltip,
+    required this.onPressed,
+    required this.iconSize,
+  });
+
+  final Key actionKey;
+  final TextStyle textStyle;
+  final String iconAsset;
+  final String iconSemanticsLabel;
+  final String tooltip;
+  final VoidCallback onPressed;
+  final double iconSize;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        Text('Clicca qui', style: textStyle),
+        const SizedBox(width: 6),
+        IconButton(
+          key: actionKey,
+          tooltip: tooltip,
+          onPressed: onPressed,
+          iconSize: iconSize,
+          padding: EdgeInsets.zero,
+          constraints: const BoxConstraints(minWidth: 48, minHeight: 48),
+          icon: SvgPicture.asset(
+            iconAsset,
+            width: iconSize,
+            height: iconSize,
+            semanticsLabel: iconSemanticsLabel,
+          ),
+        ),
+      ],
     );
   }
 }

--- a/test/widgets/composer_onboarding_test.dart
+++ b/test/widgets/composer_onboarding_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:honoo/Pages/new_hinoo_page.dart';
 import 'package:honoo/Pages/new_honoo_page.dart';
@@ -10,13 +11,24 @@ void main() {
 
   setUp(() => SharedPreferences.setMockInitialValues({}));
 
-  Future<void> pumpOnboarding(WidgetTester tester, {required Size size}) async {
+  Future<void> pumpOnboarding(
+    WidgetTester tester, {
+    required Size size,
+    TextScaler textScaler = TextScaler.noScaling,
+  }) async {
     tester.view.physicalSize = size;
     tester.view.devicePixelRatio = 1;
     addTearDown(tester.view.resetPhysicalSize);
     addTearDown(tester.view.resetDevicePixelRatio);
 
-    await tester.pumpWidget(const MaterialApp(home: ComposerOnboardingPage()));
+    await tester.pumpWidget(
+      MaterialApp(
+        home: MediaQuery(
+          data: MediaQueryData(size: size, textScaler: textScaler),
+          child: const ComposerOnboardingPage(),
+        ),
+      ),
+    );
     await tester.pumpAndSettle();
   }
 
@@ -51,6 +63,51 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byType(NewHinooPage), findsOneWidget);
+  });
+
+  testWidgets('testo e icone delle azioni restano sulla stessa riga', (
+    tester,
+  ) async {
+    await pumpOnboarding(tester, size: const Size(320, 568));
+
+    final actionText = find.text('Clicca qui');
+    expect(actionText, findsNWidgets(2));
+
+    expect(
+      tester.getCenter(actionText.at(0)).dy,
+      closeTo(
+        tester
+            .getCenter(find.byKey(const Key('composer_onboarding_bottle')))
+            .dy,
+        1,
+      ),
+    );
+    expect(
+      tester.getCenter(actionText.at(1)).dy,
+      closeTo(
+        tester
+            .getCenter(find.byKey(const Key('composer_onboarding_feather')))
+            .dy,
+        1,
+      ),
+    );
+  });
+
+  testWidgets('le icone crescono proporzionalmente al testo', (tester) async {
+    await pumpOnboarding(tester, size: const Size(390, 844));
+    final bottle = find.descendant(
+      of: find.byKey(const Key('composer_onboarding_bottle')),
+      matching: find.byType(SvgPicture),
+    );
+    final baseWidth = tester.getSize(bottle).width;
+
+    await pumpOnboarding(
+      tester,
+      size: const Size(390, 844),
+      textScaler: const TextScaler.linear(1.5),
+    );
+
+    expect(tester.getSize(bottle).width, closeTo(baseWidth * 1.5, 0.1));
   });
 
   testWidgets('la X chiude il selettore senza nasconderlo in futuro', (


### PR DESCRIPTION
## Cosa cambia
- dispone “Clicca qui” e l’icona cliccabile sulla stessa riga per honoo e hinoo
- calcola la dimensione delle icone a partire dal testo effettivamente scalato
- mantiene un’area di tap minima accessibile e il layout responsive
- aggiunge test per allineamento, scaling, navigazione e assenza di overflow

## Perché
Nel selettore aperto dalla bottiglia, testo e icona erano impilati e le icone dipendevano dalla larghezza dello schermo, invece che dalla dimensione del testo.

## Verifica
- `fvm flutter test test/widgets/composer_onboarding_test.dart`
- `fvm flutter analyze lib/Widgets/composer_onboarding.dart test/widgets/composer_onboarding_test.dart`
- `git diff --cached --check`