### PR TITLE
Fix house authorization, campanello creation, and notifications

### DIFF
--- a/lib/Controller/campanelli_controller.dart
+++ b/lib/Controller/campanelli_controller.dart
@@ -299,11 +299,12 @@ class CampanelliController extends ChangeNotifier {
       if (await _adminService.isCurrentUserAdmin()) {
         return CasaRequestResult.administrator;
       }
-      await _houseInviteService.createPendingRequest(
+      final created = await _houseInviteService.createPendingRequest(
         userId: user.id,
         email: user.email ?? '',
         createdAt: DateTime.now(),
       );
+      if (!created) return CasaRequestResult.alreadyPresent;
       _publish(_state.copyWith(hasPendingOrAcceptedInvite: true));
       return CasaRequestResult.success;
     } catch (error) {
@@ -388,18 +389,20 @@ class CampanelliController extends ChangeNotifier {
     required String email,
     DateTime? createdAt,
   }) async {
-    await _houseInviteService.createPendingRequest(
+    final created = await _houseInviteService.createPendingRequest(
       userId: userId,
       email: email,
       createdAt: createdAt ?? DateTime.now(),
     );
-    _publish(_state.copyWith(hasPendingOrAcceptedInvite: true));
+    if (created) {
+      _publish(_state.copyWith(hasPendingOrAcceptedInvite: true));
+    }
   }
 
   Future<void> startPendingKnockRefresh({
     required List<String> ownedHinooIds,
     required void Function() onChanged,
-    Duration interval = const Duration(seconds: 60),
+    Duration interval = const Duration(seconds: 15),
   }) async {
     _pendingKnockRefreshTimer?.cancel();
     final ids = List<String>.unmodifiable(ownedHinooIds);

--- a/lib/Pages/admin_menu_page.dart
+++ b/lib/Pages/admin_menu_page.dart
@@ -45,7 +45,7 @@ class _AdminMenuPageState extends State<AdminMenuPage> {
   RealtimeChannel? _statsChannel;
   bool _loadingPendingInvites = false;
   List<Map<String, dynamic>> _pendingInvites = const [];
-
+  final Set<String> _reviewingInviteIds = <String>{};
 
   @override
   void initState() {
@@ -60,7 +60,7 @@ class _AdminMenuPageState extends State<AdminMenuPage> {
         _loadPendingInvites();
         _subscribeStats();
         _statsRefreshTimer = Timer.periodic(
-          const Duration(seconds: 30),
+          const Duration(seconds: 15),
           (_) {
             _loadVisits();
             _loadMoonCounts();
@@ -124,6 +124,30 @@ class _AdminMenuPageState extends State<AdminMenuPage> {
       setState(() => _pendingInvites = list);
     } finally {
       if (mounted) setState(() => _loadingPendingInvites = false);
+    }
+  }
+
+  Future<void> _reviewHouseRequest(String inviteId, bool approved) async {
+    if (inviteId.isEmpty || _reviewingInviteIds.contains(inviteId)) return;
+    setState(() => _reviewingInviteIds.add(inviteId));
+    try {
+      final updated = await _adminService.reviewHouseRequest(
+        inviteId: inviteId,
+        approved: approved,
+      );
+      if (!mounted) return;
+      showHonooToast(
+        context,
+        message: updated
+            ? (approved ? 'Richiesta approvata.' : 'Richiesta rifiutata.')
+            : 'Richiesta già gestita.',
+      );
+      await _loadPendingInvites();
+    } catch (e) {
+      if (!mounted) return;
+      showHonooToast(context, message: 'Errore autorizzazione: $e');
+    } finally {
+      if (mounted) setState(() => _reviewingInviteIds.remove(inviteId));
     }
   }
 
@@ -232,13 +256,11 @@ class _AdminMenuPageState extends State<AdminMenuPage> {
         return;
       }
       final hasCasa = await _adminService.hasCasaForUser(target.authUserId);
-      final hasCampanello =
-          await _adminService.hasCampanelloForUser(target.authUserId);
-      if (hasCasa || hasCampanello) {
+      if (hasCasa) {
         if (!mounted) return;
         showHonooToast(
           context,
-          message: 'Utente già con casa o campanello.',
+          message: 'Utente già con casa.',
         );
         return;
       }
@@ -331,17 +353,56 @@ class _AdminMenuPageState extends State<AdminMenuPage> {
                       ),
                       const SizedBox(height: 8),
                       ..._pendingInvites.map((row) {
+                        final String inviteId = (row['id']?.toString() ?? '').trim();
                         final String email = (row['email']?.toString() ?? '').trim();
                         final String userId = (row['user_id']?.toString() ?? '').trim();
                         final String label = email.isNotEmpty ? email : (userId.isNotEmpty ? userId : 'Richiesta');
                         final String when = (row['created_at']?.toString() ?? '');
+                        final bool reviewing = _reviewingInviteIds.contains(inviteId);
                         return Padding(
                           padding: const EdgeInsets.symmetric(vertical: 4),
-                          child: Text(
-                            '• $label — $when',
-                            style: GoogleFonts.lora(
-                              color: HonooColor.onBackground.withValues(alpha: 0.9),
-                              fontSize: 14,
+                          child: Container(
+                            padding: const EdgeInsets.all(12),
+                            decoration: BoxDecoration(
+                              color: Colors.white.withValues(alpha: 0.07),
+                              borderRadius: BorderRadius.circular(14),
+                            ),
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.stretch,
+                              children: [
+                                Text(
+                                  '$label — $when',
+                                  style: GoogleFonts.lora(
+                                    color: HonooColor.onBackground.withValues(alpha: 0.9),
+                                    fontSize: 14,
+                                  ),
+                                ),
+                                const SizedBox(height: 8),
+                                Row(
+                                  mainAxisAlignment: MainAxisAlignment.end,
+                                  children: [
+                                    TextButton(
+                                      onPressed: reviewing
+                                          ? null
+                                          : () => _reviewHouseRequest(inviteId, false),
+                                      child: const Text('Rifiuta'),
+                                    ),
+                                    const SizedBox(width: 8),
+                                    ElevatedButton(
+                                      onPressed: reviewing
+                                          ? null
+                                          : () => _reviewHouseRequest(inviteId, true),
+                                      child: reviewing
+                                          ? const SizedBox(
+                                              width: 18,
+                                              height: 18,
+                                              child: CircularProgressIndicator(strokeWidth: 2),
+                                            )
+                                          : const Text('Approva'),
+                                    ),
+                                  ],
+                                ),
+                              ],
                             ),
                           ),
                         );

--- a/lib/Pages/casa_builder_page.dart
+++ b/lib/Pages/casa_builder_page.dart
@@ -5,6 +5,7 @@ import 'dart:ui' as ui;
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:google_fonts/google_fonts.dart';
+import 'package:honoo/Entities/hinoo.dart';
 import 'package:honoo/Services/hinoo_storage_uploader.dart';
 import 'package:honoo/Services/house_invite_service.dart';
 import 'package:honoo/Services/supabase_provider.dart';
@@ -20,9 +21,9 @@ import 'package:image_picker/image_picker.dart';
 import 'home_page.dart';
 
 class CasaBuilderPage extends StatefulWidget {
-  const CasaBuilderPage({super.key, required this.campanelloHinooId});
+  const CasaBuilderPage({super.key, required this.campanello});
 
-  final String campanelloHinooId;
+  final HinooDraft campanello;
 
   @override
   State<CasaBuilderPage> createState() => _CasaBuilderPageState();
@@ -176,17 +177,11 @@ class _CasaBuilderPageState extends State<CasaBuilderPage> {
       );
       setState(() => _isUploadingImage = false);
 
-      await SupabaseProvider.client.from('case').upsert({
-        'owner_id': user.id,
-        'campanello_hinoo_id': widget.campanelloHinooId,
-        'house_image_url': imageUrl,
-        'bg_transform': _imageController.value.storage.toList(),
-        'created_at': DateTime.now().toIso8601String(),
-      }, onConflict: 'owner_id');
-
-      try {
-        await _inviteService.markInvitesAccepted(user.id);
-      } catch (_) {}
+      await _inviteService.createHouseWithCampanello(
+        campanello: widget.campanello,
+        houseImageUrl: imageUrl,
+        bgTransform: _imageController.value.storage.toList(),
+      );
 
       if (!mounted) return;
       showHonooToast(context, message: 'Casa creata.');

--- a/lib/Pages/new_hinoo_page.dart
+++ b/lib/Pages/new_hinoo_page.dart
@@ -311,11 +311,10 @@ class _NewHinooPageState extends State<NewHinooPage>
       }
 
       if (widget.isCampanello) {
-        final hinooId = await _controller.saveToChestAndReturnId(hinooDraft);
         if (!mounted) return;
         Navigator.of(context).pushReplacement(
           MaterialPageRoute(
-            builder: (_) => CasaBuilderPage(campanelloHinooId: hinooId),
+            builder: (_) => CasaBuilderPage(campanello: hinooDraft),
           ),
         );
         return;
@@ -433,11 +432,10 @@ class _NewHinooPageState extends State<NewHinooPage>
       }
     }
 
-    final HinooType type =
-        widget.forcedType ??
-        (widget.isCampanello
-            ? HinooType.answer
-            : (widget.isReply ? HinooType.answer : HinooType.personal));
+    final HinooType type = widget.isCampanello
+        ? HinooType.personal
+        : (widget.forcedType ??
+            (widget.isReply ? HinooType.answer : HinooType.personal));
 
     // Se è una risposta e non è stato passato esplicitamente un conversationId,
     // usa replyTo come conversationId per garantire il raggruppamento.

--- a/lib/Services/admin_service.dart
+++ b/lib/Services/admin_service.dart
@@ -230,7 +230,7 @@ class AdminService {
         .from('house_invites')
         .select('id,status')
         .ilike('email', email)
-        .in_('status', ['pending', 'accepted']).limit(1);
+        .in_('status', ['requested', 'pending', 'accepted']).limit(1);
     if (rows is! List || rows.isEmpty) return false;
     return true;
   }
@@ -240,7 +240,7 @@ class AdminService {
     final rows = await _client
         .from('house_invites')
         .select('id,email,user_id,created_at,status')
-        .eq('status', 'pending')
+        .eq('status', 'requested')
         .order('created_at', ascending: !newestFirst);
     if (rows is! List) return const [];
     return rows.whereType<Map<String, dynamic>>().toList();
@@ -250,7 +250,7 @@ class AdminService {
     final rows = await _client
         .from('house_invites')
         .select('id')
-        .eq('status', 'pending');
+        .eq('status', 'requested');
     if (rows is! List) return 0;
     return rows.length;
   }
@@ -262,37 +262,10 @@ class AdminService {
     return rows is List && rows.isNotEmpty;
   }
 
-  Future<bool> hasCampanelloForUser(String userId) async {
-    if (userId.trim().isEmpty) return false;
-    final rows = await _client
-        .from('campanelli')
-        .select('id')
-        .eq('owner_id', userId)
-        .limit(1);
-    return rows is List && rows.isNotEmpty;
-  }
-
   Future<Set<String>> fetchExistingCaseOwners(List<String> userIds) async {
     if (userIds.isEmpty) return {};
     final rows =
         await _client.from('case').select('owner_id').in_('owner_id', userIds);
-
-    final existing = <String>{};
-    for (final row in (rows as List)) {
-      if (row is! Map) continue;
-      final String id = row['owner_id']?.toString() ?? '';
-      if (id.isNotEmpty) existing.add(id);
-    }
-    return existing;
-  }
-
-  Future<Set<String>> fetchExistingCampanelliOwners(
-      List<String> userIds) async {
-    if (userIds.isEmpty) return {};
-    final rows = await _client
-        .from('campanelli')
-        .select('owner_id')
-        .in_('owner_id', userIds);
 
     final existing = <String>{};
     for (final row in (rows as List)) {
@@ -313,12 +286,10 @@ class AdminService {
 
     final existing = await fetchExistingInvites(filtered);
     final existingCases = await fetchExistingCaseOwners(filtered);
-    final existingCampanelli = await fetchExistingCampanelliOwners(filtered);
     final toInsert = filtered
         .where((id) =>
             !existing.contains(id) &&
-            !existingCases.contains(id) &&
-            !existingCampanelli.contains(id))
+            !existingCases.contains(id))
         .toList();
     if (toInsert.isEmpty) return 0;
 
@@ -361,6 +332,20 @@ class AdminService {
       'created_at': DateTime.now().toIso8601String(),
     });
     return true;
+  }
+
+  Future<bool> reviewHouseRequest({
+    required String inviteId,
+    required bool approved,
+  }) async {
+    final result = await _client.rpc(
+      'admin_review_house_request',
+      params: {
+        'p_invite_id': inviteId,
+        'p_approved': approved,
+      },
+    );
+    return result == true;
   }
 
   Future<dynamic> _safeRpc(String fn, {Map<String, dynamic>? params}) async {

--- a/lib/Services/house_invite_service.dart
+++ b/lib/Services/house_invite_service.dart
@@ -1,3 +1,4 @@
+import 'package:honoo/Entities/hinoo.dart';
 import 'package:honoo/Services/supabase_provider.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
@@ -18,25 +19,33 @@ class HouseInviteService {
         .from('house_invites')
         .select('status')
         .eq('user_id', userId)
-        .in_('status', ['pending', 'accepted']).limit(1);
+        .in_('status', ['requested', 'pending', 'accepted']).limit(1);
     if (rows is! List || rows.isEmpty) return false;
     final row = rows.first;
     if (row is! Map) return false;
     final status = row['status']?.toString();
-    return status == 'pending' || status == 'accepted';
+    return status == 'requested' || status == 'pending' || status == 'accepted';
   }
 
-  Future<void> createPendingRequest({
+  Future<bool> hasAuthorizedInvite(String userId) async {
+    final rows = await _client
+        .from('house_invites')
+        .select('status')
+        .eq('user_id', userId)
+        .in_('status', ['pending', 'accepted']).limit(1);
+    return rows is List && rows.isNotEmpty;
+  }
+
+  Future<bool> createPendingRequest({
     required String userId,
     required String email,
     required DateTime createdAt,
   }) async {
-    await _client.from('house_invites').insert({
-      'user_id': userId,
-      if (email.isNotEmpty) 'email': email,
-      'status': 'pending',
-      'created_at': createdAt.toIso8601String(),
-    });
+    final result = await _client.rpc(
+      'request_house_invite',
+      params: {'p_email': email},
+    );
+    return result == true;
   }
 
   Future<void> syncInvitesForEmail(String email) async {
@@ -50,12 +59,37 @@ class HouseInviteService {
   Future<void> markInvitesAccepted(String userId) async {
     await _client
         .from('house_invites')
-        .update({'status': 'accepted'}).eq('user_id', userId);
+        .update({'status': 'accepted'})
+        .eq('user_id', userId)
+        .eq('status', 'pending');
   }
 
   Future<void> markInvitesDeclined(String userId) async {
     await _client
         .from('house_invites')
-        .update({'status': 'declined'}).eq('user_id', userId);
+        .update({'status': 'declined'})
+        .eq('user_id', userId)
+        .eq('status', 'pending');
+  }
+
+  Future<String> createHouseWithCampanello({
+    required HinooDraft campanello,
+    required String houseImageUrl,
+    required List<double> bgTransform,
+  }) async {
+    if (campanello.type == HinooType.answer) {
+      throw ArgumentError('Il campanello non può essere una risposta.');
+    }
+    final result = await _client.rpc(
+      'create_house_with_campanello',
+      params: {
+        'p_pages': campanello.pages.map((page) => page.toJson()).toList(),
+        'p_house_image_url': houseImageUrl,
+        'p_bg_transform': bgTransform,
+      },
+    );
+    final id = result?.toString() ?? '';
+    if (id.isEmpty) throw StateError('ID campanello mancante.');
+    return id;
   }
 }

--- a/lib/Widgets/global_invite_listener.dart
+++ b/lib/Widgets/global_invite_listener.dart
@@ -29,6 +29,7 @@ class _GlobalInviteListenerState extends State<GlobalInviteListener> {
   Timer? _inviteRefreshTimer;
   bool _checkingInviteFlow = false;
   bool _dialogOpen = false;
+  bool _inviteDeferred = false;
   bool _started = false;
   RealtimeChannel? _inviteChannel;
   String? _inviteChannelUserId;
@@ -70,6 +71,7 @@ class _GlobalInviteListenerState extends State<GlobalInviteListener> {
     _inviteChannelUserId = null;
     _inviteChannelEmail = null;
     _dialogOpen = false;
+    _inviteDeferred = false;
     if (session == null) return;
 
     _inviteService ??= HouseInviteService();
@@ -80,7 +82,7 @@ class _GlobalInviteListenerState extends State<GlobalInviteListener> {
       _subscribeInviteEmailChannel(email);
     }
     _inviteRefreshTimer = Timer.periodic(
-      const Duration(seconds: 60),
+      const Duration(seconds: 15),
       (_) => _checkInviteFlow(),
     );
     WidgetsBinding.instance.addPostFrameCallback((_) => _checkInviteFlow());
@@ -143,7 +145,6 @@ class _GlobalInviteListenerState extends State<GlobalInviteListener> {
   }
 
   void _handleInviteChange(dynamic payload, [dynamic _]) {
-    _checkInviteFlow();
     final eventType = payload is Map
         ? (payload['eventType'] ?? payload['event_type'])
         : null;
@@ -151,6 +152,15 @@ class _GlobalInviteListenerState extends State<GlobalInviteListener> {
     if (event != null && event != 'insert' && event != 'update') {
       return;
     }
+    final record = payload is Map
+        ? (payload['new'] ?? payload['newRecord'] ?? payload['record'])
+        : null;
+    final status = record is Map ? record['status']?.toString() : null;
+    if (status != null && status != 'pending' && status != 'accepted') {
+      return;
+    }
+    if (status == 'pending') _inviteDeferred = false;
+    _checkInviteFlow();
     final now = DateTime.now();
     if (_lastInviteToastAt != null &&
         now.difference(_lastInviteToastAt!) < const Duration(seconds: 3)) {
@@ -167,7 +177,7 @@ class _GlobalInviteListenerState extends State<GlobalInviteListener> {
   }
 
   Future<void> _checkInviteFlow() async {
-    if (_checkingInviteFlow || _dialogOpen) return;
+    if (_checkingInviteFlow || _dialogOpen || _inviteDeferred) return;
     _checkingInviteFlow = true;
 
     final user = SupabaseProvider.client.auth.currentUser;
@@ -191,24 +201,25 @@ class _GlobalInviteListenerState extends State<GlobalInviteListener> {
         return;
       }
 
-      var hasInvite = await inviteService.hasPendingOrAcceptedInvite(user.id);
+      var hasInvite = await inviteService.hasAuthorizedInvite(user.id);
       if (!hasInvite && email != null && email.isNotEmpty) {
         try {
           await inviteService.syncInvitesForEmail(email);
         } catch (_) {}
-        hasInvite = await inviteService.hasPendingOrAcceptedInvite(user.id);
+        hasInvite = await inviteService.hasAuthorizedInvite(user.id);
       }
       if (!hasInvite) {
         return;
       }
 
-      await inviteService.markInvitesAccepted(user.id);
-
       final bool? accepted = await _showCasaInviteDialog();
       if (accepted != true) {
-        await inviteService.markInvitesDeclined(user.id);
+        _inviteDeferred = true;
         return;
       }
+
+      await inviteService.markInvitesAccepted(user.id);
+      _inviteDeferred = true;
 
       final navigator = widget.navigatorKey.currentState;
       if (navigator == null) return;

--- a/supabase/migrations/20260803120000_fix_house_request_authorization_flow.sql
+++ b/supabase/migrations/20260803120000_fix_house_request_authorization_flow.sql
@@ -1,0 +1,224 @@
+-- Keep house requests separate from invitations authorized by an admin and
+-- create the campanello + house in one transaction.
+
+alter table public.house_invites
+  alter column invited_by drop not null;
+
+alter table public.house_invites
+  drop constraint if exists house_invites_status_check;
+
+alter table public.house_invites
+  add constraint house_invites_status_check
+  check (status in ('requested', 'pending', 'accepted', 'declined'));
+
+drop policy if exists "Invites select admin or owner" on public.house_invites;
+create policy "Invites select admin owner or email"
+  on public.house_invites
+  for select
+  to authenticated
+  using (
+    public.is_admin()
+    or auth.uid() = user_id
+    or (
+      user_id is null
+      and email is not null
+      and lower(email) = lower(coalesce(auth.jwt() ->> 'email', ''))
+    )
+  );
+
+drop policy if exists "Invites update owner status" on public.house_invites;
+create policy "Invites update owner authorized status"
+  on public.house_invites
+  for update
+  to authenticated
+  using (
+    auth.uid() = user_id
+    and status in ('pending', 'accepted')
+  )
+  with check (
+    auth.uid() = user_id
+    and status in ('accepted', 'declined')
+  );
+
+drop policy if exists "Invites update admin" on public.house_invites;
+create policy "Invites update admin"
+  on public.house_invites
+  for update
+  to authenticated
+  using (public.is_admin())
+  with check (public.is_admin());
+
+create or replace function public.request_house_invite(p_email text default null)
+returns boolean
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  requester_id uuid := auth.uid();
+begin
+  if requester_id is null then
+    raise exception 'Not authenticated';
+  end if;
+
+  perform pg_advisory_xact_lock(hashtextextended(requester_id::text, 0));
+
+  if public.is_admin() then
+    raise exception 'Administrators cannot request a house invitation';
+  end if;
+
+  if exists (
+    select 1 from public."case" where owner_id = requester_id
+  ) or exists (
+    select 1
+    from public.house_invites
+    where user_id = requester_id
+      and status in ('requested', 'pending', 'accepted')
+  ) then
+    return false;
+  end if;
+
+  insert into public.house_invites (user_id, email, invited_by, status)
+  values (
+    requester_id,
+    nullif(btrim(coalesce(p_email, '')), ''),
+    null,
+    'requested'
+  );
+
+  return true;
+end;
+$$;
+
+revoke all on function public.request_house_invite(text) from public;
+grant execute on function public.request_house_invite(text) to authenticated;
+
+create or replace function public.admin_review_house_request(
+  p_invite_id uuid,
+  p_approved boolean
+)
+returns boolean
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+begin
+  if not public.is_admin() then
+    raise exception 'Admin access required';
+  end if;
+
+  update public.house_invites
+  set status = case when p_approved then 'pending' else 'declined' end,
+      invited_by = auth.uid()
+  where id = p_invite_id
+    and status = 'requested';
+
+  return found;
+end;
+$$;
+
+revoke all on function public.admin_review_house_request(uuid, boolean) from public;
+grant execute on function public.admin_review_house_request(uuid, boolean)
+  to authenticated;
+
+create or replace function public.create_house_with_campanello(
+  p_pages jsonb,
+  p_house_image_url text,
+  p_bg_transform jsonb
+)
+returns uuid
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  owner_uid uuid := auth.uid();
+  campanello_id uuid;
+begin
+  if owner_uid is null then
+    raise exception 'Not authenticated';
+  end if;
+
+  if jsonb_typeof(p_pages) <> 'array'
+     or jsonb_array_length(p_pages) < 1
+     or jsonb_array_length(p_pages) > 9 then
+    raise exception 'Invalid campanello pages';
+  end if;
+
+  if nullif(btrim(coalesce(p_house_image_url, '')), '') is null then
+    raise exception 'House image is required';
+  end if;
+
+  perform pg_advisory_xact_lock(hashtextextended(owner_uid::text, 1));
+
+  if exists (select 1 from public."case" where owner_id = owner_uid) then
+    raise exception 'House already exists';
+  end if;
+
+  if not exists (
+    select 1
+    from public.house_invites
+    where user_id = owner_uid
+      and status = 'accepted'
+  ) then
+    raise exception 'An accepted house invitation is required';
+  end if;
+
+  insert into public.hinoo (user_id, pages, type)
+  values (owner_uid, p_pages, 'personal'::public.hinoo_type)
+  returning id into campanello_id;
+
+  insert into public."case" (
+    owner_id,
+    campanello_hinoo_id,
+    house_image_url,
+    bg_transform
+  ) values (
+    owner_uid,
+    campanello_id,
+    p_house_image_url,
+    p_bg_transform
+  );
+
+  return campanello_id;
+end;
+$$;
+
+revoke all on function public.create_house_with_campanello(jsonb, text, jsonb)
+  from public;
+grant execute on function public.create_house_with_campanello(jsonb, text, jsonb)
+  to authenticated;
+
+drop policy if exists "House access select visitor" on public.house_access;
+create policy "House access select visitor"
+  on public.house_access
+  for select
+  to authenticated
+  using (visitor_id = auth.uid());
+
+alter table public.house_invites replica identity full;
+alter table public.house_access replica identity full;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_publication_tables
+    where pubname = 'supabase_realtime'
+      and schemaname = 'public'
+      and tablename = 'house_invites'
+  ) then
+    alter publication supabase_realtime add table public.house_invites;
+  end if;
+
+  if not exists (
+    select 1
+    from pg_publication_tables
+    where pubname = 'supabase_realtime'
+      and schemaname = 'public'
+      and tablename = 'house_access'
+  ) then
+    alter publication supabase_realtime add table public.house_access;
+  end if;
+end
+$$;

--- a/test/controllers/campanelli_controller_test.dart
+++ b/test/controllers/campanelli_controller_test.dart
@@ -362,7 +362,7 @@ void main() {
           userId: 'user-1',
           email: 'user@example.com',
           createdAt: createdAt,
-        )).thenAnswer((_) async {});
+        )).thenAnswer((_) async => true);
 
     await controller.createPendingHouseRequest(
       userId: 'user-1',
@@ -407,7 +407,7 @@ void main() {
             userId: 'user-1',
             email: 'user@example.com',
             createdAt: any(named: 'createdAt'),
-          )).thenAnswer((_) async {});
+          )).thenAnswer((_) async => true);
 
       expect(
         await controller.requestHouseInvite(),

--- a/test/services/house_invite_service_test.dart
+++ b/test/services/house_invite_service_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
+import 'package:honoo/Entities/hinoo.dart';
 import 'package:honoo/Services/house_invite_service.dart';
 
 class _MockClient extends Mock implements SupabaseClient {}
@@ -51,7 +52,7 @@ void main() {
     when(() => chain.limit(any())).thenAnswer((_) => chain);
   });
 
-  test('hasPendingOrAcceptedInvite filtra status pending/accepted', () async {
+  test('hasPendingOrAcceptedInvite include richieste e inviti aperti', () async {
     chain.queueResponse([
       {'status': 'pending'}
     ]);
@@ -62,26 +63,84 @@ void main() {
     verify(() => client.from('house_invites')).called(1);
     verify(() => chain.select('status')).called(1);
     verify(() => chain.eq('user_id', 'user-1')).called(1);
-    verify(() => chain.in_('status', ['pending', 'accepted'])).called(1);
+    verify(() => chain.in_('status', ['requested', 'pending', 'accepted']))
+        .called(1);
     verify(() => chain.limit(1)).called(1);
   });
 
-  test('createPendingRequest mantiene il payload della richiesta', () async {
+  test('createPendingRequest usa la RPC protetta', () async {
     final createdAt = DateTime.utc(2026, 7, 18, 12);
-    when(() => chain.insert(any())).thenAnswer((_) => chain);
-    chain.queueResponse(<String, dynamic>{});
+    when(() => client.rpc(
+          'request_house_invite',
+          params: any(named: 'params'),
+        )).thenAnswer((_) => chain);
+    chain.queueResponse(true);
 
-    await service.createPendingRequest(
+    final created = await service.createPendingRequest(
       userId: 'user-1',
       email: 'user@example.com',
       createdAt: createdAt,
     );
 
-    verify(() => chain.insert({
-          'user_id': 'user-1',
-          'email': 'user@example.com',
-          'status': 'pending',
-          'created_at': '2026-07-18T12:00:00.000Z',
-        })).called(1);
+    expect(created, isTrue);
+    verify(() => client.rpc(
+          'request_house_invite',
+          params: {'p_email': 'user@example.com'},
+        )).called(1);
+  });
+
+  test('createHouseWithCampanello salva campanello e casa atomici', () async {
+    when(() => client.rpc(
+          'create_house_with_campanello',
+          params: any(named: 'params'),
+        )).thenAnswer((_) => chain);
+    chain.queueResponse('campanello-1');
+    const draft = HinooDraft(
+      pages: [
+        HinooSlide(
+          backgroundImage: 'https://example.com/background.png',
+          text: 'Suona qui',
+          isTextWhite: true,
+        ),
+      ],
+    );
+
+    final id = await service.createHouseWithCampanello(
+      campanello: draft,
+      houseImageUrl: 'https://example.com/house.png',
+      bgTransform: const [1, 0, 0, 1, 2, 3],
+    );
+
+    expect(id, 'campanello-1');
+    verify(() => client.rpc(
+          'create_house_with_campanello',
+          params: {
+            'p_pages': draft.pages.map((page) => page.toJson()).toList(),
+            'p_house_image_url': 'https://example.com/house.png',
+            'p_bg_transform': [1, 0, 0, 1, 2, 3],
+          },
+        )).called(1);
+  });
+
+  test('createHouseWithCampanello rifiuta bozze risposta', () async {
+    const draft = HinooDraft(
+      type: HinooType.answer,
+      pages: [
+        HinooSlide(
+          backgroundImage: null,
+          text: 'Risposta',
+          isTextWhite: false,
+        ),
+      ],
+    );
+
+    expect(
+      () => service.createHouseWithCampanello(
+        campanello: draft,
+        houseImageUrl: 'https://example.com/house.png',
+        bgTransform: const [1, 0, 0, 1, 0, 0],
+      ),
+      throwsArgumentError,
+    );
   });
 }


### PR DESCRIPTION
## What
- separates user house requests (`requested`) from administrator-authorized invitations (`pending`)
- adds administrator approve/reject actions and protected Supabase RPCs
- creates the campanello Hinoo and house atomically in one database transaction
- enables the required Realtime publications/RLS visibility and reduces fallback polling to 15 seconds
- defers invitations safely when the user chooses “Non ora” instead of declining them
- adds service/controller coverage for the corrected request and creation flow

## Why
The campanello draft was incorrectly classified as an `answer`, so saving it reached reply validation without `reply_to` or a campanello/conversation id. User requests also attempted a direct `pending` insert that conflicted with the schema and admin-only RLS, while the UI accepted invitations before explicit confirmation.

## Impact
The flow is now: user request → admin review → immediate Realtime invitation → explicit user acceptance → atomic campanello + house creation. Failed database creation no longer leaves an orphan Hinoo row.

The included Supabase migration must be applied before deploying the Flutter client.

## Checks
- `flutter analyze`
- `flutter test --no-pub` (219 passed, 7 environment-gated tests skipped)
- `git diff --cached --check`