### PR TITLE
Fix conversation replies, reveal animation and notifications

### DIFF
--- a/lib/Entities/reply_notification_event.dart
+++ b/lib/Entities/reply_notification_event.dart
@@ -6,12 +6,14 @@ class ReplyNotificationEvent {
     required this.conversationId,
     required this.senderId,
     required this.recipientId,
+    this.replyId,
   });
 
   final ReplyNotificationKind kind;
   final String conversationId;
   final String senderId;
   final String recipientId;
+  final String? replyId;
 
   String get contentLabel =>
       kind == ReplyNotificationKind.honoo ? 'honoo' : 'hinoo';
@@ -22,8 +24,8 @@ class ReplyNotificationEvent {
     required String currentUserId,
   }) {
     if (payload is! Map) return null;
-    final eventType =
-        (payload['eventType'] ?? payload['event_type'])?.toString();
+    final eventType = (payload['eventType'] ?? payload['event_type'])
+        ?.toString();
     if (eventType != null && eventType.toLowerCase() != 'insert') return null;
 
     final dynamic rawRecord = payload['new'] ?? payload['record'];
@@ -53,6 +55,7 @@ class ReplyNotificationEvent {
       conversationId: conversationId,
       senderId: senderId,
       recipientId: recipientId,
+      replyId: record['id']?.toString(),
     );
   }
 }

--- a/lib/Pages/home_page.dart
+++ b/lib/Pages/home_page.dart
@@ -7,6 +7,7 @@ import 'package:honoo/Services/supabase_provider.dart';
 import 'package:honoo/Services/home_service.dart';
 import 'package:honoo/Utility/app_logger.dart';
 import 'package:honoo/Utility/honoo_colors.dart';
+import 'package:honoo/Utility/reply_notification_signal.dart';
 import '../Widgets/honoo_app_title.dart';
 import 'placeholder_page.dart';
 
@@ -38,11 +39,13 @@ class _HomePageState extends State<HomePage> {
       const Duration(seconds: 60),
       (_) => _loadReplyCount(),
     );
+    ReplyNotificationSignal.revision.addListener(_loadReplyCount);
   }
 
   @override
   void dispose() {
     _replyRefreshTimer?.cancel();
+    ReplyNotificationSignal.revision.removeListener(_loadReplyCount);
     super.dispose();
   }
 

--- a/lib/Pages/new_hinoo_page.dart
+++ b/lib/Pages/new_hinoo_page.dart
@@ -332,14 +332,21 @@ class _NewHinooPageState extends State<NewHinooPage>
       final bool isAnswer =
           (hinooDraft.type == HinooType.answer) || widget.isReply;
       if (isAnswer) {
-        await showHonooMessageDialog(
-          context,
-          message:
-              "L'hinoo adesso è nel tuo Scrigno,\n e,\n soprattutto,\n nello Scrigno di qualcun altro.",
-        );
+        await showReplySavedDialog(context, contentName: 'hinoo');
         if (!mounted) return;
+        final conversationId = hinooDraft.conversationId;
+        if (widget.returnToPreviousOnAnswer) {
+          Navigator.of(context).pop(conversationId);
+          return;
+        }
         Navigator.of(context).pushAndRemoveUntil(
-          MaterialPageRoute(builder: (_) => const HomePage()),
+          MaterialPageRoute(
+            builder: (_) => ChestPage(
+              focusReplies: true,
+              focusConversationId: conversationId,
+              highlightLatest: true,
+            ),
+          ),
           (route) => false,
         );
         return;

--- a/lib/Pages/new_honoo_page.dart
+++ b/lib/Pages/new_honoo_page.dart
@@ -190,14 +190,6 @@ class _NewHonooPageState extends State<NewHonooPage> {
         _lastSavedRawImage = _imageUrl;
       });
 
