### PR TITLE
Refine home intro and Hinoo actions

### DIFF
--- a/lib/Pages/home_page.dart
+++ b/lib/Pages/home_page.dart
@@ -180,6 +180,9 @@ class _HomeIntro extends StatelessWidget {
                     'Vuoi essere un poeta di honoo?\n\n'
                     'Scegli',
               ),
+              const WidgetSpan(
+                child: SizedBox(key: Key('home_bottle_leading_gap'), width: 8),
+              ),
               _inlineAction(
                 key: const Key('home_inline_bottle'),
                 asset: 'assets/icons/bottle.svg',
@@ -189,6 +192,9 @@ class _HomeIntro extends StatelessWidget {
                 onPressed: () => SeaFooterBar.openComposer(context),
               ),
               const TextSpan(text: '\n\nOppure'),
+              const WidgetSpan(
+                child: SizedBox(key: Key('home_moon_leading_gap'), width: 8),
+              ),
               _inlineAction(
                 key: const Key('home_inline_moon'),
                 asset: 'assets/icons/moon.svg',
@@ -197,6 +203,9 @@ class _HomeIntro extends StatelessWidget {
                 onPressed: () => LunaFissa.openMoon(context),
               ),
               const TextSpan(text: '\ne guarda le vite degli altri\n\nO'),
+              const WidgetSpan(
+                child: SizedBox(key: Key('home_island_leading_gap'), width: 8),
+              ),
               _inlineAction(
                 key: const Key('home_inline_island'),
                 asset: 'assets/icons/isoladellestorie/island.svg',

--- a/lib/Pages/home_page.dart
+++ b/lib/Pages/home_page.dart
@@ -144,9 +144,9 @@ class _HomeIntro extends StatelessWidget {
 
   static const double _designWidth = 360;
   static const double _moonIconSize = 22;
-  static const double _largeIconSize = 29;
-  static const double _bottleIconVerticalOffset = 6;
-  static const double _islandIconVerticalOffset = 9;
+  static const double _largeIconSize = 32;
+  static const double _bottleIconVerticalOffset = 8;
+  static const double _islandIconVerticalOffset = 10;
 
   @override
   Widget build(BuildContext context) {
@@ -178,7 +178,7 @@ class _HomeIntro extends StatelessWidget {
                     'È vero\n'
                     'Ma non per i poeti\n\n'
                     'Vuoi essere un poeta di honoo?\n\n'
-                    'Clicca su ',
+                    'Scegli',
               ),
               _inlineAction(
                 key: const Key('home_inline_bottle'),
@@ -188,7 +188,7 @@ class _HomeIntro extends StatelessWidget {
                 tooltip: 'Scrivi',
                 onPressed: () => SeaFooterBar.openComposer(context),
               ),
-              const TextSpan(text: '\n\nOppure su '),
+              const TextSpan(text: '\n\nOppure'),
               _inlineAction(
                 key: const Key('home_inline_moon'),
                 asset: 'assets/icons/moon.svg',
@@ -196,7 +196,7 @@ class _HomeIntro extends StatelessWidget {
                 tooltip: 'Vai sulla Luna',
                 onPressed: () => LunaFissa.openMoon(context),
               ),
-              const TextSpan(text: '\ne guarda le vite degli altri\n\nO su '),
+              const TextSpan(text: '\ne guarda le vite degli altri\n\nO'),
               _inlineAction(
                 key: const Key('home_inline_island'),
                 asset: 'assets/icons/isoladellestorie/island.svg',

--- a/lib/Pages/new_hinoo_page.dart
+++ b/lib/Pages/new_hinoo_page.dart
@@ -445,15 +445,6 @@ class _NewHinooPageState extends State<NewHinooPage>
     return w;
   }
 
-  void _deleteCurrentFromBuilder() {
-    final dyn = _builderKey.currentState as dynamic;
-    if (dyn?.deleteCurrentPagePublic != null) {
-      dyn.deleteCurrentPagePublic();
-    } else {
-      _warnMissingApi('_deleteCurrentFromBuilder → deleteCurrentPagePublic');
-    }
-  }
-
   void _triggerDownloadFromBuilder() {
     final dyn = _builderKey.currentState as dynamic;
     if (dyn?.openDownloadDialogPublic != null) {
@@ -538,11 +529,6 @@ class _NewHinooPageState extends State<NewHinooPage>
           ),
           const SizedBox(width: 6),
         ],
-        iconBtn(
-          tooltip: 'Cancella hinoo',
-          icon: Icons.delete_outline,
-          onPressed: _deleteCurrentFromBuilder,
-        ),
       ],
     );
   }

--- a/lib/Services/reply_system_notification_web.dart
+++ b/lib/Services/reply_system_notification_web.dart
@@ -36,7 +36,7 @@ class _WebReplySystemNotification extends ReplySystemNotification {
     final notification = web.Notification(
       'Nuova risposta su honoo',
       web.NotificationOptions(
-        body: 'Hai ricevuto una risposta al tuo $contentLabel.',
+        body: 'Hai ricevuto una risposta al tuo $contentLabel',
         icon: 'icons/Icon-192.png',
         tag: 'honoo-reply-$conversationId',
       ),

--- a/lib/UI/HinooBuilder/overlays/cambia_sfondo.dart
+++ b/lib/UI/HinooBuilder/overlays/cambia_sfondo.dart
@@ -85,8 +85,8 @@ class CambiaSfondoOverlay extends StatelessWidget {
               mainAxisSize: MainAxisSize.min,
               children: [
                 Text(
-                  'Trascina per spostare l’immagine.\n'
-                  'Usa il pizzico o i controlli per zoomare.',
+                  'Trascina per spostare l’immagine\n'
+                  'Usa il pizzico o i controlli per zoomare',
                   textAlign: TextAlign.center,
                   style: GoogleFonts.lora(color: Colors.white, fontSize: 14),
                 ),

--- a/lib/UI/honoo_builder.dart
+++ b/lib/UI/honoo_builder.dart
@@ -398,6 +398,12 @@ class HonooBuilderState extends State<HonooBuilder> {
     setState(() => _isEditingText = false);
   }
 
+  Future<void> _saveEditedTextAndHonoo() async {
+    _textFocus.unfocus();
+    _emitChange();
+    await _confirmImage();
+  }
+
   Future<Uint8List?> _captureHonooAsPng() async {
     final boundary =
         _captureKey.currentContext?.findRenderObject()
@@ -704,6 +710,42 @@ class HonooBuilderState extends State<HonooBuilder> {
                     tooltip: 'download',
                   ),
                 ),
+              if (_isEditingText && hasImage && !_imageConfirmed)
+                Positioned(
+                  right: 6,
+                  bottom: 3,
+                  child: _isUploadingFinal
+                      ? const SizedBox(
+                          width: 30,
+                          height: 30,
+                          child: Padding(
+                            padding: EdgeInsets.all(5),
+                            child: CircularProgressIndicator(
+                              strokeWidth: 2.5,
+                              color: HonooColor.background,
+                            ),
+                          ),
+                        )
+                      : IconButton(
+                          key: const Key('honoo-save-edited-text'),
+                          onPressed: _saveEditedTextAndHonoo,
+                          tooltip: 'Salva honoo',
+                          padding: EdgeInsets.zero,
+                          constraints: const BoxConstraints.tightFor(
+                            width: 34,
+                            height: 34,
+                          ),
+                          icon: SvgPicture.asset(
+                            'assets/icons/ok.svg',
+                            width: 24,
+                            height: 24,
+                            colorFilter: const ColorFilter.mode(
+                              HonooColor.background,
+                              BlendMode.srcIn,
+                            ),
+                          ),
+                        ),
+                ),
             ],
           );
         },
@@ -718,6 +760,9 @@ class HonooBuilderState extends State<HonooBuilder> {
             widget.imageConfirmIconDisplaySize!,
             canvasScale,
           );
+    final double resolvedConfirmIconSize = math.min(confirmIconSize, 28);
+    final double secondaryActionIconSize = resolvedConfirmIconSize * 0.86;
+    final TextStyle actionTextStyle = GoogleFonts.arvo(fontSize: 14);
 
     return Container(
       key: const Key('honoo-image-editing-controls'),
@@ -742,7 +787,7 @@ class HonooBuilderState extends State<HonooBuilder> {
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
               Text(
-                'Trascina per spostare l’immagine.\n'
+                'Trascina per spostare l’immagine\n'
                 'Usa il pizzico o i controlli per zoomare',
                 textAlign: TextAlign.center,
                 style: GoogleFonts.arvo(
@@ -815,11 +860,14 @@ class HonooBuilderState extends State<HonooBuilder> {
                               padding: EdgeInsets.zero,
                               visualDensity: VisualDensity.compact,
                             ),
-                            icon: const Icon(
+                            icon: Icon(
                               Icons.photo_library_outlined,
-                              size: 18,
+                              size: secondaryActionIconSize,
                             ),
-                            label: const Text('Sostituisci immagine'),
+                            label: Text(
+                              'Sostituisci immagine',
+                              style: actionTextStyle,
+                            ),
                           ),
                         ),
                       ),
@@ -838,8 +886,14 @@ class HonooBuilderState extends State<HonooBuilder> {
                               padding: EdgeInsets.zero,
                               visualDensity: VisualDensity.compact,
                             ),
-                            icon: const Icon(Icons.edit_outlined, size: 18),
-                            label: const Text('Modifica testo'),
+                            icon: Icon(
+                              Icons.edit_outlined,
+                              size: secondaryActionIconSize,
+                            ),
+                            label: Text(
+                              'Modifica testo',
+                              style: actionTextStyle,
+                            ),
                           ),
                         ),
                       ),
@@ -869,14 +923,14 @@ class HonooBuilderState extends State<HonooBuilder> {
                           ),
                           icon: SvgPicture.asset(
                             'assets/icons/ok.svg',
-                            width: math.min(confirmIconSize, 28),
-                            height: math.min(confirmIconSize, 28),
+                            width: resolvedConfirmIconSize,
+                            height: resolvedConfirmIconSize,
                             colorFilter: const ColorFilter.mode(
                               HonooColor.background,
                               BlendMode.srcIn,
                             ),
                           ),
-                          label: const Text('Salva honoo'),
+                          label: Text('Salva honoo', style: actionTextStyle),
                         ),
                 ),
               ),

--- a/lib/Utility/interface_text.dart
+++ b/lib/Utility/interface_text.dart
@@ -1,0 +1,8 @@
+String withoutInterfaceTrailingPeriod(String text) {
+  final match = RegExp(r'\.(\s*)$').firstMatch(text);
+  if (match == null || (match.start > 0 && text[match.start - 1] == '.')) {
+    return text;
+  }
+
+  return '${text.substring(0, match.start)}${match.group(1) ?? ''}';
+}

--- a/lib/Widgets/composer_onboarding.dart
+++ b/lib/Widgets/composer_onboarding.dart
@@ -69,6 +69,28 @@ class ComposerOnboardingPage extends StatelessWidget {
               final scaledFontSize = textScaler.scale(fontSize);
               final iconSize = scaledFontSize * 2.25;
               final bottleIconSize = iconSize * 0.72;
+              final featherIconSize = iconSize * 1.1;
+              final topPadding = constraints.maxHeight < 700 ? 16.0 : 36.0;
+              const bottomPadding = 12.0;
+              final sectionSpacing = constraints.maxHeight < 700 ? 20.0 : 32.0;
+              final actionRowsHeight =
+                  math.max(48.0, bottleIconSize) +
+                  math.max(48.0, featherIconSize);
+              final subtitlesHeight = scaledFontSize * 1.3 * 2;
+              final fixedContentHeight =
+                  topPadding +
+                  bottomPadding +
+                  sectionSpacing +
+                  actionRowsHeight +
+                  subtitlesHeight +
+                  36;
+              final fittedExampleHeight = math.min(
+                exampleHeight,
+                math.max(
+                  120.0,
+                  (constraints.maxHeight - fixedContentHeight) / 2,
+                ),
+              );
               final textStyle = GoogleFonts.arvo(
                 color: HonooColor.onBackground,
                 fontSize: fontSize,
@@ -82,9 +104,9 @@ class ComposerOnboardingPage extends StatelessWidget {
                       key: const Key('composer_onboarding_scroll'),
                       padding: EdgeInsets.fromLTRB(
                         horizontalPadding,
-                        72,
+                        topPadding,
                         horizontalPadding,
-                        32,
+                        bottomPadding,
                       ),
                       child: Center(
                         child: ConstrainedBox(
@@ -112,10 +134,10 @@ class ComposerOnboardingPage extends StatelessWidget {
                               _ExampleImage(
                                 asset: 'assets/images/onboarding_honoo.png',
                                 width: imageWidth,
-                                height: exampleHeight,
+                                height: fittedExampleHeight,
                                 semanticsLabel: 'Esempio di honoo',
                               ),
-                              const SizedBox(height: 56),
+                              SizedBox(height: sectionSpacing),
                               _InlineComposerAction(
                                 actionKey: const Key(
                                   'composer_onboarding_feather',
@@ -125,7 +147,7 @@ class ComposerOnboardingPage extends StatelessWidget {
                                 iconSemanticsLabel: 'Piuma',
                                 tooltip: 'Componi il tuo hinoo',
                                 onPressed: () => _openHinooComposer(context),
-                                iconSize: iconSize,
+                                iconSize: featherIconSize,
                               ),
                               const SizedBox(height: 4),
                               Text(
@@ -137,10 +159,9 @@ class ComposerOnboardingPage extends StatelessWidget {
                               _ExampleImage(
                                 asset: 'assets/images/onboarding_hinoo.png',
                                 width: imageWidth,
-                                height: exampleHeight,
+                                height: fittedExampleHeight,
                                 semanticsLabel: 'Esempio di hinoo',
                               ),
-                              const SizedBox(height: 32),
                             ],
                           ),
                         ),
@@ -207,13 +228,14 @@ class _InlineComposerAction extends StatelessWidget {
       mainAxisSize: MainAxisSize.min,
       mainAxisAlignment: MainAxisAlignment.center,
       children: [
-        Text('Clicca qui', style: textStyle),
-        const SizedBox(width: 6),
+        Text('Scegli', style: textStyle),
+        const SizedBox(width: 9),
         IconButton(
           key: actionKey,
           tooltip: tooltip,
           onPressed: onPressed,
           iconSize: iconSize,
+          alignment: Alignment.centerLeft,
           padding: EdgeInsets.zero,
           constraints: const BoxConstraints(minWidth: 48, minHeight: 48),
           icon: SvgPicture.asset(

--- a/lib/Widgets/global_reply_notification_listener.dart
+++ b/lib/Widgets/global_reply_notification_listener.dart
@@ -65,10 +65,11 @@ class _GlobalReplyNotificationListenerState
       _replyEventSubscription ??= testEvents.listen(_handleEvent);
       return;
     }
-    _authSubscription ??=
-        SupabaseProvider.client.auth.onAuthStateChange.listen((state) {
-      _handleSession(state.session);
-    });
+    _authSubscription ??= SupabaseProvider.client.auth.onAuthStateChange.listen(
+      (state) {
+        _handleSession(state.session);
+      },
+    );
     _handleSession(SupabaseProvider.client.auth.currentSession);
   }
 
@@ -93,11 +94,8 @@ class _GlobalReplyNotificationListenerState
             table: 'honoo',
             filter: 'recipient_tag=eq.$userId',
           ),
-          (dynamic payload, [dynamic _]) => _handlePayload(
-            payload,
-            ReplyNotificationKind.honoo,
-            userId,
-          ),
+          (dynamic payload, [dynamic _]) =>
+              _handlePayload(payload, ReplyNotificationKind.honoo, userId),
         )
         ..subscribe();
       _hinooChannel = SupabaseProvider.client.channel('reply-hinoo-$userId')
@@ -109,11 +107,8 @@ class _GlobalReplyNotificationListenerState
             table: 'hinoo',
             filter: 'recipient_tag=eq.$userId',
           ),
-          (dynamic payload, [dynamic _]) => _handlePayload(
-            payload,
-            ReplyNotificationKind.hinoo,
-            userId,
-          ),
+          (dynamic payload, [dynamic _]) =>
+              _handlePayload(payload, ReplyNotificationKind.hinoo, userId),
         )
         ..subscribe();
     } catch (_) {
@@ -162,8 +157,9 @@ class _GlobalReplyNotificationListenerState
       ?..hideCurrentSnackBar()
       ..showSnackBar(
         SnackBar(
-          content:
-              Text('Hai ricevuto una risposta al tuo ${event.contentLabel}.'),
+          content: Text(
+            'Hai ricevuto una risposta al tuo ${event.contentLabel}',
+          ),
           action: SnackBarAction(label: 'Apri', onPressed: open),
         ),
       );

--- a/lib/Widgets/honoo_dialogs.dart
+++ b/lib/Widgets/honoo_dialogs.dart
@@ -2,42 +2,36 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
+import 'package:honoo/Utility/interface_text.dart';
 import 'package:honoo/env/env.dart';
 
 class HonooDialogStyles {
   static TextStyle title() => GoogleFonts.lora(
-        color: Colors.white,
-        fontSize: 20,
-        fontWeight: FontWeight.bold,
-      );
+    color: Colors.white,
+    fontSize: 20,
+    fontWeight: FontWeight.bold,
+  );
 
-  static TextStyle body({Color color = Colors.white70}) => GoogleFonts.lora(
-        color: color,
-        fontSize: 14,
-      );
+  static TextStyle body({Color color = Colors.white70}) =>
+      GoogleFonts.lora(color: color, fontSize: 14);
 
-  static TextStyle caption({Color color = Colors.white70}) => GoogleFonts.lora(
-        color: color,
-        fontSize: 12,
-      );
+  static TextStyle caption({Color color = Colors.white70}) =>
+      GoogleFonts.lora(color: color, fontSize: 12);
 
   static TextStyle primaryAction() => GoogleFonts.lora(
-        color: Colors.black,
-        fontSize: 14,
-        fontWeight: FontWeight.w600,
-      );
+    color: Colors.black,
+    fontSize: 14,
+    fontWeight: FontWeight.w600,
+  );
 
   static TextStyle secondaryAction() => GoogleFonts.lora(
-        color: Colors.white,
-        fontSize: 14,
-        fontWeight: FontWeight.w600,
-      );
+    color: Colors.white,
+    fontSize: 14,
+    fontWeight: FontWeight.w600,
+  );
 
   static TextStyle tertiaryAction({Color color = Colors.white54}) =>
-      GoogleFonts.lora(
-        color: color,
-        fontSize: 13,
-      );
+      GoogleFonts.lora(color: color, fontSize: 13);
 }
 
 class HonooDialogShell extends StatelessWidget {
@@ -88,12 +82,15 @@ class HonooConfirmDialog extends StatelessWidget {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Text(title,
-                style: HonooDialogStyles.title(), textAlign: TextAlign.center),
+            Text(
+              withoutInterfaceTrailingPeriod(title),
+              style: HonooDialogStyles.title(),
+              textAlign: TextAlign.center,
+            ),
             if (message != null && message!.trim().isNotEmpty) ...[
               const SizedBox(height: 12),
               Text(
-                message!,
+                withoutInterfaceTrailingPeriod(message!),
                 style: HonooDialogStyles.body(),
                 textAlign: TextAlign.center,
               ),
@@ -106,22 +103,29 @@ class HonooConfirmDialog extends StatelessWidget {
                 style: ElevatedButton.styleFrom(
                   backgroundColor: Colors.white,
                   foregroundColor: Colors.black,
-                  padding:
-                      const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 16,
+                    vertical: 14,
+                  ),
                   shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(16)),
+                    borderRadius: BorderRadius.circular(16),
+                  ),
                   elevation: 0,
                 ),
-                child: Text(confirmLabel,
-                    style: HonooDialogStyles.primaryAction()),
+                child: Text(
+                  confirmLabel,
+                  style: HonooDialogStyles.primaryAction(),
+                ),
               ),
             ),
             const SizedBox(height: 12),
             TextButton(
               onPressed: () => Navigator.of(context).pop(false),
               style: TextButton.styleFrom(foregroundColor: Colors.white54),
-              child:
-                  Text(cancelLabel, style: HonooDialogStyles.tertiaryAction()),
+              child: Text(
+                cancelLabel,
+                style: HonooDialogStyles.tertiaryAction(),
+              ),
             ),
           ],
         ),
