### PR TITLE
fix: stabilize conversation replies and notifications

### DIFF
--- a/lib/Controller/chest_controller.dart
+++ b/lib/Controller/chest_controller.dart
@@ -23,9 +23,10 @@ class ChestState {
   }) : hinoo = List.unmodifiable(hinoo),
        honooLatestReplies = Map.unmodifiable(honooLatestReplies),
        hinooLatestReplies = Map.unmodifiable(hinooLatestReplies),
-       hinooRepliesByRoot = Map.unmodifiable(
-         hinooRepliesByRoot.map(
-           (key, value) => MapEntry(key, List.unmodifiable(value)),
+       hinooRepliesByRoot = Map<String, List<HinooThreadEntry>>.unmodifiable(
+         hinooRepliesByRoot.map<String, List<HinooThreadEntry>>(
+           (key, value) =>
+               MapEntry(key, List<HinooThreadEntry>.unmodifiable(value)),
          ),
        );
 
@@ -368,15 +369,19 @@ class ChestController extends ValueNotifier<ChestState> {
       }
       final seenHonooKeys = <String>{};
       for (final row in honooRows.whereType<Map>()) {
-        final rootId = row['reply_to']?.toString() ?? '';
-        if (rootId.isEmpty) continue;
+        final conversationId = row['conversation_id']?.toString() ?? '';
+        final replyTo = row['reply_to']?.toString() ?? '';
+        final activityKey = conversationId.isNotEmpty
+            ? conversationId
+            : replyTo;
+        if (activityKey.isEmpty) continue;
         final createdRaw = (row['created_at'] ?? '').toString();
-        final key = '$rootId|$createdRaw';
+        final key = '$activityKey|$createdRaw';
         if (!seenHonooKeys.add(key)) continue;
         final created = DateTime.tryParse(createdRaw) ?? DateTime.now();
-        final existing = honooLatest[rootId];
+        final existing = honooLatest[activityKey];
         if (existing == null || created.isAfter(existing)) {
-          honooLatest[rootId] = created;
+          honooLatest[activityKey] = created;
         }
       }
 
@@ -396,6 +401,8 @@ class ChestController extends ValueNotifier<ChestState> {
         final id = row['id']?.toString() ?? '';
         if (id.isNotEmpty && !seenHinooIds.add(id)) continue;
         final rootId = row['reply_to']?.toString() ?? '';
+        final conversationId = row['conversation_id']?.toString() ?? '';
+        final activityKey = conversationId.isNotEmpty ? conversationId : rootId;
         final pages = row['pages'];
         if (rootId.isEmpty || pages is! List) continue;
         final created =
@@ -411,7 +418,7 @@ class ChestController extends ValueNotifier<ChestState> {
           replyTo: rootId,
         );
         hinooReplies
-            .putIfAbsent(rootId, () => [])
+            .putIfAbsent(rootId, () => <HinooThreadEntry>[])
             .add(
               HinooThreadEntry(
                 draft: draft,
@@ -420,9 +427,9 @@ class ChestController extends ValueNotifier<ChestState> {
                 createdAt: created,
               ),
             );
-        final existing = hinooLatest[rootId];
+        final existing = hinooLatest[activityKey];
         if (existing == null || created.isAfter(existing)) {
-          hinooLatest[rootId] = created;
+          hinooLatest[activityKey] = created;
         }
       }
 

--- a/lib/Entities/reply_navigation_result.dart
+++ b/lib/Entities/reply_navigation_result.dart
@@ -1,0 +1,9 @@
+class ReplyNavigationResult {
+  const ReplyNavigationResult({
+    required this.conversationId,
+    required this.replyId,
+  });
+
+  final String conversationId;
+  final String replyId;
+}

--- a/lib/Pages/chest_page.dart
+++ b/lib/Pages/chest_page.dart
@@ -17,10 +17,12 @@ import '../Entities/honoo.dart';
 import '../Entities/hinoo.dart';
 import '../Entities/chest_item.dart';
 import '../Entities/hinoo_thread_entry.dart';
+import '../Entities/reply_navigation_result.dart';
 
 import '../Utility/honoo_colors.dart';
 import '../Utility/responsive_layout.dart';
 import '../Utility/network_image_prefetch.dart';
+import '../Utility/replies_seen_tracker.dart';
 
 import '../Widgets/honoo_dialogs.dart';
 import '../Widgets/loading_spinner.dart';
@@ -78,6 +80,7 @@ class _ChestPageState extends State<ChestPage> with WidgetsBindingObserver {
   int _currentIndex = 0;
   bool _didApplyInitialFocus = false;
   int _conversationRefreshToken = 0;
+  String? _pendingRevealEntryId;
   Object? _honooLoadError;
   bool _isMutating = false;
   bool _isReconciling = false;
@@ -111,9 +114,30 @@ class _ChestPageState extends State<ChestPage> with WidgetsBindingObserver {
     );
   }
 
+  void _selectConversationEntry(ConversationEntry entry) {
+    setState(() => _selectedConvEntry = entry);
+    final currentUserId = SupabaseProvider.client.auth.currentUser?.id;
+    final isReply =
+        entry.honoo?.type == HonooType.answer ||
+        entry.hinoo?.type == HinooType.answer;
+    if (!isReply ||
+        currentUserId == null ||
+        entry.ownerId == currentUserId ||
+        entry.createdAt.millisecondsSinceEpoch <= 0) {
+      return;
+    }
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      unawaited(
+        RepliesSeenTracker.markAt(entry.createdAt, userId: currentUserId),
+      );
+    });
+  }
+
   @override
   void initState() {
     super.initState();
+    _pendingRevealEntryId = widget.focusReplyId;
     WidgetsBinding.instance.addObserver(this);
     _chestController.addListener(_onChestStateChanged);
     unawaited(_initialize());
@@ -247,7 +271,7 @@ class _ChestPageState extends State<ChestPage> with WidgetsBindingObserver {
       widget.focusConversationId ?? '',
       widget.focusReplies ? '1' : '0',
       widget.highlightLatest ? '1' : '0',
-      widget.focusReplyId ?? '',
+      _pendingRevealEntryId ?? '',
       _mode.name,
       _activeConversationId ?? '',
     ].join('|');
@@ -279,8 +303,11 @@ class _ChestPageState extends State<ChestPage> with WidgetsBindingObserver {
       createdAtOf: (item) => item.createdAt,
       stableIdOf: _stableIdOf,
       latestReplyOf: (item) => item.when(
-        honoo: (h) => _honooLatestReplies[h.dbId ?? ''],
-        hinoo: (row) => _hinooLatestReplies[row.id],
+        honoo: (h) => _honooLatestReplies[h.conversationId ?? h.dbId ?? ''],
+        hinoo: (row) =>
+            _hinooLatestReplies[row.conversationId ??
+                row.draft.conversationId ??
+                row.id],
       ),
       conversationIdOf: _convIdOfItem,
     );
@@ -554,7 +581,7 @@ class _ChestPageState extends State<ChestPage> with WidgetsBindingObserver {
           ),
         ),
       );
