### PR TITLE
fix: stabilize conversation reply flows

### DIFF
--- a/lib/Controller/chest_controller.dart
+++ b/lib/Controller/chest_controller.dart
@@ -65,8 +65,11 @@ class ChestController extends ValueNotifier<ChestState> {
   int _realtimeReconnectAttempt = 0;
   int _realtimeGeneration = 0;
   bool _isRefreshingReplies = false;
-  bool _refreshPending = false;
+  String? _pendingReplyUserId;
   bool _isDisposed = false;
+  String? _stateUserId;
+  int _hinooLoadGeneration = 0;
+  int _replyLoadGeneration = 0;
 
   void startRealtime(
     String userId, {
@@ -154,15 +157,19 @@ class ChestController extends ValueNotifier<ChestState> {
 
   Future<void> refreshReplies(String userId) async {
     if (_isRefreshingReplies) {
-      _refreshPending = true;
+      _pendingReplyUserId = userId;
       return;
     }
     _isRefreshingReplies = true;
     try {
+      var requestedUserId = userId;
       do {
-        _refreshPending = false;
-        await loadReplies(userId);
-      } while (_refreshPending);
+        _pendingReplyUserId = null;
+        await loadReplies(requestedUserId);
+        final pendingUserId = _pendingReplyUserId;
+        if (pendingUserId == null) break;
+        requestedUserId = pendingUserId;
+      } while (!_isDisposed);
     } finally {
       _isRefreshingReplies = false;
     }
@@ -193,16 +200,19 @@ class ChestController extends ValueNotifier<ChestState> {
 
   void completeWithoutUser() {
     if (_isDisposed) return;
-    value = ChestState(
-      hinoo: value.hinoo,
-      honooLatestReplies: value.honooLatestReplies,
-      hinooLatestReplies: value.hinooLatestReplies,
-      hinooRepliesByRoot: value.hinooRepliesByRoot,
-      isHinooLoading: false,
-      isReplyLoading: false,
-      hinooError: value.hinooError,
-      replyError: value.replyError,
-    );
+    _stateUserId = null;
+    _hinooLoadGeneration++;
+    _replyLoadGeneration++;
+    _pendingReplyUserId = null;
+    value = ChestState(isHinooLoading: false, isReplyLoading: false);
+  }
+
+  void _prepareUser(String userId) {
+    if (_stateUserId == userId) return;
+    _stateUserId = userId;
+    _hinooLoadGeneration++;
+    _replyLoadGeneration++;
+    value = ChestState();
   }
 
   void removeHinoo(String id) {
@@ -249,6 +259,8 @@ class ChestController extends ValueNotifier<ChestState> {
 
   Future<void> loadHinoo(String userId) async {
     if (_isDisposed) return;
+    _prepareUser(userId);
+    final generation = ++_hinooLoadGeneration;
     value = ChestState(
       hinoo: value.hinoo,
       honooLatestReplies: value.honooLatestReplies,
@@ -263,7 +275,11 @@ class ChestController extends ValueNotifier<ChestState> {
       final rows = await _reliability.read<List<dynamic>>(
         () => _repository.fetchHinooRows(userId),
       );
-      if (_isDisposed) return;
+      if (_isDisposed ||
+          generation != _hinooLoadGeneration ||
+          _stateUserId != userId) {
+        return;
+      }
       Set<String> moonFingerprints = const {};
       try {
         moonFingerprints = await _reliability.read<Set<String>>(
@@ -273,7 +289,11 @@ class ChestController extends ValueNotifier<ChestState> {
         // Il contenuto dello Scrigno resta utilizzabile anche se il controllo
         // dello stato Luna non è temporaneamente disponibile.
       }
-      if (_isDisposed) return;
+      if (_isDisposed ||
+          generation != _hinooLoadGeneration ||
+          _stateUserId != userId) {
+        return;
+      }
       final hinoo = rows
           .whereType<Map>()
           .map(ChestHinooItem.fromDatabaseRow)
@@ -304,7 +324,11 @@ class ChestController extends ValueNotifier<ChestState> {
         replyError: value.replyError,
       );
     } catch (error) {
-      if (_isDisposed) return;
+      if (_isDisposed ||
+          generation != _hinooLoadGeneration ||
+          _stateUserId != userId) {
+        return;
+      }
       value = ChestState(
         hinoo: value.hinoo,
         honooLatestReplies: value.honooLatestReplies,
@@ -320,6 +344,8 @@ class ChestController extends ValueNotifier<ChestState> {
 
   Future<void> loadReplies(String userId) async {
     if (_isDisposed) return;
+    _prepareUser(userId);
+    final generation = ++_replyLoadGeneration;
     value = ChestState(
       hinoo: value.hinoo,
       honooLatestReplies: value.honooLatestReplies,
@@ -335,7 +361,11 @@ class ChestController extends ValueNotifier<ChestState> {
       final honooRows = await _reliability.refresh<List<dynamic>>(
         () => _repository.fetchHonooReplyRows(userId),
       );
-      if (_isDisposed) return;
+      if (_isDisposed ||
+          generation != _replyLoadGeneration ||
+          _stateUserId != userId) {
+        return;
+      }
       final seenHonooKeys = <String>{};
       for (final row in honooRows.whereType<Map>()) {
         final rootId = row['reply_to']?.toString() ?? '';
@@ -356,7 +386,11 @@ class ChestController extends ValueNotifier<ChestState> {
       final rows = await _reliability.refresh<List<dynamic>>(
         () => _repository.fetchHinooReplyRows(userId, rootIds),
       );
-      if (_isDisposed) return;
+      if (_isDisposed ||
+          generation != _replyLoadGeneration ||
+          _stateUserId != userId) {
+        return;
+      }
       final seenHinooIds = <String>{};
       for (final row in rows.whereType<Map>()) {
         final id = row['id']?.toString() ?? '';
@@ -402,7 +436,11 @@ class ChestController extends ValueNotifier<ChestState> {
         hinooError: value.hinooError,
       );
     } catch (error) {
-      if (_isDisposed) return;
+      if (_isDisposed ||
+          generation != _replyLoadGeneration ||
+          _stateUserId != userId) {
+        return;
+      }
       value = ChestState(
         hinoo: value.hinoo,
         honooLatestReplies: value.honooLatestReplies,

--- a/lib/Entities/reply_notification_event.dart
+++ b/lib/Entities/reply_notification_event.dart
@@ -7,6 +7,7 @@ class ReplyNotificationEvent {
     required this.senderId,
     required this.recipientId,
     this.replyId,
+    this.createdAt,
   });
 
   final ReplyNotificationKind kind;
@@ -14,6 +15,7 @@ class ReplyNotificationEvent {
   final String senderId;
   final String recipientId;
   final String? replyId;
+  final DateTime? createdAt;
 
   String get contentLabel =>
       kind == ReplyNotificationKind.honoo ? 'honoo' : 'hinoo';
@@ -56,6 +58,7 @@ class ReplyNotificationEvent {
       senderId: senderId,
       recipientId: recipientId,
       replyId: record['id']?.toString(),
+      createdAt: DateTime.tryParse(record['created_at']?.toString() ?? ''),
     );
   }
 }

--- a/lib/Pages/chest_page.dart
+++ b/lib/Pages/chest_page.dart
@@ -44,11 +44,13 @@ class ChestPage extends StatefulWidget {
     this.focusReplies = false,
     this.focusConversationId,
     this.highlightLatest = false,
+    this.focusReplyId,
   });
 
   final bool focusReplies;
   final String? focusConversationId;
   final bool highlightLatest;
+  final String? focusReplyId;
 
   @override
   State<ChestPage> createState() => _ChestPageState();
@@ -74,6 +76,7 @@ class _ChestPageState extends State<ChestPage> with WidgetsBindingObserver {
   final ChestHintService _chestHintService = ChestHintService();
 
   int _currentIndex = 0;
+  bool _didApplyInitialFocus = false;
   int _conversationRefreshToken = 0;
   Object? _honooLoadError;
   bool _isMutating = false;
@@ -213,17 +216,38 @@ class _ChestPageState extends State<ChestPage> with WidgetsBindingObserver {
     return it.when(honoo: (h) => (h.dbId ?? ''), hinoo: (row) => row.id);
   }
 
+  String _slideIdentity(ChestItem item) {
+    final conversationId = _convIdOfItem(item);
+    if (conversationId != null && conversationId.isNotEmpty) {
+      return 'conversation:$conversationId';
+    }
+    return item.when(
+      honoo: (honoo) => 'honoo:${honoo.dbId ?? honoo.id}',
+      hinoo: (hinoo) => 'hinoo:${hinoo.id}',
+    );
+  }
+
   void _rebuildItems() {
+    final previousIdentity =
+        _itemsNormal.isNotEmpty &&
+            _currentIndex >= 0 &&
+            _currentIndex < _itemsNormal.length
+        ? _slideIdentity(_itemsNormal[_currentIndex])
+        : null;
     // Build a lightweight signature of inputs that affect list construction
     final String sig = [
       ctrl.version.value.toString(),
-      _hinoo.length.toString(),
-      _honooLatestReplies.length.toString(),
-      _hinooLatestReplies.length.toString(),
-      _hinooRepliesByRoot.length.toString(),
+      ..._hinoo.map(
+        (item) =>
+            '${item.id}:${item.createdAt.toIso8601String()}:${item.conversationId ?? item.draft.conversationId ?? ''}',
+      ),
+      ..._sortedActivitySignature('honoo', _honooLatestReplies),
+      ..._sortedActivitySignature('hinoo', _hinooLatestReplies),
+      ..._sortedReplySignature(),
       widget.focusConversationId ?? '',
       widget.focusReplies ? '1' : '0',
       widget.highlightLatest ? '1' : '0',
+      widget.focusReplyId ?? '',
       _mode.name,
       _activeConversationId ?? '',
     ].join('|');
@@ -263,7 +287,14 @@ class _ChestPageState extends State<ChestPage> with WidgetsBindingObserver {
     _itemsNormal = organization.items;
     final bool hasConversationItems = organization.conversationItemCount > 0;
 
-    if (_mode == ChestMode.normal && widget.focusConversationId != null) {
+    var desiredIndex = previousIdentity == null
+        ? -1
+        : _itemsNormal.indexWhere(
+            (item) => _slideIdentity(item) == previousIdentity,
+          );
+    if (_mode == ChestMode.normal &&
+        !_didApplyInitialFocus &&
+        widget.focusConversationId != null) {
       final idx = _itemsNormal.indexWhere((it) {
         final String? cid = it.when(
           honoo: (h) => h.conversationId,
@@ -272,21 +303,55 @@ class _ChestPageState extends State<ChestPage> with WidgetsBindingObserver {
         return cid == widget.focusConversationId;
       });
       if (idx >= 0) {
-        _currentIndex = idx;
+        desiredIndex = idx;
       } else if (widget.focusReplies && hasConversationItems) {
-        _currentIndex = 0;
+        desiredIndex = 0;
       }
+      if (_itemsNormal.isNotEmpty) _didApplyInitialFocus = true;
     } else if (_mode == ChestMode.normal &&
+        !_didApplyInitialFocus &&
         widget.focusReplies &&
         hasConversationItems) {
-      _currentIndex = 0;
-    } else if (_mode == ChestMode.normal &&
-        _currentIndex >= _itemsNormal.length) {
-      _currentIndex = _itemsNormal.isEmpty ? 0 : _itemsNormal.length - 1;
+      desiredIndex = 0;
+      _didApplyInitialFocus = _itemsNormal.isNotEmpty;
+    }
+    if (_mode == ChestMode.normal) {
+      if (_itemsNormal.isEmpty) {
+        desiredIndex = 0;
+      } else if (desiredIndex < 0) {
+        desiredIndex = _currentIndex.clamp(0, _itemsNormal.length - 1);
+      }
+      final indexChanged = desiredIndex != _currentIndex;
+      _currentIndex = desiredIndex;
+      if (indexChanged) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (!mounted || _itemsNormal.isEmpty) return;
+          _carouselController.jumpToPage(_currentIndex);
+        });
+      }
     }
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted) _prefetchChestFrom(_currentIndex);
     });
+  }
+
+  List<String> _sortedActivitySignature(
+    String prefix,
+    Map<String, DateTime> activity,
+  ) {
+    final values = activity.entries
+        .map((entry) => '$prefix:${entry.key}:${entry.value.toIso8601String()}')
+        .toList();
+    values.sort();
+    return values;
+  }
+
+  List<String> _sortedReplySignature() {
+    final values = _hinooRepliesByRoot.entries
+        .map((entry) => '${entry.key}:${entry.value.length}')
+        .toList();
+    values.sort();
+    return values;
   }
 
   void _prefetchChestFrom(int index) {
@@ -759,6 +824,7 @@ class _ChestPageState extends State<ChestPage> with WidgetsBindingObserver {
       isActive: isActive,
       highlightLatest: widget.highlightLatest,
       focusConversationId: widget.focusConversationId,
+      revealEntryId: widget.focusReplyId,
       onSelectConversationEntry: (entry) {
         setState(() => _selectedConvEntry = entry);
       },
@@ -859,7 +925,10 @@ class _ChestPageState extends State<ChestPage> with WidgetsBindingObserver {
                 disableCenter: true,
                 scrollPhysics: horizPhysics,
                 onPageChanged: (i, _) {
-                  setState(() => _currentIndex = i);
+                  setState(() {
+                    _currentIndex = i;
+                    _selectedConvEntry = null;
+                  });
                   _prefetchChestFrom(i);
                 },
               ),

--- a/lib/Pages/moon_page.dart
+++ b/lib/Pages/moon_page.dart
@@ -696,23 +696,20 @@ class _MoonPageState extends State<MoonPage> {
 
     if (choice == null || !mounted) return;
     if (choice == _ReplyChoice.honoo && current.honoo != null) {
-      final sent = await Navigator.push<bool>(
+      if (!await _ensureMoonItemInChest(current) || !mounted) return;
+      final conversationId = await Navigator.push<String>(
         context,
         MaterialPageRoute(
           builder: (_) => ReplyHonooPage(
             originalHonoo: current.honoo!,
             initialHintText: 'Scrivi la tua risposta',
             initialImageHint: 'Aggiungi un’immagine (opzionale)',
+            returnToPreviousOnAnswer: true,
           ),
         ),
       );
       if (!mounted) return;
-      if (sent == true) {
-        final id = current.honoo?.dbId;
-        if (id != null && id.isNotEmpty) {
-          setState(() => _repliedItemIds.add(id));
-        }
-      }
+      await _openConversationAfterReply(current, conversationId);
     } else if (choice == _ReplyChoice.honoo && current.hinoo != null) {
       // Risposta ad un hinoo con un honoo
       final parentId = current.hinooId;
@@ -724,9 +721,8 @@ class _MoonPageState extends State<MoonPage> {
         parentConversationId: current.hinoo!.conversationId,
         recipientId: recipientId,
       );
-      await _ensureMoonItemInChest(current);
-      if (!mounted) return;
-      await Navigator.push(
+      if (!await _ensureMoonItemInChest(current) || !mounted) return;
+      final conversationId = await Navigator.push<String>(
         context,
         MaterialPageRoute(
           builder: (_) => NewHonooPage(
@@ -734,15 +730,12 @@ class _MoonPageState extends State<MoonPage> {
             recipientTag: link.recipientId,
             replyTo: link.replyTo,
             conversationId: link.conversationId,
-            returnSavedId: false,
+            returnToPreviousOnAnswer: true,
           ),
         ),
       );
       if (!mounted) return;
-      await Navigator.push(
-        context,
-        MaterialPageRoute(builder: (_) => const ChestPage(focusReplies: true)),
-      );
+      await _openConversationAfterReply(current, conversationId);
     } else if (choice == _ReplyChoice.hinoo && current.hinoo != null) {
       final String? replyTo = current.hinooId;
       if (replyTo == null || replyTo.isEmpty) return;
@@ -753,9 +746,8 @@ class _MoonPageState extends State<MoonPage> {
         parentConversationId: current.hinoo!.conversationId,
         recipientId: recipientId,
       );
-      await _ensureMoonItemInChest(current);
-      if (!mounted) return;
-      await Navigator.push(
+      if (!await _ensureMoonItemInChest(current) || !mounted) return;
+      final conversationId = await Navigator.push<String>(
         context,
         MaterialPageRoute(
           builder: (_) => NewHinooPage(
@@ -763,14 +755,12 @@ class _MoonPageState extends State<MoonPage> {
             recipientTag: link.recipientId,
             replyTo: link.replyTo,
             conversationId: link.conversationId,
+            returnToPreviousOnAnswer: true,
           ),
         ),
       );
       if (!mounted) return;
-      await Navigator.push(
-        context,
-        MaterialPageRoute(builder: (_) => const ChestPage(focusReplies: true)),
-      );
+      await _openConversationAfterReply(current, conversationId);
     } else if (choice == _ReplyChoice.hinoo && current.honoo != null) {
       // Risposta ad un honoo con un hinoo
       final parentId = current.honoo!.dbId;
@@ -780,9 +770,8 @@ class _MoonPageState extends State<MoonPage> {
         parentConversationId: current.honoo!.conversationId,
         recipientId: current.honoo!.userId,
       );
-      await _ensureMoonItemInChest(current);
-      if (!mounted) return;
-      await Navigator.push(
+      if (!await _ensureMoonItemInChest(current) || !mounted) return;
+      final conversationId = await Navigator.push<String>(
         context,
         MaterialPageRoute(
           builder: (_) => NewHinooPage(
@@ -790,18 +779,37 @@ class _MoonPageState extends State<MoonPage> {
             recipientTag: link.recipientId,
             replyTo: link.replyTo,
             conversationId: link.conversationId,
+            returnToPreviousOnAnswer: true,
           ),
         ),
       );
       if (!mounted) return;
-      await Navigator.push(
-        context,
-        MaterialPageRoute(builder: (_) => const ChestPage(focusReplies: true)),
-      );
+      await _openConversationAfterReply(current, conversationId);
     }
   }
 
-  Future<void> _ensureMoonItemInChest(_MoonItem current) async {
+  Future<void> _openConversationAfterReply(
+    _MoonItem current,
+    String? conversationId,
+  ) async {
+    if (conversationId == null || conversationId.isEmpty || !mounted) return;
+    final id = current.honoo?.dbId ?? current.hinooId;
+    if (id != null && id.isNotEmpty) {
+      setState(() => _repliedItemIds.add(id));
+    }
+    await Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => ChestPage(
+          focusReplies: true,
+          focusConversationId: conversationId,
+          highlightLatest: true,
+        ),
+      ),
+    );
+  }
+
+  Future<bool> _ensureMoonItemInChest(_MoonItem current) async {
     try {
       if (current.honoo != null) {
         await HonooService.duplicateToChest(
@@ -810,9 +818,11 @@ class _MoonPageState extends State<MoonPage> {
       } else if (current.hinoo != null) {
         await HinooService.duplicateMoonToChest(current.hinoo!);
       }
+      return true;
     } catch (_) {
-      if (!mounted) return;
+      if (!mounted) return false;
       showHonooToast(context, message: 'Errore salvataggio nello scrigno.');
+      return false;
     }
   }
 }

--- a/lib/Pages/new_hinoo_page.dart
+++ b/lib/Pages/new_hinoo_page.dart
@@ -321,7 +321,7 @@ class _NewHinooPageState extends State<NewHinooPage>
         return;
       }
 
-      await _controller.saveToChest(hinooDraft);
+      final savedHinooId = await _controller.saveToChest(hinooDraft);
       if (!mounted) return;
       setState(() => _savedToChest = true);
       _chestBounceController.forward(from: 0);
@@ -344,6 +344,7 @@ class _NewHinooPageState extends State<NewHinooPage>
             builder: (_) => ChestPage(
               focusReplies: true,
               focusConversationId: conversationId,
+              focusReplyId: savedHinooId,
               highlightLatest: true,
             ),
           ),

--- a/lib/Pages/new_honoo_page.dart
+++ b/lib/Pages/new_honoo_page.dart
@@ -182,7 +182,12 @@ class _NewHonooPageState extends State<NewHonooPage> {
         return true;
       }
 
-      await HonooService.publishHonoo(newHonoo);
+      final savedReplyId = type == HonooType.answer
+          ? await HonooService.publishHonooAndReturnId(newHonoo)
+          : null;
+      if (savedReplyId == null) {
+        await HonooService.publishHonoo(newHonoo);
+      }
 
       if (!mounted) return false;
       setState(() {
@@ -214,6 +219,7 @@ class _NewHonooPageState extends State<NewHonooPage> {
             builder: (_) => ChestPage(
               focusReplies: true,
               focusConversationId: conversationId,
+              focusReplyId: savedReplyId,
               highlightLatest: true,
             ),
           ),

--- a/lib/Pages/reply_honoo_page.dart
+++ b/lib/Pages/reply_honoo_page.dart
@@ -61,6 +61,15 @@ class _ReplyHonooPageState extends State<ReplyHonooPage> {
 
     setState(() => _isSending = true);
 
+    final currentUser = SupabaseProvider.client.auth.currentUser;
+    if (currentUser == null) {
+      if (mounted) {
+        setState(() => _isSending = false);
+        showHonooToast(context, message: 'Accedi prima di rispondere.');
+      }
+      return;
+    }
+
     final now = DateTime.now().toIso8601String();
 
     final String replyTarget =
@@ -76,7 +85,7 @@ class _ReplyHonooPageState extends State<ReplyHonooPage> {
       _imageUrl ?? '',
       now,
       now,
-      SupabaseProvider.client.auth.currentUser!.id,
+      currentUser.id,
       HonooType.answer,
       link.replyTo,
       link.recipientId,
@@ -85,14 +94,12 @@ class _ReplyHonooPageState extends State<ReplyHonooPage> {
     try {
       // Assicura che il root sia nello Scrigno se arriviamo dalla Luna
       if (widget.originalHonoo.type == HonooType.moon) {
-        try {
-          await HonooController().saveToChest(
-            widget.originalHonoo.copyWith(isFromMoonSaved: true),
-          );
-        } catch (_) {}
+        await HonooController().saveToChest(
+          widget.originalHonoo.copyWith(isFromMoonSaved: true),
+        );
       }
 
-      await HonooService.publishHonoo(newHonoo);
+      final replyId = await HonooService.publishHonooAndReturnId(newHonoo);
 
       if (!mounted) return;
 
@@ -108,6 +115,7 @@ class _ReplyHonooPageState extends State<ReplyHonooPage> {
           builder: (_) => ChestPage(
             focusReplies: true,
             focusConversationId: link.conversationId,
+            focusReplyId: replyId,
             highlightLatest: true,
           ),
         ),

--- a/lib/Services/conversation_service.dart
+++ b/lib/Services/conversation_service.dart
@@ -124,12 +124,22 @@ class ConversationService {
     chan
         .on(
           RealtimeListenTypes.postgresChanges,
-          ChannelFilter(event: '*', schema: 'public', table: 'honoo'),
+          ChannelFilter(
+            event: '*',
+            schema: 'public',
+            table: 'honoo',
+            filter: 'conversation_id=eq.$conversationId',
+          ),
           refresh,
         )
         .on(
           RealtimeListenTypes.postgresChanges,
-          ChannelFilter(event: '*', schema: 'public', table: 'hinoo'),
+          ChannelFilter(
+            event: '*',
+            schema: 'public',
+            table: 'hinoo',
+            filter: 'conversation_id=eq.$conversationId',
+          ),
           refresh,
         )
         .subscribe();

--- a/lib/Services/home_service.dart
+++ b/lib/Services/home_service.dart
@@ -9,7 +9,7 @@ class HomeService {
 
   Future<int> fetchUnreadReplyCount(String userId) async {
     return policy.read(() async {
-      final lastSeen = await RepliesSeenTracker.lastSeen();
+      final lastSeen = await RepliesSeenTracker.lastSeen(userId: userId);
       final honooRows = await SupabaseProvider.client
           .from('honoo')
           .select('created_at,user_id')
@@ -25,8 +25,9 @@ class HomeService {
 
       int count = 0;
       for (final row in [...(honooRows as List), ...(hinooRows as List)]) {
-        final createdAt =
-            DateTime.tryParse((row['created_at'] ?? '').toString());
+        final createdAt = DateTime.tryParse(
+          (row['created_at'] ?? '').toString(),
+        );
         if (createdAt != null &&
             (lastSeen == null || createdAt.isAfter(lastSeen))) {
           count++;
@@ -36,7 +37,6 @@ class HomeService {
     });
   }
 
-  Future<void> recordVisit() => policy.write(
-        () => SupabaseProvider.client.rpc('increment_site_visit'),
-      );
+  Future<void> recordVisit() =>
+      policy.write(() => SupabaseProvider.client.rpc('increment_site_visit'));
 }

--- a/lib/UI/unified_thread_view.dart
+++ b/lib/UI/unified_thread_view.dart
@@ -25,6 +25,7 @@ class UnifiedThreadView extends StatefulWidget {
     this.refreshToken = 0,
     this.conversationLoader,
     this.currentUserId,
+    this.revealEntryId,
   });
 
   final String conversationId;
@@ -38,6 +39,7 @@ class UnifiedThreadView extends StatefulWidget {
   final Future<List<ConversationEntry>> Function(String conversationId)?
   conversationLoader;
   final String? currentUserId;
+  final String? revealEntryId;
 
   @override
   State<UnifiedThreadView> createState() => _UnifiedThreadViewState();
@@ -49,8 +51,8 @@ class _UnifiedThreadViewState extends State<UnifiedThreadView>
   Object? _loadError;
   List<ConversationEntry> _entries = const [];
   RealtimeChannel? _chan;
-  bool _didHighlight = false;
   String? _revealedEntryKey;
+  int _loadGeneration = 0;
   final PageController _pageController = PageController();
   late AnimationController _controller;
   late Animation<double> _liftAnimation;
@@ -114,6 +116,8 @@ class _UnifiedThreadViewState extends State<UnifiedThreadView>
 
   Future<void> _load() async {
     if (!mounted) return;
+    final generation = ++_loadGeneration;
+    final conversationId = widget.conversationId;
     if (_entries.isEmpty) {
       setState(() => _loading = true);
     }
@@ -121,9 +125,13 @@ class _UnifiedThreadViewState extends State<UnifiedThreadView>
       _loadError = null;
       final loader =
           widget.conversationLoader ?? ConversationService.fetchConversation;
-      final entries = await loader(widget.conversationId);
+      final entries = await loader(conversationId);
 
-      if (!mounted) return;
+      if (!mounted ||
+          generation != _loadGeneration ||
+          conversationId != widget.conversationId) {
+        return;
+      }
       setState(() {
         _entries = entries;
         _loading = false;
@@ -131,12 +139,15 @@ class _UnifiedThreadViewState extends State<UnifiedThreadView>
       });
       _prefetchEntriesFrom(_pageToShowFirst);
       _showLatestReceivedAndReveal();
-      if (widget.highlightLatest && !_didHighlight && _entries.isNotEmpty) {
-        _didHighlight = true;
+      if (widget.isActive && _entries.isNotEmpty) {
         widget.onSelect?.call(_entryToShowFirst);
       }
     } catch (error) {
-      if (!mounted) return;
+      if (!mounted ||
+          generation != _loadGeneration ||
+          conversationId != widget.conversationId) {
+        return;
+      }
       setState(() {
         _loading = false;
         _loadError = error;
@@ -165,8 +176,11 @@ class _UnifiedThreadViewState extends State<UnifiedThreadView>
     if (oldWidget.conversationId != widget.conversationId) {
       _chan?.unsubscribe();
       _chan = null;
-      _didHighlight = false;
       _revealedEntryKey = null;
+      _entries = const [];
+      _loading = true;
+      _loadError = null;
+      _controller.reset();
       _load();
     }
     if (oldWidget.refreshToken != widget.refreshToken &&
@@ -183,6 +197,9 @@ class _UnifiedThreadViewState extends State<UnifiedThreadView>
         _controller.reset();
       }
     }
+    if (oldWidget.revealEntryId != widget.revealEntryId) {
+      _revealedEntryKey = null;
+    }
     if (widget.isActive) _showLatestReceivedAndReveal();
   }
 
@@ -195,6 +212,13 @@ class _UnifiedThreadViewState extends State<UnifiedThreadView>
 
   int get _pageToShowFirst {
     final reversed = _entries.reversed.toList(growable: false);
+    final revealEntryId = widget.revealEntryId;
+    if (revealEntryId != null && revealEntryId.isNotEmpty) {
+      final exactIndex = reversed.indexWhere(
+        (entry) => entry.id == revealEntryId,
+      );
+      if (exactIndex >= 0) return exactIndex;
+    }
     final receivedIndex = reversed.indexWhere(_shouldReveal);
     return receivedIndex < 0 ? 0 : receivedIndex;
   }
@@ -228,6 +252,10 @@ class _UnifiedThreadViewState extends State<UnifiedThreadView>
         ? (e.honoo!.type == HonooType.answer)
         : (e.hinoo != null && e.hinoo!.type == HinooType.answer);
 
+    final revealEntryId = widget.revealEntryId;
+    if (revealEntryId != null && revealEntryId.isNotEmpty) {
+      return isReply && e.id == revealEntryId;
+    }
     return isReply;
   }
 
@@ -319,7 +347,13 @@ class _UnifiedThreadViewState extends State<UnifiedThreadView>
         scrollDirection: Axis.vertical,
         pageSnapping: true,
         physics: const PageScrollPhysics(parent: ClampingScrollPhysics()),
-        onPageChanged: _prefetchEntriesFrom,
+        onPageChanged: (index) {
+          _prefetchEntriesFrom(index);
+          final reversed = _entries.reversed.toList(growable: false);
+          if (index >= 0 && index < reversed.length) {
+            widget.onSelect?.call(reversed[index]);
+          }
+        },
         itemCount: _entries.length,
         itemBuilder: (context, index) {
           // Ordine inverso: ultimo (più recente) in cima

--- a/lib/Utility/replies_seen_tracker.dart
+++ b/lib/Utility/replies_seen_tracker.dart
@@ -5,22 +5,33 @@ import 'reply_notification_signal.dart';
 class RepliesSeenTracker {
   static const _key = 'last_seen_reply_at_v1';
 
-  static Future<DateTime?> lastSeen() async {
+  static String _keyFor(String? userId) {
+    final normalized = userId?.trim() ?? '';
+    return normalized.isEmpty ? _key : '${_key}_$normalized';
+  }
+
+  static Future<DateTime?> lastSeen({String? userId}) async {
     final prefs = await SharedPreferences.getInstance();
-    final s = prefs.getString(_key);
+    final s = prefs.getString(_keyFor(userId));
     if (s == null || s.isEmpty) return null;
     return DateTime.tryParse(s);
   }
 
-  static Future<void> markNow() async {
+  static Future<void> markNow({String? userId}) async {
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setString(_key, DateTime.now().toIso8601String());
+    await prefs.setString(
+      _keyFor(userId),
+      DateTime.now().toUtc().toIso8601String(),
+    );
     ReplyNotificationSignal.notifyChanged();
   }
 
-  static Future<void> markAt(DateTime dt) async {
+  static Future<void> markAt(DateTime dt, {String? userId}) async {
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setString(_key, dt.toIso8601String());
+    final key = _keyFor(userId);
+    final current = DateTime.tryParse(prefs.getString(key) ?? '');
+    if (current != null && !dt.isAfter(current)) return;
+    await prefs.setString(key, dt.toUtc().toIso8601String());
     ReplyNotificationSignal.notifyChanged();
   }
 }

--- a/lib/Widgets/chest_item_view.dart
+++ b/lib/Widgets/chest_item_view.dart
@@ -24,6 +24,7 @@ class ChestItemView extends StatelessWidget {
     required this.isActive,
     required this.highlightLatest,
     required this.focusConversationId,
+    required this.revealEntryId,
     required this.onSelectConversationEntry,
     required this.onDownload,
     required this.conversationRefreshToken,
@@ -39,6 +40,7 @@ class ChestItemView extends StatelessWidget {
   final bool isActive;
   final bool highlightLatest;
   final String? focusConversationId;
+  final String? revealEntryId;
   final ValueChanged<ConversationEntry> onSelectConversationEntry;
   final VoidCallback onDownload;
   final int conversationRefreshToken;
@@ -148,6 +150,7 @@ class ChestItemView extends StatelessWidget {
     isActive: isActive,
     onSelect: onSelectConversationEntry,
     highlightLatest: highlightLatest && focusConversationId == conversationId,
+    revealEntryId: focusConversationId == conversationId ? revealEntryId : null,
     onDownloadTap: onDownload,
     refreshToken: conversationRefreshToken,
   );

--- a/lib/Widgets/global_reply_notification_listener.dart
+++ b/lib/Widgets/global_reply_notification_listener.dart
@@ -43,8 +43,7 @@ class _GlobalReplyNotificationListenerState
   int _reconnectAttempt = 0;
   int _channelGeneration = 0;
   String? _activeUserId;
-  String? _lastEventKey;
-  DateTime? _lastEventAt;
+  final Set<String> _deliveredEventKeys = <String>{};
 
   @override
   void initState() {
@@ -89,6 +88,7 @@ class _GlobalReplyNotificationListenerState
       return;
     }
     _closeRealtime(clearUser: false);
+    _deliveredEventKeys.clear();
     _activeUserId = userId;
     if (userId == null) return;
     _connectChannels(userId);
@@ -128,6 +128,7 @@ class _GlobalReplyNotificationListenerState
         if (status == 'SUBSCRIBED') {
           _reconnectAttempt = 0;
           _reconnectTimer?.cancel();
+          unawaited(_catchUpMissedReplies(userId, generation));
           return;
         }
         if (status == 'CHANNEL_ERROR' ||
@@ -172,19 +173,15 @@ class _GlobalReplyNotificationListenerState
   }
 
   void _handleEvent(ReplyNotificationEvent event) {
-    final now = DateTime.now();
     final eventKey =
-        '${event.kind.name}:${event.replyId ?? event.conversationId}';
-    if (_lastEventKey == eventKey &&
-        _lastEventAt != null &&
-        now.difference(_lastEventAt!) < const Duration(seconds: 2)) {
-      return;
+        '${event.recipientId}:${event.kind.name}:${event.replyId ?? event.conversationId}';
+    if (!_deliveredEventKeys.add(eventKey)) return;
+    if (_deliveredEventKeys.length > 256) {
+      _deliveredEventKeys.remove(_deliveredEventKeys.first);
     }
-    _lastEventKey = eventKey;
-    _lastEventAt = now;
     ReplyNotificationSignal.notifyChanged();
 
-    void open() => _openConversation(event.conversationId);
+    void open() => _openConversation(event);
     _systemNotification.show(
       contentLabel: event.contentLabel,
       conversationId: event.conversationId,
@@ -206,13 +203,71 @@ class _GlobalReplyNotificationListenerState
       );
   }
 
-  void _openConversation(String conversationId) {
-    unawaited(RepliesSeenTracker.markNow());
+  Future<void> _catchUpMissedReplies(String userId, int generation) async {
+    final lastSeen = await RepliesSeenTracker.lastSeen(userId: userId);
+    if (!mounted || generation != _channelGeneration || lastSeen == null) {
+      return;
+    }
+    try {
+      final since = lastSeen.toUtc().toIso8601String();
+      final results = await Future.wait<dynamic>([
+        SupabaseProvider.client
+            .from('honoo')
+            .select(
+              'id,destination,reply_to,recipient_tag,created_at,user_id,conversation_id',
+            )
+            .eq('destination', 'reply')
+            .eq('recipient_tag', userId)
+            .gt('created_at', since)
+            .order('created_at'),
+        SupabaseProvider.client
+            .from('hinoo')
+            .select(
+              'id,type,reply_to,recipient_tag,created_at,user_id,conversation_id',
+            )
+            .eq('type', 'answer')
+            .eq('recipient_tag', userId)
+            .gt('created_at', since)
+            .order('created_at'),
+      ]);
+      if (!mounted || generation != _channelGeneration) return;
+      final pending = <ReplyNotificationEvent>[];
+      for (var i = 0; i < results.length; i++) {
+        final kind = i == 0
+            ? ReplyNotificationKind.honoo
+            : ReplyNotificationKind.hinoo;
+        for (final row in (results[i] as List).whereType<Map>()) {
+          final event = ReplyNotificationEvent.fromRealtimePayload(
+            {'eventType': 'INSERT', 'new': row},
+            kind: kind,
+            currentUserId: userId,
+          );
+          if (event != null) pending.add(event);
+        }
+      }
+      pending.sort(
+        (a, b) => (a.createdAt ?? DateTime.fromMillisecondsSinceEpoch(0))
+            .compareTo(b.createdAt ?? DateTime.fromMillisecondsSinceEpoch(0)),
+      );
+      for (final event in pending) {
+        _handleEvent(event);
+      }
+    } catch (_) {
+      // Il canale realtime resta attivo; il prossimo reconnect ritenterà il catch-up.
+    }
+  }
+
+  void _openConversation(ReplyNotificationEvent event) {
+    final seenAt = event.createdAt;
+    if (seenAt != null) {
+      unawaited(RepliesSeenTracker.markAt(seenAt, userId: event.recipientId));
+    }
     widget.navigatorKey.currentState?.push(
       MaterialPageRoute(
         builder: (_) => ChestPage(
           focusReplies: true,
-          focusConversationId: conversationId,
+          focusConversationId: event.conversationId,
+          focusReplyId: event.replyId,
           highlightLatest: true,
         ),
       ),

--- a/lib/Widgets/sea_footer_bar.dart
+++ b/lib/Widgets/sea_footer_bar.dart
@@ -8,6 +8,7 @@ import 'package:honoo/Widgets/composer_onboarding.dart';
 import 'package:honoo/IsolaDelleStorie/Pages/island_page.dart';
 import 'package:honoo/Pages/chest_page.dart';
 import 'package:honoo/Utility/replies_seen_tracker.dart';
+import 'package:honoo/Services/supabase_provider.dart';
 
 /// Barra “mare” riutilizzabile con onde + isola (sx) + scrigno (centro) + bottiglia (dx)
 /// Posizioni, dimensioni e z-order identici alla HomePage.
@@ -186,7 +187,10 @@ class SeaFooterBar extends StatelessWidget {
                         tooltip: 'Apri il tuo Cuore',
                         onPressed: () {
                           if (replyCount > 0) {
-                            RepliesSeenTracker.markNow();
+                            RepliesSeenTracker.markNow(
+                              userId:
+                                  SupabaseProvider.client.auth.currentUser?.id,
+                            );
                           }
                           Navigator.push(
                             context,

--- a/test/controllers/chest_controller_test.dart
+++ b/test/controllers/chest_controller_test.dart
@@ -188,6 +188,76 @@ void main() {
     await expectLater(loading, completes);
   });
 
+  test('il logout elimina immediatamente i dati dello Scrigno', () async {
+    when(() => repository.fetchHinooRows('user-1')).thenAnswer(
+      (_) async => [
+        {
+          'id': 'private-hinoo',
+          'pages': [
+            {
+              'backgroundImage': 'background.png',
+              'text': 'Privato',
+              'isTextWhite': true,
+            },
+          ],
+          'type': 'personal',
+          'created_at': '2026-08-03T10:00:00Z',
+          'user_id': 'user-1',
+        },
+      ],
+    );
+    when(
+      () => repository.fetchHinooMoonFingerprints('user-1'),
+    ).thenAnswer((_) async => const {});
+
+    await controller.loadHinoo('user-1');
+    expect(controller.value.hinoo, isNotEmpty);
+
+    controller.completeWithoutUser();
+
+    expect(controller.value.hinoo, isEmpty);
+    expect(controller.value.honooLatestReplies, isEmpty);
+    expect(controller.value.hinooRepliesByRoot, isEmpty);
+  });
+
+  test(
+    'un caricamento del vecchio utente non contamina la nuova sessione',
+    () async {
+      final oldRows = Completer<List<dynamic>>();
+      when(
+        () => repository.fetchHinooRows('user-old'),
+      ).thenAnswer((_) => oldRows.future);
+      when(() => repository.fetchHinooRows('user-new')).thenAnswer(
+        (_) async => [
+          {
+            'id': 'new-user-hinoo',
+            'pages': [
+              {
+                'backgroundImage': 'background.png',
+                'text': 'Nuovo utente',
+                'isTextWhite': true,
+              },
+            ],
+            'type': 'personal',
+            'created_at': '2026-08-03T11:00:00Z',
+            'user_id': 'user-new',
+          },
+        ],
+      );
+      when(
+        () => repository.fetchHinooMoonFingerprints('user-new'),
+      ).thenAnswer((_) async => const {});
+
+      final oldLoad = controller.loadHinoo('user-old');
+      await Future<void>.delayed(Duration.zero);
+      await controller.loadHinoo('user-new');
+      oldRows.complete(const []);
+      await oldLoad;
+
+      expect(controller.value.hinoo.single.id, 'new-user-hinoo');
+    },
+  );
+
   test('start e stop gestiscono il ciclo di vita Realtime', () {
     controller.startRealtime(
       'user-1',

--- a/test/pages/reply_honoo_flow_test.dart
+++ b/test/pages/reply_honoo_flow_test.dart
@@ -20,6 +20,7 @@ void main() {
     harness = SupabaseTestHarness(withAuthenticatedUser: true);
     harness.enableOverrides();
     final honoo = harness.stubTable('honoo');
+    honoo.queueResponse(<String, dynamic>{'id': 'reply-1'});
     final hinoo = harness.stubTable('hinoo');
     when(() => honoo.neq(any(), any())).thenAnswer((_) => honoo);
     when(() => hinoo.neq(any(), any())).thenAnswer((_) => hinoo);

--- a/test/utility/replies_seen_tracker_test.dart
+++ b/test/utility/replies_seen_tracker_test.dart
@@ -1,0 +1,28 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:honoo/Utility/replies_seen_tracker.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  test('mantiene un cursore separato per ogni utente', () async {
+    final firstSeen = DateTime.parse('2026-08-03T10:00:00Z');
+    final secondSeen = DateTime.parse('2026-08-03T11:00:00Z');
+
+    await RepliesSeenTracker.markAt(firstSeen, userId: 'user-1');
+    await RepliesSeenTracker.markAt(secondSeen, userId: 'user-2');
+
+    expect(await RepliesSeenTracker.lastSeen(userId: 'user-1'), firstSeen);
+    expect(await RepliesSeenTracker.lastSeen(userId: 'user-2'), secondSeen);
+  });
+
+  test('non arretra il cursore quando arriva un evento più vecchio', () async {
+    final newest = DateTime.parse('2026-08-03T12:00:00Z');
+    final older = DateTime.parse('2026-08-03T09:00:00Z');
+
+    await RepliesSeenTracker.markAt(newest, userId: 'user-1');
+    await RepliesSeenTracker.markAt(older, userId: 'user-1');
+
+    expect(await RepliesSeenTracker.lastSeen(userId: 'user-1'), newest);
+  });
+}

--- a/test/widgets/chest_item_view_animation_test.dart
+++ b/test/widgets/chest_item_view_animation_test.dart
@@ -55,6 +55,7 @@ void main() {
             isActive: true,
             highlightLatest: false,
             focusConversationId: null,
+            revealEntryId: null,
             onSelectConversationEntry: (ConversationEntry _) {},
             onDownload: () {},
             conversationRefreshToken: 0,

--- a/test/widgets/global_reply_notification_listener_test.dart
+++ b/test/widgets/global_reply_notification_listener_test.dart
@@ -15,6 +15,7 @@ class _FakeReplySystemNotification extends ReplySystemNotification {
   VoidCallback? onTap;
   String? contentLabel;
   String? conversationId;
+  int showCount = 0;
 
   @override
   ReplyNotificationPermission get permission =>
@@ -29,6 +30,7 @@ class _FakeReplySystemNotification extends ReplySystemNotification {
     required String conversationId,
     required VoidCallback onTap,
   }) {
+    showCount += 1;
     this.contentLabel = contentLabel;
     this.conversationId = conversationId;
     this.onTap = onTap;
@@ -74,16 +76,19 @@ void main() {
         ),
       );
 
-      events.add(
-        const ReplyNotificationEvent(
-          kind: ReplyNotificationKind.hinoo,
-          conversationId: 'conversation-42',
-          senderId: 'other_user',
-          recipientId: 'test_user',
-        ),
+      final event = ReplyNotificationEvent(
+        kind: ReplyNotificationKind.hinoo,
+        conversationId: 'conversation-42',
+        senderId: 'other_user',
+        recipientId: 'test_user',
+        replyId: 'reply-42',
+        createdAt: DateTime.utc(2026, 8, 3, 10),
       );
+      events.add(event);
+      events.add(event);
       await tester.pump();
 
+      expect(notification.showCount, 1);
       expect(notification.contentLabel, 'hinoo');
       expect(notification.conversationId, 'conversation-42');
       expect(notification.onTap, isNotNull);
@@ -101,6 +106,9 @@ void main() {
 
       expect(navigatorKey.currentState!.canPop(), isTrue);
       expect(find.byType(ChestPage), findsOneWidget);
+      final chestPage = tester.widget<ChestPage>(find.byType(ChestPage));
+      expect(chestPage.focusConversationId, 'conversation-42');
+      expect(chestPage.focusReplyId, 'reply-42');
 
       await tester.pumpWidget(const SizedBox.shrink());
     },

--- a/test/widgets/unified_thread_reveal_test.dart
+++ b/test/widgets/unified_thread_reveal_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:honoo/Entities/conversation_entry.dart';
@@ -299,4 +301,122 @@ void main() {
       expect(borderWithColor(HonooColor.secondary), findsNothing);
     },
   );
+
+  testWidgets(
+    'revealEntryId anima la risposta richiesta, non quella più recente',
+    (tester) async {
+      tester.view.devicePixelRatio = 1;
+      tester.view.physicalSize = const Size(600, 900);
+      addTearDown(tester.view.resetDevicePixelRatio);
+      addTearDown(tester.view.resetPhysicalSize);
+
+      final root = ConversationEntry.honoo(
+        honoo(
+          id: 'root-exact',
+          text: 'Padre esatto',
+          owner: 'me',
+          createdAt: '2026-07-20T10:00:00Z',
+        ),
+      );
+      final requestedReply = ConversationEntry.honoo(
+        honoo(
+          id: 'reply-requested',
+          text: 'Risposta richiesta',
+          owner: 'other',
+          createdAt: '2026-07-20T11:00:00Z',
+          type: HonooType.answer,
+          replyTo: 'root-exact',
+        ),
+      );
+      final newerReply = ConversationEntry.honoo(
+        honoo(
+          id: 'reply-newer',
+          text: 'Risposta più recente',
+          owner: 'other',
+          createdAt: '2026-07-20T12:00:00Z',
+          type: HonooType.answer,
+          replyTo: 'reply-requested',
+        ),
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: UnifiedThreadView(
+              conversationId: 'conversation-1',
+              revealEntryId: 'reply-requested',
+              maxWidth: 600,
+              maxHeight: 700,
+              isActive: true,
+              conversationLoader: (_) async => [
+                root,
+                requestedReply,
+                newerReply,
+              ],
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 350));
+
+      expect(find.text('Risposta richiesta'), findsOneWidget);
+      expect(find.text('Padre esatto'), findsOneWidget);
+      expect(find.byKey(const Key('reply_reveal_parent')), findsOneWidget);
+    },
+  );
+
+  testWidgets('un caricamento vecchio non sostituisce la nuova conversazione', (
+    tester,
+  ) async {
+    final first = Completer<List<ConversationEntry>>();
+    final second = Completer<List<ConversationEntry>>();
+    Future<List<ConversationEntry>> loader(String conversationId) =>
+        conversationId == 'conversation-old' ? first.future : second.future;
+
+    Widget app(String conversationId) => MaterialApp(
+      home: Scaffold(
+        body: UnifiedThreadView(
+          key: const Key('race-thread'),
+          conversationId: conversationId,
+          maxWidth: 390,
+          maxHeight: 700,
+          conversationLoader: loader,
+        ),
+      ),
+    );
+
+    await tester.pumpWidget(app('conversation-old'));
+    await tester.pump();
+    await tester.pumpWidget(app('conversation-new'));
+    await tester.pump();
+
+    second.complete([
+      ConversationEntry.honoo(
+        honoo(
+          id: 'new-entry',
+          text: 'Conversazione nuova',
+          owner: 'me',
+          createdAt: '2026-07-20T12:00:00Z',
+        ),
+      ),
+    ]);
+    await tester.pumpAndSettle();
+    expect(find.text('Conversazione nuova'), findsOneWidget);
+
+    first.complete([
+      ConversationEntry.honoo(
+        honoo(
+          id: 'old-entry',
+          text: 'Conversazione vecchia',
+          owner: 'me',
+          createdAt: '2026-07-20T10:00:00Z',
+        ),
+      ),
+    ]);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Conversazione nuova'), findsOneWidget);
+    expect(find.text('Conversazione vecchia'), findsNothing);
+  });
 }


### PR DESCRIPTION
## Sintesi

- apre lo Scrigno sulla conversazione e sulla risposta appena salvata, mantenendo stabile la slide durante i refresh Realtime
- ripristina il reveal verticale della risposta e protegge i caricamenti da risultati obsoleti o appartenenti a un altro utente
- rende le notifiche per-utente, deduplicate e recuperabili dopo una disconnessione
- uniforma i flussi di risposta dalla Luna e impedisce di proseguire se il salvataggio della radice fallisce

## Verifica

- flutter analyze
- flutter test --no-pub test/chest_ordering_test.dart test/controllers/chest_controller_test.dart test/services/conversation_service_test.dart test/widgets/chest_item_view_animation_test.dart test/widgets/unified_thread_reveal_test.dart test/widgets/global_reply_notification_listener_test.dart test/pages/reply_honoo_flow_test.dart test/utility/replies_seen_tracker_test.dart