@@ -158,7 +162,8 @@ class _HonooMessageDialogState extends State<HonooMessageDialog> {
     super.initState();
 
     // Non avviare il timer in CI/test (Codex ha CI=true)
-    final bool inCi = const bool.fromEnvironment('CI', defaultValue: false) ||
+    final bool inCi =
+        const bool.fromEnvironment('CI', defaultValue: false) ||
         (readEnv('CI') == 'true');
 
     if (!inCi) {
@@ -191,14 +196,14 @@ class _HonooMessageDialogState extends State<HonooMessageDialog> {
             ],
             if (widget.title != null && widget.title!.trim().isNotEmpty) ...[
               Text(
-                widget.title!,
+                withoutInterfaceTrailingPeriod(widget.title!),
                 style: HonooDialogStyles.title(),
                 textAlign: TextAlign.center,
               ),
               const SizedBox(height: 8),
             ],
             Text(
-              widget.message,
+              withoutInterfaceTrailingPeriod(widget.message),
               style: HonooDialogStyles.body(color: Colors.white),
               textAlign: TextAlign.center,
             ),

--- a/test/pages/home_page_layout_test.dart
+++ b/test/pages/home_page_layout_test.dart
@@ -49,9 +49,9 @@ void main() {
     expect(find.byKey(const Key('home_inline_island')), findsOneWidget);
 
     for (final entry in const [
-      (Key('home_inline_bottle'), 29.0),
+      (Key('home_inline_bottle'), 32.0),
       (Key('home_inline_moon'), 22.0),
-      (Key('home_inline_island'), 29.0),
+      (Key('home_inline_island'), 32.0),
     ]) {
       final key = entry.$1;
       final button = tester.widget<IconButton>(find.byKey(key));

--- a/test/pages/home_page_layout_test.dart
+++ b/test/pages/home_page_layout_test.dart
@@ -47,6 +47,17 @@ void main() {
     expect(find.byKey(const Key('home_inline_bottle')), findsOneWidget);
     expect(find.byKey(const Key('home_inline_moon')), findsOneWidget);
     expect(find.byKey(const Key('home_inline_island')), findsOneWidget);
+    expect(find.byKey(const Key('home_bottle_leading_gap')), findsOneWidget);
+    expect(find.byKey(const Key('home_moon_leading_gap')), findsOneWidget);
+    expect(find.byKey(const Key('home_island_leading_gap')), findsOneWidget);
+
+    for (final key in const [
+      Key('home_bottle_leading_gap'),
+      Key('home_moon_leading_gap'),
+      Key('home_island_leading_gap'),
+    ]) {
+      expect(tester.getSize(find.byKey(key)).width, 8);
+    }
 
     for (final entry in const [
       (Key('home_inline_bottle'), 32.0),

--- a/test/pages/new_hinoo_page_test.dart
+++ b/test/pages/new_hinoo_page_test.dart
@@ -20,7 +20,7 @@ void main() {
     expect(find.byTooltip('Apri il tuo Cuore'), findsOneWidget);
   });
 
-  testWidgets('il cestino hinoo è sopra e fuori dal box di editing', (
+  testWidgets('il cestino hinoo non è mostrato sopra il box di editing', (
     tester,
   ) async {
     await tester.pumpWidget(
@@ -32,14 +32,7 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    final Finder deleteButton = find.byTooltip('Cancella hinoo');
-    final Finder editor = find.byType(HinooBuilder);
-
-    expect(deleteButton, findsOneWidget);
-    expect(editor, findsOneWidget);
-    expect(
-      tester.getBottomLeft(deleteButton).dy,
-      lessThanOrEqualTo(tester.getTopLeft(editor).dy),
-    );
+    expect(find.byTooltip('Cancella hinoo'), findsNothing);
+    expect(find.byType(HinooBuilder), findsOneWidget);
   });
 }

--- a/test/ui/cambia_sfondo_overlay_test.dart
+++ b/test/ui/cambia_sfondo_overlay_test.dart
@@ -23,8 +23,8 @@ void main() {
 
     expect(
       find.text(
-        'Trascina per spostare l’immagine.\n'
-        'Usa il pizzico o i controlli per zoomare.',
+        'Trascina per spostare l’immagine\n'
+        'Usa il pizzico o i controlli per zoomare',
       ),
       findsOneWidget,
     );

--- a/test/ui/honoo_image_editor_controls_test.dart
+++ b/test/ui/honoo_image_editor_controls_test.dart
@@ -2,6 +2,8 @@ import 'dart:convert';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:google_fonts/google_fonts.dart';
 import 'package:honoo/UI/honoo_builder.dart';
 
 void main() {
@@ -37,7 +39,7 @@ void main() {
 
     expect(
       find.text(
-        'Trascina per spostare l’immagine.\n'
+        'Trascina per spostare l’immagine\n'
         'Usa il pizzico o i controlli per zoomare',
       ),
       findsOneWidget,
@@ -60,6 +62,30 @@ void main() {
       greaterThan(tester.getCenter(replace).dy),
     );
     expect(find.text('Salva honoo'), findsOneWidget);
+
+    final replaceIcon = tester.widget<Icon>(
+      find.descendant(
+        of: replace,
+        matching: find.byIcon(Icons.photo_library_outlined),
+      ),
+    );
+    final editIcon = tester.widget<Icon>(
+      find.descendant(of: editText, matching: find.byIcon(Icons.edit_outlined)),
+    );
+    final saveIcon = tester.widget<SvgPicture>(
+      find.descendant(of: save, matching: find.byType(SvgPicture)),
+    );
+    expect(replaceIcon.size, closeTo(saveIcon.width! * 0.86, 0.01));
+    expect(editIcon.size, replaceIcon.size);
+
+    for (final label in [
+      'Sostituisci immagine',
+      'Modifica testo',
+      'Salva honoo',
+    ]) {
+      final text = tester.widget<Text>(find.text(label));
+      expect(text.style?.fontFamily, GoogleFonts.arvo().fontFamily);
+    }
   });
 
   testWidgets('Modifica testo conserva il testo e consente il ritorno', (
@@ -93,6 +119,15 @@ void main() {
     expect(find.byType(TextField), findsOneWidget);
     expect(find.text('Testo iniziale'), findsOneWidget);
     expect(find.byKey(const Key('honoo-image-editing-controls')), findsNothing);
+    expect(find.byKey(const Key('honoo-save-edited-text')), findsOneWidget);
+
+    final saveEditedTextIcon = tester.widget<SvgPicture>(
+      find.descendant(
+        of: find.byKey(const Key('honoo-save-edited-text')),
+        matching: find.byType(SvgPicture),
+      ),
+    );
+    expect(saveEditedTextIcon.width, 24);
 
     await tester.enterText(find.byType(TextField), 'Testo modificato');
     await tester.tap(find.byKey(const Key('honoo-image-area')));

--- a/test/utility/interface_text_test.dart
+++ b/test/utility/interface_text_test.dart
@@ -1,0 +1,20 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:honoo/Utility/interface_text.dart';
+
+void main() {
+  test('rimuove il punto finale dai testi di interfaccia', () {
+    expect(
+      withoutInterfaceTrailingPeriod('Operazione completata.'),
+      'Operazione completata',
+    );
+    expect(
+      withoutInterfaceTrailingPeriod('Operazione completata.\n'),
+      'Operazione completata\n',
+    );
+  });
+
+  test('mantiene i puntini di sospensione e il testo senza punto', () {
+    expect(withoutInterfaceTrailingPeriod('Attendi...'), 'Attendi...');
+    expect(withoutInterfaceTrailingPeriod('Salva honoo'), 'Salva honoo');
+  });
+}

--- a/test/widgets/composer_onboarding_test.dart
+++ b/test/widgets/composer_onboarding_test.dart
@@ -35,7 +35,7 @@ void main() {
   testWidgets('mostra solo i due blocchi di composizione', (tester) async {
     await pumpOnboarding(tester, size: const Size(390, 844));
 
-    expect(find.text('Clicca qui'), findsNWidgets(2));
+    expect(find.text('Scegli'), findsNWidgets(2));
     expect(find.text('per comporre il tuo honoo'), findsOneWidget);
     expect(find.text('per comporre il tuo hinoo'), findsOneWidget);
     expect(find.text('Se clicchi'), findsNothing);
@@ -70,7 +70,7 @@ void main() {
   ) async {
     await pumpOnboarding(tester, size: const Size(320, 568));
 
-    final actionText = find.text('Clicca qui');
+    final actionText = find.text('Scegli');
     expect(actionText, findsNWidgets(2));
 
     expect(
@@ -108,6 +108,15 @@ void main() {
     );
 
     expect(tester.getSize(bottle).width, closeTo(baseWidth * 1.5, 0.1));
+  });
+
+  testWidgets('il selettore entra nel viewport mobile senza scroll', (
+    tester,
+  ) async {
+    await pumpOnboarding(tester, size: const Size(390, 844));
+
+    final scrollable = tester.state<ScrollableState>(find.byType(Scrollable));
+    expect(scrollable.position.maxScrollExtent, 0);
   });
 
   testWidgets('la X chiude il selettore senza nasconderlo in futuro', (

--- a/test/widgets/conversation_notification_prompt_test.dart
+++ b/test/widgets/conversation_notification_prompt_test.dart
@@ -82,6 +82,6 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(notification.requests, 1);
-    expect(find.text('Notifiche attivate.'), findsOneWidget);
+    expect(find.text('Notifiche attivate'), findsOneWidget);
   });
 }

--- a/test/widgets/global_reply_notification_listener_test.dart
+++ b/test/widgets/global_reply_notification_listener_test.dart
@@ -72,19 +72,21 @@ void main() {
         ),
       );
 
-      events.add(const ReplyNotificationEvent(
-        kind: ReplyNotificationKind.hinoo,
-        conversationId: 'conversation-42',
-        senderId: 'other_user',
-        recipientId: 'test_user',
-      ));
+      events.add(
+        const ReplyNotificationEvent(
+          kind: ReplyNotificationKind.hinoo,
+          conversationId: 'conversation-42',
+          senderId: 'other_user',
+          recipientId: 'test_user',
+        ),
+      );
       await tester.pump();
 
       expect(notification.contentLabel, 'hinoo');
       expect(notification.conversationId, 'conversation-42');
       expect(notification.onTap, isNotNull);
       expect(
-        find.text('Hai ricevuto una risposta al tuo hinoo.'),
+        find.text('Hai ricevuto una risposta al tuo hinoo'),
         findsOneWidget,
       );
 

--- a/test/widgets/honoo_dialogs_test.dart
+++ b/test/widgets/honoo_dialogs_test.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:honoo/Widgets/honoo_dialogs.dart';
+
+void main() {
+  testWidgets('i dialoghi rimuovono il punto finale dai testi di interfaccia', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: HonooConfirmDialog(
+            title: 'Titolo.',
+            message: 'Messaggio conclusivo.',
+            confirmLabel: 'Conferma',
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('Titolo'), findsOneWidget);
+    expect(find.text('Messaggio conclusivo'), findsOneWidget);
+    expect(find.text('Titolo.'), findsNothing);
+    expect(find.text('Messaggio conclusivo.'), findsNothing);
+  });
+}


### PR DESCRIPTION
Summary:
- refine Home intro copy, icon size, and alignment
- remove the top delete action from the Hinoo editor
- update widget tests for the intended UI

Validation:
- fvm dart format --output=none --set-exit-if-changed (modified Dart files)
- fvm flutter analyze
- fvm flutter test test/pages/home_page_layout_test.dart test/pages/new_hinoo_page_test.dart
- fvm flutter test