### PR TITLE
Ingrandisci le icone delle azioni Home

### DIFF
--- a/lib/Pages/home_page.dart
+++ b/lib/Pages/home_page.dart
@@ -146,9 +146,9 @@ class _HomeIntro extends StatelessWidget {
   const _HomeIntro();
 
   static const double _designWidth = 360;
-  static const double _bottleIconSize = 33;
+  static const double _bottleIconSize = 35;
   static const double _moonIconSize = 23;
-  static const double _islandIconSize = 34;
+  static const double _islandIconSize = 36;
   static const double _bottleIconVerticalOffset = 9;
   static const double _moonIconVerticalOffset = 1;
   static const double _islandIconVerticalOffset = 10;

--- a/test/pages/home_page_layout_test.dart
+++ b/test/pages/home_page_layout_test.dart
@@ -60,9 +60,9 @@ void main() {
     }
 
     for (final entry in const [
-      (Key('home_inline_bottle'), 33.0),
+      (Key('home_inline_bottle'), 35.0),
       (Key('home_inline_moon'), 23.0),
-      (Key('home_inline_island'), 34.0),
+      (Key('home_inline_island'), 36.0),
     ]) {
       final key = entry.$1;
       final button = tester.widget<IconButton>(find.byKey(key));


### PR DESCRIPTION
## Modifiche
- aumenta la bottiglia Home da 33 a 35 px
- aumenta l’isola Home da 34 a 36 px
- aggiorna il test di layout con le nuove dimensioni

## Verifiche
- `flutter analyze`
- `flutter test --no-pub` (228 test superati, 7 saltati)