-      if (openChestAfterSave) {
-        Navigator.of(context).pushAndRemoveUntil(
-          MaterialPageRoute(builder: (_) => const ChestPage()),
-          (route) => false,
-        );
-        return true;
-      }
-
       final bool shouldOfferNotifications =
           type == HonooType.personal &&
           await ConversationNotificationPrompt.shouldOfferForFirstConversation(
@@ -211,14 +203,28 @@ class _NewHonooPageState extends State<NewHonooPage> {
       }
 
       if (type == HonooType.answer) {
-        await showHonooMessageDialog(
-          context,
-          message:
-              "L'honoo adesso è nel tuo Scrigno, e, soprattutto nello Scrigno di quacun altro.",
-        );
+        await showReplySavedDialog(context, contentName: 'honoo');
         if (!mounted) return false;
+        if (widget.returnToPreviousOnAnswer) {
+          Navigator.of(context).pop(conversationId);
+          return true;
+        }
         Navigator.of(context).pushAndRemoveUntil(
-          MaterialPageRoute(builder: (_) => const HomePage()),
+          MaterialPageRoute(
+            builder: (_) => ChestPage(
+              focusReplies: true,
+              focusConversationId: conversationId,
+              highlightLatest: true,
+            ),
+          ),
+          (route) => false,
+        );
+        return true;
+      }
+
+      if (openChestAfterSave) {
+        Navigator.of(context).pushAndRemoveUntil(
+          MaterialPageRoute(builder: (_) => const ChestPage()),
           (route) => false,
         );
         return true;

--- a/lib/Pages/reply_honoo_page.dart
+++ b/lib/Pages/reply_honoo_page.dart
@@ -11,7 +11,7 @@ import '../Entities/honoo.dart';
 import '../Entities/conversation_link.dart';
 import 'package:honoo/Services/supabase_provider.dart';
 import 'package:honoo/Controller/honoo_controller.dart';
-import 'home_page.dart';
+import 'chest_page.dart';
 
 class ReplyHonooPage extends StatefulWidget {
   final Honoo originalHonoo;
@@ -97,14 +97,20 @@ class _ReplyHonooPageState extends State<ReplyHonooPage> {
       if (!mounted) return;
 
       _sentOnce = true;
-      await showHonooMessageDialog(
-        context,
-        message:
-            "L'honoo adesso è nel tuo Scrigno,\n e,\n soprattutto,\nnello Scrigno di qualcun altro.",
-      );
+      await showReplySavedDialog(context, contentName: 'honoo');
       if (!mounted) return;
+      if (widget.returnToPreviousOnAnswer) {
+        Navigator.of(context).pop(link.conversationId);
+        return;
+      }
       Navigator.of(context).pushAndRemoveUntil(
-        MaterialPageRoute(builder: (_) => const HomePage()),
+        MaterialPageRoute(
+          builder: (_) => ChestPage(
+            focusReplies: true,
+            focusConversationId: link.conversationId,
+            highlightLatest: true,
+          ),
+        ),
         (route) => false,
       );
     } catch (e) {

--- a/lib/UI/unified_thread_view.dart
+++ b/lib/UI/unified_thread_view.dart
@@ -50,7 +50,7 @@ class _UnifiedThreadViewState extends State<UnifiedThreadView>
   List<ConversationEntry> _entries = const [];
   RealtimeChannel? _chan;
   bool _didHighlight = false;
-  bool _hasPlayedReveal = false;
+  String? _revealedEntryKey;
   final PageController _pageController = PageController();
   late AnimationController _controller;
   late Animation<double> _liftAnimation;
@@ -166,7 +166,7 @@ class _UnifiedThreadViewState extends State<UnifiedThreadView>
       _chan?.unsubscribe();
       _chan = null;
       _didHighlight = false;
-      _hasPlayedReveal = false;
+      _revealedEntryKey = null;
       _load();
     }
     if (oldWidget.refreshToken != widget.refreshToken &&
@@ -179,7 +179,7 @@ class _UnifiedThreadViewState extends State<UnifiedThreadView>
       if (widget.isActive && !oldWidget.isActive) {
         _load();
       } else if (!widget.isActive && oldWidget.isActive) {
-        _hasPlayedReveal = false;
+        _revealedEntryKey = null;
         _controller.reset();
       }
     }
@@ -208,8 +208,9 @@ class _UnifiedThreadViewState extends State<UnifiedThreadView>
         _pageController.jumpToPage(targetPage);
       }
       final entry = _entries.reversed.elementAt(targetPage);
-      if (!_hasPlayedReveal && _shouldReveal(entry)) {
-        _hasPlayedReveal = true;
+      final entryKey = '${entry.kind.name}:${entry.id}';
+      if (_revealedEntryKey != entryKey && _shouldReveal(entry)) {
+        _revealedEntryKey = entryKey;
         _controller.forward(from: 0);
       }
     });
@@ -317,9 +318,7 @@ class _UnifiedThreadViewState extends State<UnifiedThreadView>
         controller: _pageController,
         scrollDirection: Axis.vertical,
         pageSnapping: true,
-        physics: const PageScrollPhysics(
-          parent: ClampingScrollPhysics(),
-        ),
+        physics: const PageScrollPhysics(parent: ClampingScrollPhysics()),
         onPageChanged: _prefetchEntriesFrom,
         itemCount: _entries.length,
         itemBuilder: (context, index) {

--- a/lib/Utility/replies_seen_tracker.dart
+++ b/lib/Utility/replies_seen_tracker.dart
@@ -1,5 +1,7 @@
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'reply_notification_signal.dart';
+
 class RepliesSeenTracker {
   static const _key = 'last_seen_reply_at_v1';
 
@@ -13,11 +15,12 @@ class RepliesSeenTracker {
   static Future<void> markNow() async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setString(_key, DateTime.now().toIso8601String());
+    ReplyNotificationSignal.notifyChanged();
   }
 
   static Future<void> markAt(DateTime dt) async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setString(_key, dt.toIso8601String());
+    ReplyNotificationSignal.notifyChanged();
   }
 }
-

--- a/lib/Utility/reply_notification_signal.dart
+++ b/lib/Utility/reply_notification_signal.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/foundation.dart';
+
+/// Segnale leggero in-process per riallineare subito i contatori delle risposte.
+class ReplyNotificationSignal {
+  ReplyNotificationSignal._();
+
+  static final ValueNotifier<int> revision = ValueNotifier<int>(0);
+
+  static void notifyChanged() {
+    revision.value += 1;
+  }
+}

--- a/lib/Widgets/global_reply_notification_listener.dart
+++ b/lib/Widgets/global_reply_notification_listener.dart
@@ -8,6 +8,7 @@ import '../Pages/chest_page.dart';
 import '../Services/reply_system_notification.dart';
 import '../Services/supabase_provider.dart';
 import '../Utility/replies_seen_tracker.dart';
+import '../Utility/reply_notification_signal.dart';
 
 class GlobalReplyNotificationListener extends StatefulWidget {
   const GlobalReplyNotificationListener({
@@ -37,8 +38,10 @@ class _GlobalReplyNotificationListenerState
       widget.systemNotification ?? ReplySystemNotification.platform();
   StreamSubscription<AuthState>? _authSubscription;
   StreamSubscription<ReplyNotificationEvent>? _replyEventSubscription;
-  RealtimeChannel? _honooChannel;
-  RealtimeChannel? _hinooChannel;
+  RealtimeChannel? _replyChannel;
+  Timer? _reconnectTimer;
+  int _reconnectAttempt = 0;
+  int _channelGeneration = 0;
   String? _activeUserId;
   String? _lastEventKey;
   DateTime? _lastEventAt;
@@ -55,7 +58,7 @@ class _GlobalReplyNotificationListenerState
     if (!oldWidget.enabled && widget.enabled) {
       _start();
     } else if (oldWidget.enabled && !widget.enabled) {
-      _stopChannels();
+      _stop();
     }
   }
 
@@ -75,46 +78,82 @@ class _GlobalReplyNotificationListenerState
 
   void _handleSession(Session? session) {
     final userId = session?.user.id;
-    if (userId == _activeUserId) return;
-    _stopChannels();
-    _activeUserId = userId;
-    if (userId == null) return;
-
     final accessToken = session?.accessToken;
     if (accessToken != null) {
       SupabaseProvider.client.realtime.setAuth(accessToken);
     }
-    try {
-      _honooChannel = SupabaseProvider.client.channel('reply-honoo-$userId')
-        ..on(
-          RealtimeListenTypes.postgresChanges,
-          ChannelFilter(
-            event: 'INSERT',
-            schema: 'public',
-            table: 'honoo',
-            filter: 'recipient_tag=eq.$userId',
-          ),
-          (dynamic payload, [dynamic _]) =>
-              _handlePayload(payload, ReplyNotificationKind.honoo, userId),
-        )
-        ..subscribe();
-      _hinooChannel = SupabaseProvider.client.channel('reply-hinoo-$userId')
-        ..on(
-          RealtimeListenTypes.postgresChanges,
-          ChannelFilter(
-            event: 'INSERT',
-            schema: 'public',
-            table: 'hinoo',
-            filter: 'recipient_tag=eq.$userId',
-          ),
-          (dynamic payload, [dynamic _]) =>
-              _handlePayload(payload, ReplyNotificationKind.hinoo, userId),
-        )
-        ..subscribe();
-    } catch (_) {
-      _stopChannels();
-      _activeUserId = userId;
+    if (userId == _activeUserId) {
+      if (userId != null && _replyChannel == null) {
+        _connectChannels(userId);
+      }
+      return;
     }
+    _closeRealtime(clearUser: false);
+    _activeUserId = userId;
+    if (userId == null) return;
+    _connectChannels(userId);
+  }
+
+  void _connectChannels(String userId) {
+    _reconnectTimer?.cancel();
+    final generation = ++_channelGeneration;
+    try {
+      final channel =
+          SupabaseProvider.client.channel('reply-events-$userId-$generation')
+            ..on(
+              RealtimeListenTypes.postgresChanges,
+              ChannelFilter(
+                event: 'INSERT',
+                schema: 'public',
+                table: 'honoo',
+                filter: 'recipient_tag=eq.$userId',
+              ),
+              (dynamic payload, [dynamic _]) =>
+                  _handlePayload(payload, ReplyNotificationKind.honoo, userId),
+            )
+            ..on(
+              RealtimeListenTypes.postgresChanges,
+              ChannelFilter(
+                event: 'INSERT',
+                schema: 'public',
+                table: 'hinoo',
+                filter: 'recipient_tag=eq.$userId',
+              ),
+              (dynamic payload, [dynamic _]) =>
+                  _handlePayload(payload, ReplyNotificationKind.hinoo, userId),
+            );
+      _replyChannel = channel;
+      channel.subscribe((status, [error]) {
+        if (!mounted || generation != _channelGeneration) return;
+        if (status == 'SUBSCRIBED') {
+          _reconnectAttempt = 0;
+          _reconnectTimer?.cancel();
+          return;
+        }
+        if (status == 'CHANNEL_ERROR' ||
+            status == 'CLOSED' ||
+            status == 'TIMED_OUT') {
+          _scheduleReconnect(userId);
+        }
+      });
+    } catch (_) {
+      _replyChannel = null;
+      _scheduleReconnect(userId);
+    }
+  }
+
+  void _scheduleReconnect(String userId) {
+    if (_activeUserId != userId || _reconnectTimer?.isActive == true) return;
+    final cappedAttempt = _reconnectAttempt > 5 ? 5 : _reconnectAttempt;
+    final seconds = 1 << cappedAttempt;
+    _reconnectAttempt += 1;
+    _reconnectTimer = Timer(Duration(seconds: seconds), () {
+      if (!mounted || _activeUserId != userId) return;
+      final staleChannel = _replyChannel;
+      _replyChannel = null;
+      staleChannel?.unsubscribe();
+      _connectChannels(userId);
+    });
   }
 
   void _handlePayload(
@@ -134,7 +173,8 @@ class _GlobalReplyNotificationListenerState
 
   void _handleEvent(ReplyNotificationEvent event) {
     final now = DateTime.now();
-    final eventKey = '${event.kind.name}:${event.conversationId}';
+    final eventKey =
+        '${event.kind.name}:${event.replyId ?? event.conversationId}';
     if (_lastEventKey == eventKey &&
         _lastEventAt != null &&
         now.difference(_lastEventAt!) < const Duration(seconds: 2)) {
@@ -142,6 +182,7 @@ class _GlobalReplyNotificationListenerState
     }
     _lastEventKey = eventKey;
     _lastEventAt = now;
+    ReplyNotificationSignal.notifyChanged();
 
     void open() => _openConversation(event.conversationId);
     _systemNotification.show(
@@ -178,20 +219,27 @@ class _GlobalReplyNotificationListenerState
     );
   }
 
-  void _stopChannels() {
+  void _closeRealtime({bool clearUser = true}) {
+    _reconnectTimer?.cancel();
+    _reconnectTimer = null;
+    _channelGeneration += 1;
+    _replyChannel?.unsubscribe();
+    _replyChannel = null;
+    _reconnectAttempt = 0;
+    if (clearUser) _activeUserId = null;
+  }
+
+  void _stop() {
     _replyEventSubscription?.cancel();
     _replyEventSubscription = null;
-    _honooChannel?.unsubscribe();
-    _hinooChannel?.unsubscribe();
-    _honooChannel = null;
-    _hinooChannel = null;
-    _activeUserId = null;
+    _authSubscription?.cancel();
+    _authSubscription = null;
+    _closeRealtime();
   }
 
   @override
   void dispose() {
-    _stopChannels();
-    _authSubscription?.cancel();
+    _stop();
     super.dispose();
   }
 

--- a/lib/Widgets/honoo_dialogs.dart
+++ b/lib/Widgets/honoo_dialogs.dart
@@ -235,6 +235,19 @@ Future<void> showHonooMessageDialog(
   );
 }
 
+Future<void> showReplySavedDialog(
+  BuildContext context, {
+  required String contentName,
+}) {
+  return showHonooMessageDialog(
+    context,
+    message:
+        'Il tuo $contentName è nel tuo Scrigno,\n'
+        'ma soprattutto,\n'
+        'in quello di qualcun altro.',
+  );
+}
+
 void showHonooToast(
   BuildContext context, {
   required String message,

--- a/test/entities/reply_notification_event_test.dart
+++ b/test/entities/reply_notification_event_test.dart
@@ -7,6 +7,7 @@ void main() {
       {
         'eventType': 'INSERT',
         'new': {
+          'id': 'reply-42',
           'destination': 'reply',
           'reply_to': 'root-1',
           'conversation_id': 'conversation-1',
@@ -21,6 +22,7 @@ void main() {
     expect(event, isNotNull);
     expect(event!.conversationId, 'conversation-1');
     expect(event.contentLabel, 'honoo');
+    expect(event.replyId, 'reply-42');
   });
 
   test('riconosce una nuova risposta Hinoo', () {
@@ -48,17 +50,16 @@ void main() {
       String event = 'INSERT',
       String recipient = 'me',
       String sender = 'other',
-    }) =>
-        {
-          'eventType': event,
-          'new': {
-            'destination': 'reply',
-            'reply_to': 'root-1',
-            'conversation_id': 'conversation-1',
-            'recipient_tag': recipient,
-            'user_id': sender,
-          },
-        };
+    }) => {
+      'eventType': event,
+      'new': {
+        'destination': 'reply',
+        'reply_to': 'root-1',
+        'conversation_id': 'conversation-1',
+        'recipient_tag': recipient,
+        'user_id': sender,
+      },
+    };
 
     ReplyNotificationEvent? parse(Map<String, dynamic> value) =>
         ReplyNotificationEvent.fromRealtimePayload(

--- a/test/pages/reply_honoo_flow_test.dart
+++ b/test/pages/reply_honoo_flow_test.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:honoo/Pages/home_page.dart';
+import 'package:honoo/Pages/chest_page.dart';
 import 'package:honoo/Pages/reply_honoo_page.dart';
 import 'package:honoo/Entities/honoo.dart';
 import 'package:honoo/Widgets/honoo_dialogs.dart';
@@ -24,8 +24,9 @@ void main() {
     when(() => honoo.neq(any(), any())).thenAnswer((_) => honoo);
     when(() => hinoo.neq(any(), any())).thenAnswer((_) => hinoo);
     final visit = MockQueryChain();
-    when(() => harness.client.rpc('increment_site_visit'))
-        .thenAnswer((_) => visit);
+    when(
+      () => harness.client.rpc('increment_site_visit'),
+    ).thenAnswer((_) => visit);
   });
 
   tearDown(() {
@@ -33,55 +34,119 @@ void main() {
   });
 
   testWidgets(
-      'ReplyHonooPage: dopo la conferma della risposta torna alla Home',
-      (tester) async {
-    final original = Honoo(
-      1,
-      '“Testo origine”',
-      '',
-      '2024-01-01T00:00:00Z',
-      '2024-01-01T00:00:00Z',
-      'user_1',
-      HonooType.personal,
-    );
+    'ReplyHonooPage: dopo la conferma apre la conversazione nello Scrigno',
+    (tester) async {
+      final original = Honoo(
+        1,
+        '“Testo origine”',
+        '',
+        '2024-01-01T00:00:00Z',
+        '2024-01-01T00:00:00Z',
+        'user_1',
+        HonooType.personal,
+      );
 
-    await tester.pumpWidget(
-      Sizer(
-        builder: (context, orientation, deviceType) {
-          return MaterialApp(
-            home: ReplyHonooPage(
-              originalHonoo: original,
-            ),
-          );
-        },
-      ),
-    );
-    await tester.pumpAndSettle();
+      await tester.pumpWidget(
+        Sizer(
+          builder: (context, orientation, deviceType) {
+            return MaterialApp(home: ReplyHonooPage(originalHonoo: original));
+          },
+        ),
+      );
+      await tester.pumpAndSettle();
 
-    final tf = find.byType(TextField).first;
-    expect(tf, findsOneWidget);
+      final tf = find.byType(TextField).first;
+      expect(tf, findsOneWidget);
 
-    await tester.enterText(tf, '“risposta di prova”');
-    await tester.pump();
+      await tester.enterText(tf, '“risposta di prova”');
+      await tester.pump();
 
-    final sendButton = find.bySemanticsLabel('Invia risposta');
-    expect(sendButton, findsOneWidget);
+      final sendButton = find.bySemanticsLabel('Invia risposta');
+      expect(sendButton, findsOneWidget);
 
-    await tester.tap(sendButton);
-    await tester.pump();
-    await tester.pump();
+      await tester.tap(sendButton);
+      await tester.pump();
+      await tester.pump();
 
-    expect(find.byType(HonooMessageDialog), findsOneWidget);
-    Navigator.of(
-      tester.element(find.byType(HonooMessageDialog)),
-      rootNavigator: true,
-    ).pop();
-    await tester.pumpAndSettle();
+      expect(find.byType(HonooMessageDialog), findsOneWidget);
+      expect(
+        find.text(
+          'Il tuo honoo è nel tuo Scrigno,\n'
+          'ma soprattutto,\n'
+          'in quello di qualcun altro',
+        ),
+        findsOneWidget,
+      );
+      Navigator.of(
+        tester.element(find.byType(HonooMessageDialog)),
+        rootNavigator: true,
+      ).pop();
+      await tester.pumpAndSettle();
 
-    expect(find.byType(HomePage), findsOneWidget);
-    expect(find.byType(ReplyHonooPage), findsNothing);
+      expect(find.byType(ChestPage), findsOneWidget);
+      expect(find.byType(ReplyHonooPage), findsNothing);
 
-    await tester.pumpWidget(const SizedBox.shrink());
-    await tester.pump(const Duration(seconds: 25));
-  });
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump(const Duration(seconds: 25));
+    },
+  );
+
+  testWidgets(
+    'ReplyHonooPage: nello Scrigno restituisce la conversazione aggiornata',
+    (tester) async {
+      final result = ValueNotifier<String?>(null);
+      final original = Honoo(
+        1,
+        '“Testo origine”',
+        '',
+        '2024-01-01T00:00:00Z',
+        '2024-01-01T00:00:00Z',
+        'user_1',
+        HonooType.personal,
+      );
+
+      await tester.pumpWidget(
+        Sizer(
+          builder: (context, orientation, deviceType) {
+            return MaterialApp(
+              home: Builder(
+                builder: (context) => Scaffold(
+                  body: ElevatedButton(
+                    onPressed: () async {
+                      result.value = await Navigator.of(context).push<String>(
+                        MaterialPageRoute(
+                          builder: (_) => ReplyHonooPage(
+                            originalHonoo: original,
+                            returnToPreviousOnAnswer: true,
+                          ),
+                        ),
+                      );
+                    },
+                    child: const Text('Rispondi'),
+                  ),
+                ),
+              ),
+            );
+          },
+        ),
+      );
+
+      await tester.tap(find.text('Rispondi'));
+      await tester.pumpAndSettle();
+      await tester.enterText(find.byType(TextField).first, 'risposta');
+      await tester.tap(find.bySemanticsLabel('Invia risposta'));
+      await tester.pump();
+      await tester.pump();
+
+      Navigator.of(
+        tester.element(find.byType(HonooMessageDialog)),
+        rootNavigator: true,
+      ).pop();
+      await tester.pumpAndSettle();
+
+      expect(result.value, '1');
+      expect(find.byType(ReplyHonooPage), findsNothing);
+      expect(find.text('Rispondi'), findsOneWidget);
+    },
+  );
 }

--- a/test/widgets/global_reply_notification_listener_test.dart
+++ b/test/widgets/global_reply_notification_listener_test.dart
@@ -6,6 +6,7 @@ import 'package:honoo/Entities/reply_notification_event.dart';
 import 'package:honoo/Pages/chest_page.dart';
 import 'package:honoo/Services/reply_system_notification.dart';
 import 'package:honoo/Widgets/global_reply_notification_listener.dart';
+import 'package:honoo/Utility/reply_notification_signal.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../test_supabase_helper.dart';
@@ -59,6 +60,7 @@ void main() {
     (tester) async {
       final navigatorKey = GlobalKey<NavigatorState>();
       final notification = _FakeReplySystemNotification();
+      final initialRevision = ReplyNotificationSignal.revision.value;
 
       await tester.pumpWidget(
         GlobalReplyNotificationListener(
@@ -85,6 +87,10 @@ void main() {
       expect(notification.contentLabel, 'hinoo');
       expect(notification.conversationId, 'conversation-42');
       expect(notification.onTap, isNotNull);
+      expect(
+        ReplyNotificationSignal.revision.value,
+        greaterThan(initialRevision),
+      );
       expect(
         find.text('Hai ricevuto una risposta al tuo hinoo'),
         findsOneWidget,

--- a/test/widgets/unified_thread_reveal_test.dart
+++ b/test/widgets/unified_thread_reveal_test.dart
@@ -125,6 +125,77 @@ void main() {
     expect(find.byType(PageView), findsNothing);
   });
 
+  testWidgets('una nuova risposta riavvia il reveal dopo il refresh', (
+    tester,
+  ) async {
+    tester.view.devicePixelRatio = 1;
+    tester.view.physicalSize = const Size(600, 900);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    addTearDown(tester.view.resetPhysicalSize);
+
+    final root = ConversationEntry.honoo(
+      honoo(
+        id: 'root-refresh',
+        text: 'Padre aggiornato',
+        owner: 'me',
+        createdAt: '2026-07-20T10:00:00Z',
+      ),
+    );
+    final firstReply = ConversationEntry.honoo(
+      honoo(
+        id: 'reply-refresh-1',
+        text: 'Prima risposta',
+        owner: 'other',
+        createdAt: '2026-07-20T11:00:00Z',
+        type: HonooType.answer,
+        replyTo: 'root-refresh',
+      ),
+    );
+    final secondReply = ConversationEntry.honoo(
+      honoo(
+        id: 'reply-refresh-2',
+        text: 'Seconda risposta appena salvata',
+        owner: 'me',
+        createdAt: '2026-07-20T12:00:00Z',
+        type: HonooType.answer,
+        replyTo: 'reply-refresh-1',
+      ),
+    );
+    var entries = [root, firstReply];
+
+    Widget app(int refreshToken) => MaterialApp(
+      home: Scaffold(
+        body: UnifiedThreadView(
+          key: const Key('refreshable-thread'),
+          conversationId: 'conversation-1',
+          maxWidth: 600,
+          maxHeight: 700,
+          isActive: true,
+          currentUserId: 'me',
+          refreshToken: refreshToken,
+          conversationLoader: (_) async => entries,
+        ),
+      ),
+    );
+
+    await tester.pumpWidget(app(0));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 1000));
+
+    entries = [root, firstReply, secondReply];
+    await tester.pumpWidget(app(1));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+    await tester.pump(const Duration(milliseconds: 350));
+
+    expect(find.text('Seconda risposta appena salvata'), findsOneWidget);
+    final foreground = tester.widget<Transform>(
+      find.byKey(const Key('reply_reveal_foreground')),
+    );
+    expect(foreground.transform.getTranslation().y, lessThan(0));
+    expect(find.byKey(const Key('reply_reveal_parent')), findsOneWidget);
+  });
+
   testWidgets('un errore di conversazione mostra Riprova', (tester) async {
     await tester.pumpWidget(
       MaterialApp(


### PR DESCRIPTION
## Cosa cambia
- dopo una risposta apre o aggiorna la conversazione esatta nello Scrigno
- uniforma il popup di conferma per honoo e hinoo
- riavvia lo swipe/reveal quando compare una nuova risposta
- aggiorna subito il badge tramite il segnale realtime, mantenendo il polling di sicurezza
- riconnette automaticamente il listener notifiche e deduplica per ID della risposta

## Verifiche
- flutter analyze --no-pub
- flutter test --no-pub
- test mirati per navigazione, popup, reveal e notifiche