-      _refreshConversationInPlace(result is String ? result : null);
+      _refreshConversationInPlace(result);
     } else {
       final String? replyTo = current.dbId;
       if (replyTo == null || replyTo.isEmpty) return;
@@ -575,7 +602,7 @@ class _ChestPageState extends State<ChestPage> with WidgetsBindingObserver {
           ),
         ),
       );
-      _refreshConversationInPlace(result is String ? result : null);
+      _refreshConversationInPlace(result);
     }
   }
 
@@ -616,7 +643,7 @@ class _ChestPageState extends State<ChestPage> with WidgetsBindingObserver {
           ),
         ),
       );
-      _refreshConversationInPlace(result is String ? result : null);
+      _refreshConversationInPlace(result);
     } else {
       final String recipient =
           current.ownerId ?? current.draft.recipientTag ?? '';
@@ -639,13 +666,18 @@ class _ChestPageState extends State<ChestPage> with WidgetsBindingObserver {
           ),
         ),
       );
-      _refreshConversationInPlace(result is String ? result : null);
+      _refreshConversationInPlace(result);
     }
   }
 
-  void _refreshConversationInPlace(String? conversationId) {
-    if (!mounted || conversationId == null || conversationId.isEmpty) return;
+  void _refreshConversationInPlace(Object? result) {
+    if (!mounted) return;
+    final navigation = result is ReplyNavigationResult ? result : null;
+    final conversationId =
+        navigation?.conversationId ?? (result is String ? result : null);
+    if (conversationId == null || conversationId.isEmpty) return;
     setState(() {
+      _pendingRevealEntryId = navigation?.replyId;
       _conversationRefreshToken++;
     });
   }
@@ -824,10 +856,8 @@ class _ChestPageState extends State<ChestPage> with WidgetsBindingObserver {
       isActive: isActive,
       highlightLatest: widget.highlightLatest,
       focusConversationId: widget.focusConversationId,
-      revealEntryId: widget.focusReplyId,
-      onSelectConversationEntry: (entry) {
-        setState(() => _selectedConvEntry = entry);
-      },
+      revealEntryId: _pendingRevealEntryId,
+      onSelectConversationEntry: _selectConversationEntry,
       onDownload: () => _handleDownloadForItem(item, repaintKey),
       conversationRefreshToken: _conversationRefreshToken,
     );

--- a/lib/Pages/moon_page.dart
+++ b/lib/Pages/moon_page.dart
@@ -12,6 +12,7 @@ import 'package:honoo/Services/hinoo_service.dart';
 import '../Entities/hinoo.dart';
 import '../Entities/honoo.dart';
 import '../Entities/conversation_link.dart';
+import '../Entities/reply_navigation_result.dart';
 import 'home_page.dart';
 import '../UI/hinoo_viewer.dart';
 import '../UI/hinoo_typography.dart';
@@ -697,7 +698,7 @@ class _MoonPageState extends State<MoonPage> {
     if (choice == null || !mounted) return;
     if (choice == _ReplyChoice.honoo && current.honoo != null) {
       if (!await _ensureMoonItemInChest(current) || !mounted) return;
-      final conversationId = await Navigator.push<String>(
+      final result = await Navigator.push<Object?>(
         context,
         MaterialPageRoute(
           builder: (_) => ReplyHonooPage(
@@ -709,7 +710,7 @@ class _MoonPageState extends State<MoonPage> {
         ),
       );
       if (!mounted) return;
-      await _openConversationAfterReply(current, conversationId);
+      await _openConversationAfterReply(current, result);
     } else if (choice == _ReplyChoice.honoo && current.hinoo != null) {
       // Risposta ad un hinoo con un honoo
       final parentId = current.hinooId;
@@ -722,7 +723,7 @@ class _MoonPageState extends State<MoonPage> {
         recipientId: recipientId,
       );
       if (!await _ensureMoonItemInChest(current) || !mounted) return;
-      final conversationId = await Navigator.push<String>(
+      final result = await Navigator.push<Object?>(
         context,
         MaterialPageRoute(
           builder: (_) => NewHonooPage(
@@ -735,7 +736,7 @@ class _MoonPageState extends State<MoonPage> {
         ),
       );
       if (!mounted) return;
-      await _openConversationAfterReply(current, conversationId);
+      await _openConversationAfterReply(current, result);
     } else if (choice == _ReplyChoice.hinoo && current.hinoo != null) {
       final String? replyTo = current.hinooId;
       if (replyTo == null || replyTo.isEmpty) return;
@@ -747,7 +748,7 @@ class _MoonPageState extends State<MoonPage> {
         recipientId: recipientId,
       );
       if (!await _ensureMoonItemInChest(current) || !mounted) return;
-      final conversationId = await Navigator.push<String>(
+      final result = await Navigator.push<Object?>(
         context,
         MaterialPageRoute(
           builder: (_) => NewHinooPage(
@@ -760,7 +761,7 @@ class _MoonPageState extends State<MoonPage> {
         ),
       );
       if (!mounted) return;
-      await _openConversationAfterReply(current, conversationId);
+      await _openConversationAfterReply(current, result);
     } else if (choice == _ReplyChoice.hinoo && current.honoo != null) {
       // Risposta ad un honoo con un hinoo
       final parentId = current.honoo!.dbId;
@@ -771,7 +772,7 @@ class _MoonPageState extends State<MoonPage> {
         recipientId: current.honoo!.userId,
       );
       if (!await _ensureMoonItemInChest(current) || !mounted) return;
-      final conversationId = await Navigator.push<String>(
+      final result = await Navigator.push<Object?>(
         context,
         MaterialPageRoute(
           builder: (_) => NewHinooPage(
@@ -784,14 +785,17 @@ class _MoonPageState extends State<MoonPage> {
         ),
       );
       if (!mounted) return;
-      await _openConversationAfterReply(current, conversationId);
+      await _openConversationAfterReply(current, result);
     }
   }
 
   Future<void> _openConversationAfterReply(
     _MoonItem current,
-    String? conversationId,
+    Object? result,
   ) async {
+    final navigation = result is ReplyNavigationResult ? result : null;
+    final conversationId =
+        navigation?.conversationId ?? (result is String ? result : null);
     if (conversationId == null || conversationId.isEmpty || !mounted) return;
     final id = current.honoo?.dbId ?? current.hinooId;
     if (id != null && id.isNotEmpty) {
@@ -803,6 +807,7 @@ class _MoonPageState extends State<MoonPage> {
         builder: (_) => ChestPage(
           focusReplies: true,
           focusConversationId: conversationId,
+          focusReplyId: navigation?.replyId,
           highlightLatest: true,
         ),
       ),

--- a/lib/Pages/new_hinoo_page.dart
+++ b/lib/Pages/new_hinoo_page.dart
@@ -21,6 +21,7 @@ import 'email_login_page.dart';
 import 'home_page.dart';
 import 'placeholder_page.dart';
 import '../Entities/hinoo.dart';
+import '../Entities/reply_navigation_result.dart';
 import 'casa_builder_page.dart';
 import '../Widgets/conversation_notification_prompt.dart';
 
@@ -320,7 +321,11 @@ class _NewHinooPageState extends State<NewHinooPage>
         return;
       }
 
-      final savedHinooId = await _controller.saveToChest(hinooDraft);
+      final bool isAnswer =
+          (hinooDraft.type == HinooType.answer) || widget.isReply;
+      final savedHinooId = isAnswer
+          ? await _controller.saveToChestAndReturnId(hinooDraft)
+          : await _controller.saveToChest(hinooDraft);
       if (!mounted) return;
       setState(() => _savedToChest = true);
       _chestBounceController.forward(from: 0);
@@ -328,14 +333,17 @@ class _NewHinooPageState extends State<NewHinooPage>
         await ConversationNotificationPrompt.show(context);
         if (!mounted) return;
       }
-      final bool isAnswer =
-          (hinooDraft.type == HinooType.answer) || widget.isReply;
       if (isAnswer) {
         await showReplySavedDialog(context, contentName: 'hinoo');
         if (!mounted) return;
         final conversationId = hinooDraft.conversationId;
         if (widget.returnToPreviousOnAnswer) {
-          Navigator.of(context).pop(conversationId);
+          Navigator.of(context).pop(
+            ReplyNavigationResult(
+              conversationId: conversationId!,
+              replyId: savedHinooId,
+            ),
+          );
           return;
         }
         Navigator.of(context).pushAndRemoveUntil(
@@ -443,7 +451,7 @@ class _NewHinooPageState extends State<NewHinooPage>
     final HinooType type = widget.isCampanello
         ? HinooType.personal
         : (widget.forcedType ??
-            (widget.isReply ? HinooType.answer : HinooType.personal));
+              (widget.isReply ? HinooType.answer : HinooType.personal));
 
     // Se è una risposta e non è stato passato esplicitamente un conversationId,
     // usa replyTo come conversationId per garantire il raggruppamento.

--- a/lib/Pages/new_honoo_page.dart
+++ b/lib/Pages/new_honoo_page.dart
@@ -6,6 +6,7 @@ import 'package:honoo/Utility/honoo_colors.dart';
 import 'package:honoo/Services/supabase_provider.dart';
 
 import '../Entities/honoo.dart';
+import '../Entities/reply_navigation_result.dart';
 import '../Services/honoo_image_uploader.dart';
 import '../UI/honoo_builder.dart';
 import 'package:honoo/Services/honoo_service.dart';
@@ -211,7 +212,12 @@ class _NewHonooPageState extends State<NewHonooPage> {
         await showReplySavedDialog(context, contentName: 'honoo');
         if (!mounted) return false;
         if (widget.returnToPreviousOnAnswer) {
-          Navigator.of(context).pop(conversationId);
+          Navigator.of(context).pop(
+            ReplyNavigationResult(
+              conversationId: conversationId,
+              replyId: savedReplyId!,
+            ),
+          );
           return true;
         }
         Navigator.of(context).pushAndRemoveUntil(

--- a/lib/Pages/reply_honoo_page.dart
+++ b/lib/Pages/reply_honoo_page.dart
@@ -9,6 +9,7 @@ import 'package:honoo/Widgets/responsive_footer_bar.dart';
 import 'package:honoo/Widgets/honoo_app_title.dart';
 import '../Entities/honoo.dart';
 import '../Entities/conversation_link.dart';
+import '../Entities/reply_navigation_result.dart';
 import 'package:honoo/Services/supabase_provider.dart';
 import 'package:honoo/Controller/honoo_controller.dart';
 import 'chest_page.dart';
@@ -107,7 +108,12 @@ class _ReplyHonooPageState extends State<ReplyHonooPage> {
       await showReplySavedDialog(context, contentName: 'honoo');
       if (!mounted) return;
       if (widget.returnToPreviousOnAnswer) {
-        Navigator.of(context).pop(link.conversationId);
+        Navigator.of(context).pop(
+          ReplyNavigationResult(
+            conversationId: link.conversationId,
+            replyId: replyId,
+          ),
+        );
         return;
       }
       Navigator.of(context).pushAndRemoveUntil(

--- a/lib/Services/chest_repository.dart
+++ b/lib/Services/chest_repository.dart
@@ -8,8 +8,8 @@ class ChestRepository {
   ChestRepository({
     SupabaseClient? client,
     ReliabilityPolicy reliabilityPolicy = const ReliabilityPolicy(),
-  })  : _client = client ?? SupabaseProvider.client,
-        _reliability = reliabilityPolicy;
+  }) : _client = client ?? SupabaseProvider.client,
+       _reliability = reliabilityPolicy;
 
   final SupabaseClient _client;
   final ReliabilityPolicy _reliability;
@@ -32,10 +32,11 @@ class ChestRepository {
       final rows = await _client
           .from('hinoo')
           .select(
-              'id,pages,type,reply_to,recipient_tag,created_at,is_from_moon_saved,user_id,conversation_id')
+            'id,pages,type,reply_to,recipient_tag,created_at,is_from_moon_saved,user_id,conversation_id',
+          )
           .eq('user_id', userId)
-          .in_('type', ['personal', 'answer']).order('created_at',
-              ascending: false);
+          .in_('type', ['personal', 'answer'])
+          .order('created_at', ascending: false);
       return _asList(rows);
     } on PostgrestException catch (error) {
       final combined =
@@ -45,10 +46,11 @@ class ChestRepository {
       final rows = await _client
           .from('hinoo')
           .select(
-              'id,pages,type,reply_to,recipient_tag,created_at,user_id,conversation_id')
+            'id,pages,type,reply_to,recipient_tag,created_at,user_id,conversation_id',
+          )
           .eq('user_id', userId)
-          .in_('type', ['personal', 'answer']).order('created_at',
-              ascending: false);
+          .in_('type', ['personal', 'answer'])
+          .order('created_at', ascending: false);
       return _asList(rows);
     }
   }
@@ -56,12 +58,12 @@ class ChestRepository {
   Future<List<dynamic>> fetchHonooReplyRows(String userId) async {
     final repliesToUser = await _client
         .from('honoo')
-        .select('reply_to,created_at')
+        .select('conversation_id,reply_to,created_at')
         .eq('destination', 'reply')
         .eq('recipient_tag', userId);
     final repliesFromUser = await _client
         .from('honoo')
-        .select('reply_to,created_at')
+        .select('conversation_id,reply_to,created_at')
         .eq('destination', 'reply')
         .eq('user_id', userId);
     return [..._asList(repliesToUser), ..._asList(repliesFromUser)];
@@ -69,23 +71,23 @@ class ChestRepository {
 
   Future<List<dynamic>> fetchHinooReplyRows(
     String userId,
-    List<String> rootIds,
+    List<String> _,
   ) async {
-    if (rootIds.isEmpty) return const [];
-
     final repliesToUser = await _client
         .from('hinoo')
-        .select('id,reply_to,pages,type,recipient_tag,created_at,user_id')
+        .select(
+          'id,conversation_id,reply_to,pages,type,recipient_tag,created_at,user_id',
+        )
         .eq('type', 'answer')
         .eq('recipient_tag', userId)
-        .in_('reply_to', rootIds)
         .order('created_at', ascending: true);
     final repliesFromUser = await _client
         .from('hinoo')
-        .select('id,reply_to,pages,type,recipient_tag,created_at,user_id')
+        .select(
+          'id,conversation_id,reply_to,pages,type,recipient_tag,created_at,user_id',
+        )
         .eq('type', 'answer')
         .eq('user_id', userId)
-        .in_('reply_to', rootIds)
         .order('created_at', ascending: true);
     return [..._asList(repliesToUser), ..._asList(repliesFromUser)];
   }

--- a/lib/UI/unified_thread_view.dart
+++ b/lib/UI/unified_thread_view.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:honoo/Entities/hinoo.dart';
 import 'package:honoo/Entities/honoo.dart';
@@ -52,6 +53,8 @@ class _UnifiedThreadViewState extends State<UnifiedThreadView>
   List<ConversationEntry> _entries = const [];
   RealtimeChannel? _chan;
   String? _revealedEntryKey;
+  String? _appliedFocusKey;
+  int _currentPageIndex = 0;
   int _loadGeneration = 0;
   final PageController _pageController = PageController();
   late AnimationController _controller;
@@ -118,6 +121,7 @@ class _UnifiedThreadViewState extends State<UnifiedThreadView>
     if (!mounted) return;
     final generation = ++_loadGeneration;
     final conversationId = widget.conversationId;
+    final pageBeforeLoad = _currentPageIndex;
     if (_entries.isEmpty) {
       setState(() => _loading = true);
     }
@@ -132,15 +136,20 @@ class _UnifiedThreadViewState extends State<UnifiedThreadView>
           conversationId != widget.conversationId) {
         return;
       }
+      final wasEmpty = _entries.isEmpty;
       setState(() {
         _entries = entries;
         _loading = false;
         _loadError = null;
       });
       _prefetchEntriesFrom(_pageToShowFirst);
-      _showLatestReceivedAndReveal();
+      _showLatestReceivedAndReveal(forceFocus: wasEmpty);
       if (widget.isActive && _entries.isNotEmpty) {
-        widget.onSelect?.call(_entryToShowFirst);
+        final hasExplicitReveal = (widget.revealEntryId ?? '').isNotEmpty;
+        final selectedPage = (wasEmpty || hasExplicitReveal)
+            ? _pageToShowFirst
+            : pageBeforeLoad.clamp(0, _entries.length - 1);
+        widget.onSelect?.call(_entries.reversed.elementAt(selectedPage));
       }
     } catch (error) {
       if (!mounted ||
@@ -177,6 +186,8 @@ class _UnifiedThreadViewState extends State<UnifiedThreadView>
       _chan?.unsubscribe();
       _chan = null;
       _revealedEntryKey = null;
+      _appliedFocusKey = null;
+      _currentPageIndex = 0;
       _entries = const [];
       _loading = true;
       _loadError = null;
@@ -199,15 +210,9 @@ class _UnifiedThreadViewState extends State<UnifiedThreadView>
     }
     if (oldWidget.revealEntryId != widget.revealEntryId) {
       _revealedEntryKey = null;
+      _appliedFocusKey = null;
+      _showLatestReceivedAndReveal(forceFocus: true);
     }
-    if (widget.isActive) _showLatestReceivedAndReveal();
-  }
-
-  ConversationEntry get _entryToShowFirst {
-    for (final entry in _entries.reversed) {
-      if (_shouldReveal(entry)) return entry;
-    }
-    return _entries.last;
   }
 
   int get _pageToShowFirst {
@@ -223,15 +228,22 @@ class _UnifiedThreadViewState extends State<UnifiedThreadView>
     return receivedIndex < 0 ? 0 : receivedIndex;
   }
 
-  void _showLatestReceivedAndReveal() {
+  void _showLatestReceivedAndReveal({bool forceFocus = false}) {
     if (!widget.isActive || _entries.isEmpty || !mounted) return;
+    final targetPage = _pageToShowFirst;
+    final entry = _entries.reversed.elementAt(targetPage);
+    final focusKey = '${widget.conversationId}:${entry.kind.name}:${entry.id}';
+    if (_appliedFocusKey == focusKey) return;
+    if (!forceFocus && widget.revealEntryId == null && _currentPageIndex != 0) {
+      return;
+    }
+    _appliedFocusKey = focusKey;
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted || !widget.isActive || _entries.isEmpty) return;
-      final targetPage = _pageToShowFirst;
       if (_pageController.hasClients) {
         _pageController.jumpToPage(targetPage);
+        _currentPageIndex = targetPage;
       }
-      final entry = _entries.reversed.elementAt(targetPage);
       final entryKey = '${entry.kind.name}:${entry.id}';
       if (_revealedEntryKey != entryKey && _shouldReveal(entry)) {
         _revealedEntryKey = entryKey;
@@ -342,57 +354,71 @@ class _UnifiedThreadViewState extends State<UnifiedThreadView>
     return SizedBox(
       width: widget.maxWidth,
       height: widget.maxHeight,
-      child: PageView.builder(
-        controller: _pageController,
-        scrollDirection: Axis.vertical,
-        pageSnapping: true,
-        physics: const PageScrollPhysics(parent: ClampingScrollPhysics()),
-        onPageChanged: (index) {
-          _prefetchEntriesFrom(index);
-          final reversed = _entries.reversed.toList(growable: false);
-          if (index >= 0 && index < reversed.length) {
-            widget.onSelect?.call(reversed[index]);
-          }
-        },
-        itemCount: _entries.length,
-        itemBuilder: (context, index) {
-          // Ordine inverso: ultimo (più recente) in cima
-          final revIndex = _entries.length - 1 - index;
-          final e = _entries[revIndex];
-          final Widget page = _entryCard(e);
-          if (index == _pageToShowFirst && _shouldReveal(e)) {
-            final answeredEntry = _answeredEntryFor(e);
-            final answeredPage = answeredEntry == null
-                ? null
-                : Transform.translate(
-                    offset: Offset(0, widget.maxHeight * 0.52),
-                    child: _entryCard(
-                      answeredEntry,
-                      keyName: 'reply_reveal_parent',
+      child: ScrollConfiguration(
+        behavior: ScrollConfiguration.of(context).copyWith(
+          dragDevices: {
+            PointerDeviceKind.touch,
+            PointerDeviceKind.mouse,
+            PointerDeviceKind.stylus,
+            PointerDeviceKind.trackpad,
+          },
+        ),
+        child: PageView.builder(
+          controller: _pageController,
+          scrollDirection: Axis.vertical,
+          pageSnapping: true,
+          physics: const PageScrollPhysics(parent: ClampingScrollPhysics()),
+          onPageChanged: (index) {
+            _currentPageIndex = index;
+            _prefetchEntriesFrom(index);
+            final reversed = _entries.reversed.toList(growable: false);
+            if (index >= 0 && index < reversed.length) {
+              widget.onSelect?.call(reversed[index]);
+            }
+          },
+          itemCount: _entries.length,
+          itemBuilder: (context, index) {
+            // Ordine inverso: ultimo (più recente) in cima
+            final revIndex = _entries.length - 1 - index;
+            final e = _entries[revIndex];
+            final Widget page = _entryCard(e);
+            if (index == _pageToShowFirst && _shouldReveal(e)) {
+              final answeredEntry = _answeredEntryFor(e);
+              final answeredPage = answeredEntry == null
+                  ? null
+                  : Transform.translate(
+                      offset: Offset(0, widget.maxHeight * 0.52),
+                      child: _entryCard(
+                        answeredEntry,
+                        keyName: 'reply_reveal_parent',
+                      ),
+                    );
+              return AnimatedBuilder(
+                animation: _liftAnimation,
+                builder: (context, childWidget) {
+                  final double revealHeight = widget.maxHeight * 0.48;
+                  return ClipRect(
+                    child: Stack(
+                      children: [
+                        if (answeredPage != null) answeredPage,
+                        Transform.translate(
+                          key: const Key('reply_reveal_foreground'),
+                          offset: Offset(
+                            0,
+                            _liftAnimation.value * revealHeight,
+                          ),
+                          child: childWidget,
+                        ),
+                      ],
                     ),
                   );
-            return AnimatedBuilder(
-              animation: _liftAnimation,
-              builder: (context, childWidget) {
-                final double revealHeight = widget.maxHeight * 0.48;
-                return ClipRect(
-                  child: Stack(
-                    children: [
-                      if (answeredPage != null) answeredPage,
-                      Transform.translate(
-                        key: const Key('reply_reveal_foreground'),
-                        offset: Offset(0, _liftAnimation.value * revealHeight),
-                        child: childWidget,
-                      ),
-                    ],
-                  ),
-                );
-              },
-              child: page,
-            );
-          }
-          return page;
-        },
+                },
+                child: page,
+              );
+            }
+            return page;
+          },
+        ),
       ),
     );
   }

--- a/lib/Widgets/chest_item_view.dart
+++ b/lib/Widgets/chest_item_view.dart
@@ -150,7 +150,12 @@ class ChestItemView extends StatelessWidget {
     isActive: isActive,
     onSelect: onSelectConversationEntry,
     highlightLatest: highlightLatest && focusConversationId == conversationId,
-    revealEntryId: focusConversationId == conversationId ? revealEntryId : null,
+    revealEntryId:
+        isActive &&
+            (focusConversationId == null ||
+                focusConversationId == conversationId)
+        ? revealEntryId
+        : null,
     onDownloadTap: onDownload,
     refreshToken: conversationRefreshToken,
   );

--- a/lib/Widgets/global_reply_notification_listener.dart
+++ b/lib/Widgets/global_reply_notification_listener.dart
@@ -7,8 +7,8 @@ import '../Entities/reply_notification_event.dart';
 import '../Pages/chest_page.dart';
 import '../Services/reply_system_notification.dart';
 import '../Services/supabase_provider.dart';
-import '../Utility/replies_seen_tracker.dart';
 import '../Utility/reply_notification_signal.dart';
+import '../Utility/replies_seen_tracker.dart';
 
 class GlobalReplyNotificationListener extends StatefulWidget {
   const GlobalReplyNotificationListener({
@@ -258,10 +258,6 @@ class _GlobalReplyNotificationListenerState
   }
 
   void _openConversation(ReplyNotificationEvent event) {
-    final seenAt = event.createdAt;
-    if (seenAt != null) {
-      unawaited(RepliesSeenTracker.markAt(seenAt, userId: event.recipientId));
-    }
     widget.navigatorKey.currentState?.push(
       MaterialPageRoute(
         builder: (_) => ChestPage(

--- a/lib/Widgets/sea_footer_bar.dart
+++ b/lib/Widgets/sea_footer_bar.dart
@@ -7,8 +7,6 @@ import 'package:honoo/Widgets/composer_onboarding.dart';
 // Pagine per la navigazione (come in HomePage)
 import 'package:honoo/IsolaDelleStorie/Pages/island_page.dart';
 import 'package:honoo/Pages/chest_page.dart';
-import 'package:honoo/Utility/replies_seen_tracker.dart';
-import 'package:honoo/Services/supabase_provider.dart';
 
 /// Barra “mare” riutilizzabile con onde + isola (sx) + scrigno (centro) + bottiglia (dx)
 /// Posizioni, dimensioni e z-order identici alla HomePage.
@@ -186,12 +184,6 @@ class SeaFooterBar extends StatelessWidget {
                         splashRadius: 40,
                         tooltip: 'Apri il tuo Cuore',
                         onPressed: () {
-                          if (replyCount > 0) {
-                            RepliesSeenTracker.markNow(
-                              userId:
-                                  SupabaseProvider.client.auth.currentUser?.id,
-                            );
-                          }
                           Navigator.push(
                             context,
                             MaterialPageRoute(

--- a/test/controllers/chest_controller_test.dart
+++ b/test/controllers/chest_controller_test.dart
@@ -133,20 +133,52 @@ void main() {
   test('loadReplies deduplica e conserva la risposta più recente', () async {
     when(() => repository.fetchHonooReplyRows('user-1')).thenAnswer(
       (_) async => [
-        {'reply_to': 'root-1', 'created_at': '2024-01-01T10:00:00Z'},
-        {'reply_to': 'root-1', 'created_at': '2024-01-01T12:00:00Z'},
-        {'reply_to': 'root-1', 'created_at': '2024-01-01T12:00:00Z'},
+        {
+          'conversation_id': 'conversation-1',
+          'reply_to': 'root-1',
+          'created_at': '2024-01-01T10:00:00Z',
+        },
+        {
+          'conversation_id': 'conversation-1',
+          'reply_to': 'reply-1',
+          'created_at': '2024-01-01T12:00:00Z',
+        },
+        {
+          'conversation_id': 'conversation-1',
+          'reply_to': 'reply-1',
+          'created_at': '2024-01-01T12:00:00Z',
+        },
       ],
     );
-    when(
-      () => repository.fetchHinooReplyRows('user-1', const []),
-    ).thenAnswer((_) async => const []);
+    when(() => repository.fetchHinooReplyRows('user-1', const [])).thenAnswer(
+      (_) async => [
+        {
+          'id': 'hinoo-reply-2',
+          'conversation_id': 'hinoo-conversation-1',
+          'reply_to': 'hinoo-reply-1',
+          'created_at': '2024-01-01T13:00:00Z',
+          'user_id': 'user-2',
+          'pages': [
+            <String, dynamic>{
+              'backgroundImage': 'background.png',
+              'text': 'Risposta concatenata',
+              'isTextWhite': true,
+            },
+          ],
+        },
+      ],
+    );
 
     await controller.loadReplies('user-1');
 
+    expect(controller.value.replyError, isNull);
     expect(
-      controller.value.honooLatestReplies['root-1'],
+      controller.value.honooLatestReplies['conversation-1'],
       DateTime.parse('2024-01-01T12:00:00Z'),
+    );
+    expect(
+      controller.value.hinooLatestReplies['hinoo-conversation-1'],
+      DateTime.parse('2024-01-01T13:00:00Z'),
     );
     expect(controller.value.isReplyLoading, isFalse);
     expect(

--- a/test/pages/reply_honoo_flow_test.dart
+++ b/test/pages/reply_honoo_flow_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:honoo/Pages/chest_page.dart';
 import 'package:honoo/Pages/reply_honoo_page.dart';
 import 'package:honoo/Entities/honoo.dart';
+import 'package:honoo/Entities/reply_navigation_result.dart';
 import 'package:honoo/Widgets/honoo_dialogs.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:sizer/sizer.dart';
@@ -95,7 +96,7 @@ void main() {
   testWidgets(
     'ReplyHonooPage: nello Scrigno restituisce la conversazione aggiornata',
     (tester) async {
-      final result = ValueNotifier<String?>(null);
+      final result = ValueNotifier<ReplyNavigationResult?>(null);
       final original = Honoo(
         1,
         '“Testo origine”',
@@ -114,14 +115,15 @@ void main() {
                 builder: (context) => Scaffold(
                   body: ElevatedButton(
                     onPressed: () async {
-                      result.value = await Navigator.of(context).push<String>(
-                        MaterialPageRoute(
-                          builder: (_) => ReplyHonooPage(
-                            originalHonoo: original,
-                            returnToPreviousOnAnswer: true,
-                          ),
-                        ),
-                      );
+                      result.value = await Navigator.of(context)
+                          .push<ReplyNavigationResult>(
+                            MaterialPageRoute(
+                              builder: (_) => ReplyHonooPage(
+                                originalHonoo: original,
+                                returnToPreviousOnAnswer: true,
+                              ),
+                            ),
+                          );
                     },
                     child: const Text('Rispondi'),
                   ),
@@ -145,7 +147,8 @@ void main() {
       ).pop();
       await tester.pumpAndSettle();
 
-      expect(result.value, '1');
+      expect(result.value?.conversationId, '1');
+      expect(result.value?.replyId, 'reply-1');
       expect(find.byType(ReplyHonooPage), findsNothing);
       expect(find.text('Rispondi'), findsOneWidget);
     },

--- a/test/widgets/unified_thread_reveal_test.dart
+++ b/test/widgets/unified_thread_reveal_test.dart
@@ -198,6 +198,65 @@ void main() {
     expect(find.byKey(const Key('reply_reveal_parent')), findsOneWidget);
   });
 
+  testWidgets('lo swipe resta sulla pagina scelta dopo il rebuild del padre', (
+    tester,
+  ) async {
+    tester.view.devicePixelRatio = 1;
+    tester.view.physicalSize = const Size(600, 900);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    addTearDown(tester.view.resetPhysicalSize);
+
+    final root = ConversationEntry.honoo(
+      honoo(
+        id: 'root-scroll',
+        text: 'Contenuto a cui si è risposto',
+        owner: 'me',
+        createdAt: '2026-07-20T10:00:00Z',
+      ),
+    );
+    final reply = ConversationEntry.honoo(
+      honoo(
+        id: 'reply-scroll',
+        text: 'Risposta inizialmente visibile',
+        owner: 'other',
+        createdAt: '2026-07-20T11:00:00Z',
+        type: HonooType.answer,
+        replyTo: 'root-scroll',
+      ),
+    );
+    String? selectedId;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: StatefulBuilder(
+          builder: (context, setState) => Scaffold(
+            body: UnifiedThreadView(
+              conversationId: 'conversation-1',
+              maxWidth: 600,
+              maxHeight: 700,
+              isActive: true,
+              currentUserId: 'me',
+              conversationLoader: (_) async => [root, reply],
+              onSelect: (entry) {
+                selectedId = entry.id;
+                setState(() {});
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 1000));
+    expect(selectedId, 'reply-scroll');
+
+    await tester.drag(find.byType(PageView), const Offset(0, -650));
+    await tester.pumpAndSettle();
+
+    expect(selectedId, 'root-scroll');
+    expect(find.text('Contenuto a cui si è risposto'), findsOneWidget);
+  });
+
   testWidgets('un errore di conversazione mostra Riprova', (tester) async {
     await tester.pumpWidget(
       MaterialApp(


### PR DESCRIPTION
## Cosa cambia

- mantiene lo swipe verticale sulla pagina scelta anche dopo il rebuild del contenitore
- riapre la conversazione e mette a fuoco la risposta appena salvata tramite un risultato di navigazione tipizzato
- usa `conversation_id` per ordinare correttamente l’attività, incluse le risposte concatenate Honoo/Hinoo
- segna una notifica come letta solo dopo aver visualizzato una risposta ricevuta
- conserva il popup di conferma richiesto dopo il salvataggio
- corregge il tipo runtime delle liste di risposte Hinoo nello stato dello Scrigno

## Causa

Il rebuild provocato da `onPageChanged` riapplicava sempre il salto alla risposta più recente, annullando lo swipe. Inoltre, alcuni flussi restituivano l’ID conversazione senza l’ID esatto della risposta appena salvata (e Hinoo poteva restituire un fingerprint), mentre attività e stato letto venivano calcolati o aggiornati troppo presto.

## Verifiche

- `flutter analyze --no-pub`
- `flutter test --no-pub` — 228 test passati, 7 saltati perché opzionali/live
- `git diff --cached --check`
