### PR TITLE
Fix conversation visibility, preservation, and chest ordering

### DIFF
--- a/lib/Controller/chest_organizer.dart
+++ b/lib/Controller/chest_organizer.dart
@@ -19,35 +19,25 @@ class ChestOrganizer {
     required DateTime? Function(T item) latestReplyOf,
     required String? Function(T item) conversationIdOf,
   }) {
-    final conversationItems = <T>[];
-    final otherItems = <T>[];
-
-    for (final item in items) {
-      if (latestReplyOf(item) != null) {
-        conversationItems.add(item);
-      } else {
-        otherItems.add(item);
-      }
-    }
-
     int compareCreatedAt(T a, T b) {
       final byCreated = createdAtOf(b).compareTo(createdAtOf(a));
       if (byCreated != 0) return byCreated;
       return stableIdOf(a).compareTo(stableIdOf(b));
     }
 
-    conversationItems.sort((a, b) {
-      final aReply = latestReplyOf(a);
-      final bReply = latestReplyOf(b);
-      if (aReply == null && bReply == null) return compareCreatedAt(a, b);
-      if (aReply == null) return 1;
-      if (bReply == null) return -1;
-      final byLatest = bReply.compareTo(aReply);
-      return byLatest != 0 ? byLatest : compareCreatedAt(a, b);
-    });
-    otherItems.sort(compareCreatedAt);
+    DateTime activityOf(T item) {
+      final createdAt = createdAtOf(item);
+      final latestReply = latestReplyOf(item);
+      return latestReply != null && latestReply.isAfter(createdAt)
+          ? latestReply
+          : createdAt;
+    }
 
-    final ordered = <T>[...conversationItems, ...otherItems];
+    final ordered = List<T>.of(items)
+      ..sort((a, b) {
+        final byActivity = activityOf(b).compareTo(activityOf(a));
+        return byActivity != 0 ? byActivity : compareCreatedAt(a, b);
+      });
     final regrouped = <T>[];
     final consumed = <int>{};
 
@@ -78,7 +68,10 @@ class ChestOrganizer {
         continue;
       }
 
-      group.sort(compareCreatedAt);
+      group.sort((a, b) {
+        final byActivity = activityOf(b).compareTo(activityOf(a));
+        return byActivity != 0 ? byActivity : compareCreatedAt(a, b);
+      });
       // Ogni conversazione occupa una sola slide del carosello. La slide
       // renderizza poi l'intero thread tramite UnifiedThreadView.
       regrouped.add(group.first);
@@ -87,7 +80,9 @@ class ChestOrganizer {
 
     return ChestOrganization<T>(
       items: List.unmodifiable(regrouped),
-      conversationItemCount: conversationItems.length,
+      conversationItemCount: items
+          .where((item) => latestReplyOf(item) != null)
+          .length,
     );
   }
 }

--- a/lib/Entities/conversation_entry.dart
+++ b/lib/Entities/conversation_entry.dart
@@ -1,7 +1,7 @@
 import 'package:honoo/Entities/hinoo.dart';
 import 'package:honoo/Entities/honoo.dart';
 
-enum ConversationEntryKind { honoo, hinoo }
+enum ConversationEntryKind { honoo, hinoo, deleted }
 
 class ConversationEntry {
   final ConversationEntryKind kind;
@@ -25,15 +25,16 @@ class ConversationEntry {
   });
 
   factory ConversationEntry.honoo(Honoo h) => ConversationEntry._(
-        ConversationEntryKind.honoo,
-        honoo: h,
-        createdAt: DateTime.tryParse(h.createdAt) ??
-            DateTime.fromMillisecondsSinceEpoch(0),
-        ownerId: h.userId,
-        id: h.dbId,
-        replyTo: h.replyTo,
-        isFromMoonSaved: h.isFromMoonSaved,
-      );
+    ConversationEntryKind.honoo,
+    honoo: h,
+    createdAt:
+        DateTime.tryParse(h.createdAt) ??
+        DateTime.fromMillisecondsSinceEpoch(0),
+    ownerId: h.userId,
+    id: h.dbId,
+    replyTo: h.replyTo,
+    isFromMoonSaved: h.isFromMoonSaved,
+  );
 
   factory ConversationEntry.hinoo(
     HinooDraft d, {
@@ -41,14 +42,22 @@ class ConversationEntry {
     String? ownerId,
     String? id,
     bool isFromMoonSaved = false,
-  }) =>
-      ConversationEntry._(
-        ConversationEntryKind.hinoo,
-        hinoo: d,
-        createdAt: createdAt,
-        ownerId: ownerId,
-        id: id,
-        replyTo: d.replyTo,
-        isFromMoonSaved: isFromMoonSaved,
-      );
+  }) => ConversationEntry._(
+    ConversationEntryKind.hinoo,
+    hinoo: d,
+    createdAt: createdAt,
+    ownerId: ownerId,
+    id: id,
+    replyTo: d.replyTo,
+    isFromMoonSaved: isFromMoonSaved,
+  );
+
+  factory ConversationEntry.deleted({
+    required String id,
+    required DateTime createdAt,
+  }) => ConversationEntry._(
+    ConversationEntryKind.deleted,
+    id: id,
+    createdAt: createdAt,
+  );
 }

--- a/lib/Pages/chest_page.dart
+++ b/lib/Pages/chest_page.dart
@@ -595,6 +595,7 @@ class _ChestPageState extends State<ChestPage> with WidgetsBindingObserver {
         context,
         MaterialPageRoute(
           builder: (context) => NewHinooPage(
+            targetContentName: 'honoo',
             forcedType: HinooType.answer,
             recipientTag: link.recipientId,
             replyTo: link.replyTo,
@@ -624,6 +625,7 @@ class _ChestPageState extends State<ChestPage> with WidgetsBindingObserver {
         context,
         MaterialPageRoute(
           builder: (context) => ReplyHonooPage(
+            targetContentName: 'hinoo',
             originalHonoo:
                 Honoo(
                     0,
@@ -659,6 +661,7 @@ class _ChestPageState extends State<ChestPage> with WidgetsBindingObserver {
         context,
         MaterialPageRoute(
           builder: (context) => NewHinooPage(
+            targetContentName: 'hinoo',
             forcedType: HinooType.answer,
             recipientTag: link.recipientId,
             replyTo: link.replyTo,

--- a/lib/Pages/chest_page.dart
+++ b/lib/Pages/chest_page.dart
@@ -516,6 +516,7 @@ class _ChestPageState extends State<ChestPage> with WidgetsBindingObserver {
 
   Future<void> _sendConversationEntryToMoon(ConversationEntry entry) async {
     if (_isMutating) return;
+    if (entry.kind == ConversationEntryKind.deleted) return;
     setState(() => _isMutating = true);
     try {
       if (entry.kind == ConversationEntryKind.honoo) {

--- a/lib/Pages/moon_page.dart
+++ b/lib/Pages/moon_page.dart
@@ -571,11 +571,32 @@ class _MoonPageState extends State<MoonPage> {
     if (_items.isEmpty) return;
     final _MoonItem current = _items[_currentIndex];
     final bool isHonoo = current.honoo != null;
+    final String kind = isHonoo ? 'honoo' : 'hinoo';
+    final String? id = isHonoo ? current.honoo!.dbId : current.hinooId;
+    if (id == null || id.isEmpty) return;
+
+    final bool hasConversation;
+    try {
+      hasConversation = await _contentFeedService.moonContentHasConversation(
+        kind: kind,
+        id: id,
+      );
+    } catch (error) {
+      if (!mounted) return;
+      showHonooToast(
+        context,
+        message: 'Non riesco a verificare le conversazioni collegate: $error',
+      );
+      return;
+    }
+    if (!mounted) return;
     final bool? confirmed = await showDialog<bool>(
       context: context,
       barrierDismissible: true,
-      builder: (_) => const HonooConfirmDialog(
-        title: 'Vuoi davvero eliminarlo?',
+      builder: (_) => HonooConfirmDialog(
+        title: hasConversation
+            ? 'Questo contenuto fa parte di una conversazione, vuoi eliminarlo?'
+            : 'Vuoi davvero eliminarlo?',
         message: '',
         confirmLabel: 'Sì',
         cancelLabel: 'No',
@@ -584,15 +605,7 @@ class _MoonPageState extends State<MoonPage> {
     if (confirmed != true) return;
 
     try {
-      if (isHonoo) {
-        final id = current.honoo!.dbId;
-        if (id == null || id.isEmpty) return;
-        await HonooService.deleteHonooById(id);
-      } else {
-        final id = current.hinooId;
-        if (id == null || id.isEmpty) return;
-        await HinooService.deleteHinooById(id);
-      }
+      await _contentFeedService.deleteMoonContent(kind: kind, id: id);
       if (!mounted) return;
       // Calcola il target come l'ultimo elemento visto prima di quello cancellato
       final int desired = (_currentIndex > 0) ? _currentIndex - 1 : 0;

--- a/lib/Pages/moon_page.dart
+++ b/lib/Pages/moon_page.dart
@@ -31,7 +31,6 @@ import 'reply_honoo_page.dart';
 import 'new_hinoo_page.dart';
 import 'new_honoo_page.dart';
 import '../Controller/honoo_controller.dart';
-import '../Controller/hinoo_controller.dart';
 import '../Utility/app_logger.dart';
 import '../Utility/network_image_prefetch.dart';
 
@@ -550,21 +549,38 @@ class _MoonPageState extends State<MoonPage> {
               ? 'honoo salvato nello Scrigno.'
               : 'Era già nel tuo Scrigno.',
         );
+        _openSavedMoonItemInChest(honoo.conversationId ?? honoo.dbId);
         return;
       }
       if (current.hinoo != null) {
         final draft = current.hinoo!.copyWith(
           type: HinooType.personal,
           isFromMoonSaved: true,
+          conversationId: current.hinoo!.conversationId ?? current.hinooId,
         );
-        await HinooController().saveToChest(draft);
+        final saved = await HinooService.duplicateMoonToChest(draft);
         if (!mounted) return;
-        showHonooToast(context, message: 'hinoo salvato nello Scrigno.');
+        showHonooToast(
+          context,
+          message: saved == DuplicationResult.inserted
+              ? 'hinoo salvato nello Scrigno.'
+              : 'Era già nel tuo Scrigno.',
+        );
+        _openSavedMoonItemInChest(draft.conversationId);
       }
     } catch (e) {
       if (!mounted) return;
       showHonooToast(context, message: 'Errore: $e');
     }
+  }
+
+  void _openSavedMoonItemInChest(String? conversationId) {
+    if (!mounted) return;
+    Navigator.of(context).pushReplacement(
+      MaterialPageRoute(
+        builder: (_) => ChestPage(focusConversationId: conversationId),
+      ),
+    );
   }
 
   Future<void> _deleteCurrentFromMoon() async {
@@ -740,6 +756,7 @@ class _MoonPageState extends State<MoonPage> {
         context,
         MaterialPageRoute(
           builder: (_) => NewHonooPage(
+            targetContentName: 'hinoo',
             forcedType: HonooType.answer,
             recipientTag: link.recipientId,
             replyTo: link.replyTo,
@@ -765,6 +782,7 @@ class _MoonPageState extends State<MoonPage> {
         context,
         MaterialPageRoute(
           builder: (_) => NewHinooPage(
+            targetContentName: 'hinoo',
             forcedType: HinooType.answer,
             recipientTag: link.recipientId,
             replyTo: link.replyTo,
@@ -789,6 +807,7 @@ class _MoonPageState extends State<MoonPage> {
         context,
         MaterialPageRoute(
           builder: (_) => NewHinooPage(
+            targetContentName: 'honoo',
             forcedType: HinooType.answer,
             recipientTag: link.recipientId,
             replyTo: link.replyTo,

--- a/lib/Pages/new_hinoo_page.dart
+++ b/lib/Pages/new_hinoo_page.dart
@@ -24,6 +24,7 @@ import '../Entities/hinoo.dart';
 import '../Entities/reply_navigation_result.dart';
 import 'casa_builder_page.dart';
 import '../Widgets/conversation_notification_prompt.dart';
+import '../Widgets/repeated_reply_prompt.dart';
 
 class NewHinooPage extends StatefulWidget {
   const NewHinooPage({
@@ -36,6 +37,7 @@ class NewHinooPage extends StatefulWidget {
     this.replyTo,
     this.conversationId,
     this.returnToPreviousOnAnswer = false,
+    this.targetContentName = 'hinoo',
   });
 
   final bool isReply;
@@ -46,6 +48,7 @@ class NewHinooPage extends StatefulWidget {
   final String? replyTo;
   final String? conversationId;
   final bool returnToPreviousOnAnswer;
+  final String targetContentName;
 
   @override
   State<NewHinooPage> createState() => _NewHinooPageState();
@@ -179,7 +182,7 @@ class _NewHinooPageState extends State<NewHinooPage>
       return;
     }
 
-    final HinooDraft hinooDraft = _convertRawBuilderDraft(rawDraft);
+    var hinooDraft = _convertRawBuilderDraft(rawDraft);
 
     final user = SupabaseProvider.client.auth.currentUser;
     if (user == null) {
@@ -295,6 +298,17 @@ class _NewHinooPageState extends State<NewHinooPage>
     }
 
     final userId = SupabaseProvider.client.auth.currentUser?.id;
+    if (hinooDraft.type == HinooType.answer &&
+        widget.replyTo?.isNotEmpty == true) {
+      final selectedConversationId = await chooseReplyConversation(
+        context: context,
+        parentId: widget.replyTo!,
+        defaultConversationId: hinooDraft.conversationId ?? widget.replyTo!,
+        contentName: widget.targetContentName,
+      );
+      if (selectedConversationId == null || !mounted) return;
+      hinooDraft = hinooDraft.copyWith(conversationId: selectedConversationId);
+    }
     final bool shouldOfferNotifications =
         userId != null &&
         hinooDraft.type == HinooType.personal &&

--- a/lib/Pages/new_honoo_page.dart
+++ b/lib/Pages/new_honoo_page.dart
@@ -23,6 +23,7 @@ import 'placeholder_page.dart';
 import '../Utility/responsive_layout.dart';
 import '../Widgets/responsive_footer_bar.dart';
 import '../Widgets/conversation_notification_prompt.dart';
+import '../Widgets/repeated_reply_prompt.dart';
 import 'package:uuid/uuid.dart';
 
 class NewHonooPage extends StatefulWidget {
@@ -34,6 +35,7 @@ class NewHonooPage extends StatefulWidget {
     this.conversationId,
     this.replyTo,
     this.returnToPreviousOnAnswer = false,
+    this.targetContentName = 'honoo',
   });
 
   final HonooType? forcedType;
@@ -42,6 +44,7 @@ class NewHonooPage extends StatefulWidget {
   final String? conversationId;
   final String? replyTo;
   final bool returnToPreviousOnAnswer;
+  final String targetContentName;
 
   @override
   State<NewHonooPage> createState() => _NewHonooPageState();
@@ -161,7 +164,18 @@ class _NewHonooPageState extends State<NewHonooPage> {
     // 4) Crea e salva
     final HonooType type = widget.forcedType ?? HonooType.personal;
     // conversation: se risposta usa quella fornita; altrimenti genera una nuova
-    final String conversationId = widget.conversationId ?? const Uuid().v4();
+    String conversationId = widget.conversationId ?? const Uuid().v4();
+    if (type == HonooType.answer && widget.replyTo?.isNotEmpty == true) {
+      if (!mounted) return false;
+      final selectedConversationId = await chooseReplyConversation(
+        context: context,
+        parentId: widget.replyTo!,
+        defaultConversationId: conversationId,
+        contentName: widget.targetContentName,
+      );
+      if (selectedConversationId == null || !mounted) return false;
+      conversationId = selectedConversationId;
+    }
     final newHonoo = Honoo(
       0,
       _text,

--- a/lib/Pages/reply_honoo_page.dart
+++ b/lib/Pages/reply_honoo_page.dart
@@ -10,6 +10,7 @@ import 'package:honoo/Widgets/honoo_app_title.dart';
 import '../Entities/honoo.dart';
 import '../Entities/conversation_link.dart';
 import '../Entities/reply_navigation_result.dart';
+import '../Widgets/repeated_reply_prompt.dart';
 import 'package:honoo/Services/supabase_provider.dart';
 import 'package:honoo/Controller/honoo_controller.dart';
 import 'chest_page.dart';
@@ -26,9 +27,11 @@ class ReplyHonooPage extends StatefulWidget {
     this.initialHintText = 'Scrivi la tua risposta',
     this.initialImageHint = 'Aggiungi un’immagine (opzionale)',
     this.returnToPreviousOnAnswer = false,
+    this.targetContentName = 'honoo',
   });
 
   final bool returnToPreviousOnAnswer;
+  final String targetContentName;
 
   @override
   State<ReplyHonooPage> createState() => _ReplyHonooPageState();
@@ -75,10 +78,25 @@ class _ReplyHonooPageState extends State<ReplyHonooPage> {
 
     final String replyTarget =
         widget.originalHonoo.dbId ?? widget.originalHonoo.id.toString();
-    final link = ConversationLink.fromParent(
+    final defaultLink = ConversationLink.fromParent(
       parentId: replyTarget,
       parentConversationId: widget.originalHonoo.conversationId,
       recipientId: widget.originalHonoo.userId,
+    );
+    final conversationId = await chooseReplyConversation(
+      context: context,
+      parentId: replyTarget,
+      defaultConversationId: defaultLink.conversationId,
+      contentName: widget.targetContentName,
+    );
+    if (conversationId == null || !mounted) {
+      setState(() => _isSending = false);
+      return;
+    }
+    final link = ConversationLink(
+      replyTo: defaultLink.replyTo,
+      conversationId: conversationId,
+      recipientId: defaultLink.recipientId,
     );
     final newHonoo = Honoo(
       0,

--- a/lib/Pages/shared_hinoo_page.dart
+++ b/lib/Pages/shared_hinoo_page.dart
@@ -388,6 +388,7 @@ class _SharedHinooPageState extends State<SharedHinooPage> {
                         await Navigator.of(context).push(
                           MaterialPageRoute(
                             builder: (_) => NewHinooPage(
+                              targetContentName: 'hinoo',
                               forcedType: HinooType.answer,
                               recipientTag: link.recipientId,
                               replyTo: link.replyTo,
@@ -440,6 +441,7 @@ class _SharedHinooPageState extends State<SharedHinooPage> {
                         await Navigator.of(context).push(
                           MaterialPageRoute(
                             builder: (_) => NewHonooPage(
+                              targetContentName: 'hinoo',
                               forcedType: HonooType.answer,
                               recipientTag: link.recipientId,
                               replyTo: link.replyTo,

--- a/lib/Pages/shared_honoo_page.dart
+++ b/lib/Pages/shared_honoo_page.dart
@@ -408,6 +408,7 @@ class _SharedHonooPageState extends State<SharedHonooPage> {
                         await Navigator.of(context).push(
                           MaterialPageRoute(
                             builder: (_) => NewHinooPage(
+                              targetContentName: 'honoo',
                               forcedType: HinooType.answer,
                               recipientTag: link.recipientId,
                               replyTo: link.replyTo,

--- a/lib/Services/content_feed_service.dart
+++ b/lib/Services/content_feed_service.dart
@@ -5,6 +5,27 @@ import 'supabase_provider.dart';
 class ContentFeedService {
   const ContentFeedService();
 
+  Future<bool> moonContentHasConversation({
+    required String kind,
+    required String id,
+  }) async {
+    final result = await SupabaseProvider.client.rpc(
+      'admin_moon_content_has_replies',
+      params: {'p_kind': kind, 'p_id': id},
+    );
+    return result == true;
+  }
+
+  Future<void> deleteMoonContent({
+    required String kind,
+    required String id,
+  }) async {
+    await SupabaseProvider.client.rpc(
+      'admin_soft_delete_moon_content',
+      params: {'p_kind': kind, 'p_id': id},
+    );
+  }
+
   /// Indica se l'utente ha già creato almeno una radice di conversazione.
   /// Le risposte non contano: il prompt notifiche deve seguire il primo
   /// contenuto personale salvato nello Scrigno.
@@ -30,7 +51,8 @@ class ContentFeedService {
     final rows = await SupabaseProvider.client
         .from('moon_public')
         .select(
-            'id,user_id,kind,pages,text,image_url,recipient_tag,created_at,conversation_id')
+          'id,user_id,kind,pages,text,image_url,recipient_tag,created_at,conversation_id',
+        )
         .order('created_at', ascending: false);
     return (rows as List)
         .whereType<Map>()
@@ -39,11 +61,13 @@ class ContentFeedService {
   }
 
   Future<List<Map<String, dynamic>>> fetchSharedHinooRows(
-      String ownerId) async {
+    String ownerId,
+  ) async {
     final rows = await SupabaseProvider.client
         .from('hinoo')
         .select(
-            'id,pages,type,recipient_tag,created_at,conversation_id,reply_to')
+          'id,pages,type,recipient_tag,created_at,conversation_id,reply_to',
+        )
         .eq('user_id', ownerId)
         .eq('type', 'personal')
         .order('created_at', ascending: false);
@@ -56,7 +80,8 @@ class ContentFeedService {
   /// Radici delle conversazioni condivise, Honoo e Hinoo, ordinate per data.
   /// Restituisce un solo elemento per conversation_id senza imporre modelli UI.
   Future<List<Map<String, dynamic>>> fetchSharedConversationRoots(
-      String ownerId) async {
+    String ownerId,
+  ) async {
     final honooRows = await SupabaseProvider.client
         .from('honoo')
         .select('id,conversation_id,created_at')
@@ -70,30 +95,36 @@ class ContentFeedService {
         .eq('type', 'personal')
         .order('created_at', ascending: false);
 
-    final combined = <Map<String, dynamic>>[
-      ...(honooRows as List)
-          .whereType<Map>()
-          .map((row) => row.cast<String, dynamic>()),
-      ...(hinooRows as List)
-          .whereType<Map>()
-          .map((row) => row.cast<String, dynamic>()),
-    ]..sort((a, b) {
-        final aDate = DateTime.tryParse(a['created_at']?.toString() ?? '') ??
-            DateTime.fromMillisecondsSinceEpoch(0);
-        final bDate = DateTime.tryParse(b['created_at']?.toString() ?? '') ??
-            DateTime.fromMillisecondsSinceEpoch(0);
-        return bDate.compareTo(aDate);
-      });
+    final combined =
+        <Map<String, dynamic>>[
+          ...(honooRows as List).whereType<Map>().map(
+            (row) => row.cast<String, dynamic>(),
+          ),
+          ...(hinooRows as List).whereType<Map>().map(
+            (row) => row.cast<String, dynamic>(),
+          ),
+        ]..sort((a, b) {
+          final aDate =
+              DateTime.tryParse(a['created_at']?.toString() ?? '') ??
+              DateTime.fromMillisecondsSinceEpoch(0);
+          final bDate =
+              DateTime.tryParse(b['created_at']?.toString() ?? '') ??
+              DateTime.fromMillisecondsSinceEpoch(0);
+          return bDate.compareTo(aDate);
+        });
 
     final seen = <String>{};
-    return combined.where((row) {
-      final id = row['id']?.toString() ?? '';
-      final conversationId = row['conversation_id']?.toString();
-      final effectiveId =
-          conversationId?.isNotEmpty == true ? conversationId! : id;
-      if (effectiveId.isEmpty || !seen.add(effectiveId)) return false;
-      row['conversation_id'] = effectiveId;
-      return true;
-    }).toList(growable: false);
+    return combined
+        .where((row) {
+          final id = row['id']?.toString() ?? '';
+          final conversationId = row['conversation_id']?.toString();
+          final effectiveId = conversationId?.isNotEmpty == true
+              ? conversationId!
+              : id;
+          if (effectiveId.isEmpty || !seen.add(effectiveId)) return false;
+          row['conversation_id'] = effectiveId;
+          return true;
+        })
+        .toList(growable: false);
   }
 }

--- a/lib/Services/conversation_service.dart
+++ b/lib/Services/conversation_service.dart
@@ -21,7 +21,7 @@ class ConversationService {
     final honooRows = await _client
         .from('honoo')
         .select(
-          'id,text,image_url,destination,reply_to,recipient_tag,created_at,updated_at,user_id,conversation_id,is_from_moon_saved',
+          'id,text,image_url,destination,reply_to,recipient_tag,created_at,updated_at,user_id,conversation_id,is_from_moon_saved,admin_deleted_at',
         )
         .eq('conversation_id', conversationId)
         .order('created_at', ascending: true);
@@ -29,17 +29,41 @@ class ConversationService {
     final hinooRows = await _client
         .from('hinoo')
         .select(
-          'id,pages,type,recipient_tag,reply_to,created_at,user_id,conversation_id,is_from_moon_saved',
+          'id,pages,type,recipient_tag,reply_to,created_at,user_id,conversation_id,is_from_moon_saved,admin_deleted_at',
         )
         .eq('conversation_id', conversationId)
         .order('created_at', ascending: true);
 
+    final tombstoneRows = await _client
+        .from('conversation_tombstones')
+        .select('content_id,conversation_id,original_created_at')
+        .eq('conversation_id', conversationId)
+        .order('original_created_at', ascending: true);
+
     final entries = <_Entry>[];
     for (final r in (honooRows as List)) {
+      if (r['admin_deleted_at'] != null) {
+        entries.add(
+          _Entry.deleted(
+            id: r['id']?.toString(),
+            createdAt: _parseCreatedAt(r['created_at']),
+          ),
+        );
+        continue;
+      }
       final h = Honoo.fromMap(Map<String, dynamic>.from(r));
       entries.add(_Entry.honoo(h));
     }
     for (final r in (hinooRows as List)) {
+      if (r['admin_deleted_at'] != null) {
+        entries.add(
+          _Entry.deleted(
+            id: r['id']?.toString(),
+            createdAt: _parseCreatedAt(r['created_at']),
+          ),
+        );
+        continue;
+      }
       final pages = r['pages'];
       if (pages is! List) continue;
       final replyTo = r['reply_to']?.toString();
@@ -78,6 +102,20 @@ class ConversationService {
         ),
       );
     }
+    final existingIds = entries
+        .map((entry) => entry.id)
+        .whereType<String>()
+        .toSet();
+    for (final row in (tombstoneRows as List)) {
+      final id = row['content_id']?.toString();
+      if (id == null || id.isEmpty || !existingIds.add(id)) continue;
+      entries.add(
+        _Entry.deleted(
+          id: id,
+          createdAt: _parseCreatedAt(row['original_created_at']),
+        ),
+      );
+    }
     final deduplicatedEntries = _deduplicateMoonRoots(entries)
       ..sort((a, b) => a.createdAt.compareTo(b.createdAt));
     return deduplicatedEntries
@@ -91,10 +129,18 @@ class ConversationService {
               id: e.id,
               isFromMoonSaved: e.isFromMoonSaved,
             ),
+            deleted: () => ConversationEntry.deleted(
+              id: e.id ?? '',
+              createdAt: e.createdAt,
+            ),
           ),
         )
         .toList();
   }
+
+  static DateTime _parseCreatedAt(dynamic value) =>
+      DateTime.tryParse(value?.toString() ?? '') ??
+      DateTime.fromMillisecondsSinceEpoch(0);
 
   static List<_Entry> _deduplicateMoonRoots(List<_Entry> entries) {
     final moonSavedRootKeys = entries
@@ -160,6 +206,7 @@ class _Entry {
   final String? ownerId;
   final String? id;
   final bool isFromMoonSaved;
+  final bool isDeleted;
 
   _Entry._(
     this.honoo,
@@ -168,6 +215,7 @@ class _Entry {
     this.ownerId,
     this.id,
     this.isFromMoonSaved = false,
+    this.isDeleted = false,
   });
   factory _Entry.honoo(Honoo h) => _Entry._(
     h,
@@ -192,11 +240,17 @@ class _Entry {
     isFromMoonSaved: isFromMoonSaved,
   );
 
-  bool get isReply => honoo != null
+  factory _Entry.deleted({required String? id, required DateTime createdAt}) =>
+      _Entry._(null, null, createdAt, id: id, isDeleted: true);
+
+  bool get isReply => isDeleted
+      ? false
+      : honoo != null
       ? honoo!.type == HonooType.answer
       : hinoo!.type == HinooType.answer;
 
   String get contentKey {
+    if (isDeleted) return 'deleted\u001f${id ?? ''}';
     if (honoo != null) {
       return 'honoo\u001f${honoo!.text}\u001f${honoo!.image}';
     }
@@ -207,7 +261,9 @@ class _Entry {
   T when<T>({
     required T Function(Honoo) honoo,
     required T Function(HinooDraft) hinoo,
+    required T Function() deleted,
   }) {
+    if (isDeleted) return deleted();
     if (this.honoo != null) return honoo(this.honoo!);
     return hinoo(this.hinoo!);
   }

--- a/lib/Services/conversation_service.dart
+++ b/lib/Services/conversation_service.dart
@@ -106,6 +106,54 @@ class ConversationService {
         .map((entry) => entry.id)
         .whereType<String>()
         .toSet();
+    final missingParentIds = entries
+        .map((entry) => entry.honoo?.replyTo ?? entry.hinoo?.replyTo)
+        .whereType<String>()
+        .where((id) => id.isNotEmpty && !existingIds.contains(id))
+        .toSet();
+    if (missingParentIds.isNotEmpty) {
+      final parentHonooRows = await _client
+          .from('honoo')
+          .select(
+            'id,text,image_url,destination,reply_to,recipient_tag,created_at,updated_at,user_id,conversation_id,is_from_moon_saved,admin_deleted_at',
+          )
+          .in_('id', missingParentIds.toList());
+      final parentHinooRows = await _client
+          .from('hinoo')
+          .select(
+            'id,pages,type,recipient_tag,reply_to,created_at,user_id,conversation_id,is_from_moon_saved,admin_deleted_at',
+          )
+          .in_('id', missingParentIds.toList());
+      for (final row in (parentHonooRows as List)) {
+        if (row['admin_deleted_at'] != null) continue;
+        entries.add(
+          _Entry.honoo(Honoo.fromMap(Map<String, dynamic>.from(row))),
+        );
+      }
+      for (final row in (parentHinooRows as List)) {
+        if (row['admin_deleted_at'] != null || row['pages'] is! List) continue;
+        final pages = (row['pages'] as List)
+            .whereType<Map<String, dynamic>>()
+            .map(HinooSlide.fromJson)
+            .toList();
+        entries.add(
+          _Entry.hinoo(
+            HinooDraft(
+              pages: pages,
+              type: _fromDbType(row['type'] as String?),
+              recipientTag: row['recipient_tag']?.toString(),
+              replyTo: row['reply_to']?.toString(),
+              conversationId: row['conversation_id']?.toString(),
+              isFromMoonSaved: (row['is_from_moon_saved'] as bool?) ?? false,
+            ),
+            createdAt: _parseCreatedAt(row['created_at']),
+            ownerId: row['user_id']?.toString(),
+            id: row['id']?.toString(),
+            isFromMoonSaved: (row['is_from_moon_saved'] as bool?) ?? false,
+          ),
+        );
+      }
+    }
     for (final row in (tombstoneRows as List)) {
       final id = row['content_id']?.toString();
       if (id == null || id.isEmpty || !existingIds.add(id)) continue;

--- a/lib/Services/reply_conversation_service.dart
+++ b/lib/Services/reply_conversation_service.dart
@@ -1,0 +1,45 @@
+import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:uuid/uuid.dart';
+
+import 'supabase_provider.dart';
+
+class PreviousUnansweredReply {
+  const PreviousUnansweredReply({required this.conversationId});
+
+  final String conversationId;
+}
+
+typedef PreviousReplyLookup = Future<dynamic> Function(String parentId);
+
+/// Individua l'ultima conversazione avviata dall'utente sullo stesso
+/// contenuto che non ha ancora ricevuto una contro-risposta.
+class ReplyConversationService {
+  ReplyConversationService({SupabaseClient? client, this._lookup})
+    : _client = client ?? SupabaseProvider.client;
+
+  final SupabaseClient _client;
+  final PreviousReplyLookup? _lookup;
+
+  Future<PreviousUnansweredReply?> findPreviousUnansweredReply({
+    required String parentId,
+  }) async {
+    if (_client.auth.currentUser == null || parentId.isEmpty) return null;
+    try {
+      final result = _lookup != null
+          ? await _lookup(parentId)
+          : await _client.rpc(
+              'find_previous_unanswered_conversation',
+              params: {'target_parent_id': parentId},
+            );
+      final conversationId = result?.toString() ?? '';
+      return conversationId.isEmpty
+          ? null
+          : PreviousUnansweredReply(conversationId: conversationId);
+    } catch (_) {
+      // Una versione del backend non ancora migrata non deve impedire l'invio.
+      return null;
+    }
+  }
+
+  String createConversationId() => const Uuid().v4();
+}

--- a/lib/UI/unified_thread_view.dart
+++ b/lib/UI/unified_thread_view.dart
@@ -253,6 +253,8 @@ class _UnifiedThreadViewState extends State<UnifiedThreadView>
   }
 
   bool _shouldReveal(ConversationEntry e) {
+    if (e.kind == ConversationEntryKind.deleted) return false;
+
     // Moon-saved: non rivelare
     final bool isMoon =
         e.isFromMoonSaved == true ||
@@ -277,6 +279,12 @@ class _UnifiedThreadViewState extends State<UnifiedThreadView>
       for (final entry in _entries.reversed) {
         if (entry.id == replyTo) return entry;
       }
+      final replyIndex = _entries.indexOf(reply);
+      if (replyIndex > 0) {
+        final fallback = _entries[replyIndex - 1];
+        if (fallback.isFromMoonSaved) return fallback;
+      }
+      return null;
     }
     final replyIndex = _entries.indexOf(reply);
     return replyIndex > 0 ? _entries[replyIndex - 1] : null;
@@ -284,31 +292,49 @@ class _UnifiedThreadViewState extends State<UnifiedThreadView>
 
   Widget _entryCard(ConversationEntry entry, {String? keyName}) {
     final GlobalKey repaintKey = GlobalKey();
-    final card = entry.kind == ConversationEntryKind.honoo
-        ? RepaintBoundary(
-            key: repaintKey,
-            child: HonooCard(
-              honoo: entry.honoo!,
-              onDownloadTap: () => _downloadFromBoundary(
-                repaintKey: repaintKey,
-                baseName: 'honoo',
-              ),
+    final Widget card;
+    switch (entry.kind) {
+      case ConversationEntryKind.honoo:
+        card = RepaintBoundary(
+          key: repaintKey,
+          child: HonooCard(
+            honoo: entry.honoo!,
+            onDownloadTap: () => _downloadFromBoundary(
+              repaintKey: repaintKey,
+              baseName: 'honoo',
             ),
-          )
-        : RepaintBoundary(
-            key: repaintKey,
-            child: HinooViewer(
-              draft: entry.hinoo!,
-              maxHeight: widget.maxHeight,
-              maxWidth: widget.maxWidth,
-              isReply: entry.hinoo!.type == HinooType.answer,
-              authorId: entry.ownerId,
-              onDownloadTap: () => _downloadFromBoundary(
-                repaintKey: repaintKey,
-                baseName: 'hinoo',
-              ),
+          ),
+        );
+        break;
+      case ConversationEntryKind.hinoo:
+        card = RepaintBoundary(
+          key: repaintKey,
+          child: HinooViewer(
+            draft: entry.hinoo!,
+            maxHeight: widget.maxHeight,
+            maxWidth: widget.maxWidth,
+            isReply: entry.hinoo!.type == HinooType.answer,
+            authorId: entry.ownerId,
+            onDownloadTap: () => _downloadFromBoundary(
+              repaintKey: repaintKey,
+              baseName: 'hinoo',
             ),
-          );
+          ),
+        );
+        break;
+      case ConversationEntryKind.deleted:
+        card = const ColoredBox(
+          color: HonooColor.background,
+          child: Center(
+            child: Text(
+              'contenuto eliminato',
+              textAlign: TextAlign.center,
+              style: TextStyle(color: HonooColor.onBackground, fontSize: 18),
+            ),
+          ),
+        );
+        break;
+    }
     return SizedBox.expand(
       key: keyName == null ? null : Key(keyName),
       child: card,
@@ -384,15 +410,14 @@ class _UnifiedThreadViewState extends State<UnifiedThreadView>
             final Widget page = _entryCard(e);
             if (index == _pageToShowFirst && _shouldReveal(e)) {
               final answeredEntry = _answeredEntryFor(e);
-              final answeredPage = answeredEntry == null
-                  ? null
-                  : Transform.translate(
-                      offset: Offset(0, widget.maxHeight * 0.52),
-                      child: _entryCard(
-                        answeredEntry,
-                        keyName: 'reply_reveal_parent',
-                      ),
-                    );
+              if (answeredEntry == null) return page;
+              final answeredPage = Transform.translate(
+                offset: Offset(0, widget.maxHeight * 0.52),
+                child: _entryCard(
+                  answeredEntry,
+                  keyName: 'reply_reveal_parent',
+                ),
+              );
               return AnimatedBuilder(
                 animation: _liftAnimation,
                 builder: (context, childWidget) {
@@ -400,7 +425,7 @@ class _UnifiedThreadViewState extends State<UnifiedThreadView>
                   return ClipRect(
                     child: Stack(
                       children: [
-                        if (answeredPage != null) answeredPage,
+                        answeredPage,
                         Transform.translate(
                           key: const Key('reply_reveal_foreground'),
                           offset: Offset(

--- a/lib/Widgets/chest_footer.dart
+++ b/lib/Widgets/chest_footer.dart
@@ -105,16 +105,16 @@ class ChestFooter extends StatelessWidget {
     if (entry == null || conversationId == null || conversationId.isEmpty) {
       return;
     }
-    final isMine = entry.ownerId != null &&
+    if (entry.kind == ConversationEntryKind.deleted) return;
+    final isMine =
+        entry.ownerId != null &&
         currentUserId != null &&
         entry.ownerId == currentUserId;
     final isPersonalEntry = entry.kind == ConversationEntryKind.honoo
         ? entry.honoo!.type == HonooType.personal
         : entry.hinoo!.type == HinooType.personal;
     if (isMine && isPersonalEntry) {
-      actions.add(
-        _moonAction(() => onSendConversationEntryToMoon(entry)),
-      );
+      actions.add(_moonAction(() => onSendConversationEntryToMoon(entry)));
     }
   }
 
@@ -133,25 +133,25 @@ class ChestFooter extends StatelessWidget {
   }
 
   ResponsiveFooterAction _moonAction(VoidCallback onPressed) => _action(
-        asset: 'assets/icons/moon.svg',
-        label: 'Luna',
-        tooltip: 'Spedisci sulla Luna',
-        onPressed: onPressed,
-      );
+    asset: 'assets/icons/moon.svg',
+    label: 'Luna',
+    tooltip: 'Spedisci sulla Luna',
+    onPressed: onPressed,
+  );
 
   ResponsiveFooterAction _replyAction(VoidCallback onPressed) => _action(
-        asset: 'assets/icons/reply.svg',
-        label: 'Rispondi',
-        tooltip: 'Rispondi',
-        onPressed: onPressed,
-      );
+    asset: 'assets/icons/reply.svg',
+    label: 'Rispondi',
+    tooltip: 'Rispondi',
+    onPressed: onPressed,
+  );
 
   ResponsiveFooterAction _deleteAction(VoidCallback onPressed) => _action(
-        asset: 'assets/icons/cancella.svg',
-        label: 'Cancella',
-        tooltip: 'Cancella',
-        onPressed: onPressed,
-      );
+    asset: 'assets/icons/cancella.svg',
+    label: 'Cancella',
+    tooltip: 'Cancella',
+    onPressed: onPressed,
+  );
 
   ResponsiveFooterAction _action({
     required String asset,
@@ -159,19 +159,15 @@ class ChestFooter extends StatelessWidget {
     required String tooltip,
     required VoidCallback onPressed,
     bool applyColorFilter = true,
-  }) =>
-      ResponsiveFooterAction(
-        asset: asset,
-        semanticsLabel: label,
-        colorFilter: applyColorFilter
-            ? const ColorFilter.mode(
-                HonooColor.onBackground,
-                BlendMode.srcIn,
-              )
-            : null,
-        size: iconSize,
-        splashRadius: 25,
-        tooltip: tooltip,
-        onPressed: onPressed,
-      );
+  }) => ResponsiveFooterAction(
+    asset: asset,
+    semanticsLabel: label,
+    colorFilter: applyColorFilter
+        ? const ColorFilter.mode(HonooColor.onBackground, BlendMode.srcIn)
+        : null,
+    size: iconSize,
+    splashRadius: 25,
+    tooltip: tooltip,
+    onPressed: onPressed,
+  );
 }

--- a/lib/Widgets/repeated_reply_prompt.dart
+++ b/lib/Widgets/repeated_reply_prompt.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+
+import '../Services/reply_conversation_service.dart';
+import 'honoo_dialogs.dart';
+
+/// Restituisce il conversation_id da usare. Se non esiste una risposta
+/// precedente senza contro-risposta mantiene il thread naturale del contenuto.
+Future<String?> chooseReplyConversation({
+  required BuildContext context,
+  required String parentId,
+  required String defaultConversationId,
+  required String contentName,
+  ReplyConversationService? service,
+}) async {
+  final resolver = service ?? ReplyConversationService();
+  final previous = await resolver.findPreviousUnansweredReply(
+    parentId: parentId,
+  );
+  if (!context.mounted) return null;
+  if (previous == null) return defaultConversationId;
+
+  final createNew = await showDialog<bool>(
+    context: context,
+    barrierDismissible: true,
+    builder: (_) => HonooConfirmDialog(
+      title: 'Hai già risposto a questo $contentName.',
+      message: 'Vuoi che questa risposta crei una nuova conversazione?',
+      confirmLabel: 'Sì',
+      cancelLabel: 'No',
+    ),
+  );
+  if (!context.mounted || createNew == null) return null;
+  return createNew ? resolver.createConversationId() : previous.conversationId;
+}

--- a/supabase/migrations/20260804123000_preserve_deleted_conversation_content.sql
+++ b/supabase/migrations/20260804123000_preserve_deleted_conversation_content.sql
@@ -1,0 +1,221 @@
+-- Preserve the position of Moon content removed by an admin and repair
+-- conversations whose parent content was already hard-deleted.
+
+alter table public.honoo
+  add column if not exists admin_deleted_at timestamptz;
+
+alter table public.hinoo
+  add column if not exists admin_deleted_at timestamptz;
+
+create table if not exists public.conversation_tombstones (
+  content_id uuid primary key,
+  conversation_id text not null,
+  source_kind text not null
+    check (source_kind in ('honoo', 'hinoo', 'unknown')),
+  original_created_at timestamptz not null,
+  deleted_at timestamptz not null default now()
+);
+
+alter table public.conversation_tombstones enable row level security;
+
+drop policy if exists "authenticated read conversation tombstones"
+  on public.conversation_tombstones;
+create policy "authenticated read conversation tombstones"
+  on public.conversation_tombstones
+  for select
+  to authenticated
+  using (true);
+
+-- Existing orphan replies cannot recover the deleted payload, but their
+-- reply_to id and conversation id are sufficient to restore its placeholder.
+with orphan_replies as (
+  select
+    reply_to as content_id,
+    coalesce(nullif(conversation_id, ''), reply_to::text) as conversation_id,
+    created_at
+  from public.honoo reply
+  where reply_to is not null
+    and not exists (select 1 from public.honoo h where h.id = reply.reply_to)
+    and not exists (select 1 from public.hinoo h where h.id = reply.reply_to)
+  union all
+  select
+    reply_to as content_id,
+    coalesce(nullif(conversation_id, ''), reply_to::text) as conversation_id,
+    created_at
+  from public.hinoo reply
+  where reply_to is not null
+    and not exists (select 1 from public.honoo h where h.id = reply.reply_to)
+    and not exists (select 1 from public.hinoo h where h.id = reply.reply_to)
+), repaired as (
+  select
+    content_id,
+    min(conversation_id) as conversation_id,
+    min(created_at) - interval '1 microsecond' as original_created_at
+  from orphan_replies
+  group by content_id
+)
+insert into public.conversation_tombstones (
+  content_id,
+  conversation_id,
+  source_kind,
+  original_created_at
+)
+select content_id, conversation_id, 'unknown', original_created_at
+from repaired
+on conflict (content_id) do nothing;
+
+create or replace function public.admin_moon_content_has_replies(
+  p_kind text,
+  p_id uuid
+)
+returns boolean
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+begin
+  if not public.is_admin() then
+    raise exception 'Admin privileges required';
+  end if;
+
+  if p_kind not in ('honoo', 'hinoo') then
+    raise exception 'Unsupported content kind: %', p_kind;
+  end if;
+
+  return exists(select 1 from public.honoo where reply_to = p_id)
+    or exists(select 1 from public.hinoo where reply_to = p_id);
+end
+$$;
+
+create or replace function public.admin_soft_delete_moon_content(
+  p_kind text,
+  p_id uuid
+)
+returns void
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_conversation_id text;
+  v_created_at timestamptz;
+begin
+  if not public.is_admin() then
+    raise exception 'Admin privileges required';
+  end if;
+
+  if p_kind = 'honoo' then
+    select coalesce(nullif(conversation_id, ''), id::text), created_at
+      into v_conversation_id, v_created_at
+    from public.honoo
+    where id = p_id
+      and destination = 'moon'
+      and admin_deleted_at is null;
+
+    if not found then
+      raise exception 'Moon content not found';
+    end if;
+
+    insert into public.conversation_tombstones (
+      content_id,
+      conversation_id,
+      source_kind,
+      original_created_at
+    ) values (p_id, v_conversation_id, 'honoo', v_created_at)
+    on conflict (content_id) do update
+      set conversation_id = excluded.conversation_id,
+          source_kind = excluded.source_kind,
+          original_created_at = excluded.original_created_at,
+          deleted_at = now();
+
+    update public.honoo
+    set admin_deleted_at = now(),
+        text = 'contenuto eliminato',
+        image_url = '',
+        updated_at = now()
+    where id = p_id;
+  elsif p_kind = 'hinoo' then
+    select coalesce(nullif(conversation_id, ''), id::text), created_at
+      into v_conversation_id, v_created_at
+    from public.hinoo
+    where id = p_id
+      and type::text = 'moon'
+      and admin_deleted_at is null;
+
+    if not found then
+      raise exception 'Moon content not found';
+    end if;
+
+    insert into public.conversation_tombstones (
+      content_id,
+      conversation_id,
+      source_kind,
+      original_created_at
+    ) values (p_id, v_conversation_id, 'hinoo', v_created_at)
+    on conflict (content_id) do update
+      set conversation_id = excluded.conversation_id,
+          source_kind = excluded.source_kind,
+          original_created_at = excluded.original_created_at,
+          deleted_at = now();
+
+    update public.hinoo
+    set admin_deleted_at = now(),
+        pages = jsonb_build_array(
+          jsonb_build_object(
+            'backgroundImage', null,
+            'text', 'contenuto eliminato',
+            'isTextWhite', true,
+            'bgScale', 1.0,
+            'bgOffsetX', 0.0,
+            'bgOffsetY', 0.0
+          )
+        ),
+        updated_at = now()
+    where id = p_id;
+  else
+    raise exception 'Unsupported content kind: %', p_kind;
+  end if;
+end
+$$;
+
+revoke all on function public.admin_moon_content_has_replies(text, uuid)
+  from public;
+revoke all on function public.admin_soft_delete_moon_content(text, uuid)
+  from public;
+grant execute on function public.admin_moon_content_has_replies(text, uuid)
+  to authenticated;
+grant execute on function public.admin_soft_delete_moon_content(text, uuid)
+  to authenticated;
+
+-- Admin deletion must pass through the preserving RPC above.
+drop policy if exists "honoo delete admin moon" on public.honoo;
+drop policy if exists "hinoo delete admin moon" on public.hinoo;
+
+create or replace view public.moon_public as
+select
+  'hinoo'::text as kind,
+  id,
+  user_id,
+  created_at,
+  pages,
+  recipient_tag,
+  null::text as text,
+  null::text as image_url,
+  conversation_id
+from public.hinoo
+where type::text = 'moon'
+  and admin_deleted_at is null
+union all
+select
+  'honoo'::text as kind,
+  id,
+  user_id,
+  created_at,
+  null::jsonb as pages,
+  recipient_tag,
+  text,
+  image_url,
+  conversation_id
+from public.honoo
+where destination = 'moon'
+  and admin_deleted_at is null;

--- a/supabase/migrations/20260804150000_conversation_participants_and_forks.sql
+++ b/supabase/migrations/20260804150000_conversation_participants_and_forks.sql
@@ -1,0 +1,152 @@
+-- Ogni partecipante può leggere l'intero filo, non soltanto le righe che
+-- possiede o di cui è destinatario diretto.
+create or replace function public.is_conversation_participant(
+  target_conversation_id text
+)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public, pg_temp
+as $$
+  select exists (
+    select 1
+    from public.honoo h
+    where h.conversation_id = target_conversation_id
+      and (
+        h.user_id = auth.uid()
+        or h.recipient_tag = auth.uid()::text
+        or h.recipient_tag in (
+          select u.address from public.users u where u.auth_id = auth.uid()
+        )
+      )
+    union all
+    select 1
+    from public.hinoo x
+    where x.conversation_id = target_conversation_id
+      and (
+        x.user_id = auth.uid()
+        or x.recipient_tag = auth.uid()::text
+        or x.recipient_tag in (
+          select u.address from public.users u where u.auth_id = auth.uid()
+        )
+      )
+  );
+$$;
+
+revoke all on function public.is_conversation_participant(text) from public;
+grant execute on function public.is_conversation_participant(text)
+  to authenticated;
+
+create or replace function public.find_previous_unanswered_conversation(
+  target_parent_id uuid
+)
+returns text
+language sql
+stable
+security definer
+set search_path = public, pg_temp
+as $$
+  with direct_replies as (
+    select h.conversation_id, h.created_at
+    from public.honoo h
+    where h.reply_to = target_parent_id
+      and h.user_id = auth.uid()
+    union all
+    select x.conversation_id, x.created_at
+    from public.hinoo x
+    where x.reply_to = target_parent_id
+      and x.user_id = auth.uid()
+  ), unanswered as (
+    select d.conversation_id, d.created_at
+    from direct_replies d
+    where d.conversation_id is not null
+      and not exists (
+        select 1
+        from public.honoo h
+        where h.conversation_id = d.conversation_id
+          and h.user_id <> auth.uid()
+          and h.created_at > d.created_at
+        union all
+        select 1
+        from public.hinoo x
+        where x.conversation_id = d.conversation_id
+          and x.user_id <> auth.uid()
+          and x.created_at > d.created_at
+      )
+  )
+  select u.conversation_id
+  from unanswered u
+  order by u.created_at desc
+  limit 1;
+$$;
+
+revoke all on function public.find_previous_unanswered_conversation(uuid)
+  from public;
+grant execute on function public.find_previous_unanswered_conversation(uuid)
+  to authenticated;
+
+drop policy if exists "conversation participants read honoo"
+  on public.honoo;
+create policy "conversation participants read honoo"
+  on public.honoo
+  as permissive
+  for select
+  to authenticated
+  using (public.is_conversation_participant(conversation_id));
+
+drop policy if exists "conversation participants read hinoo"
+  on public.hinoo;
+create policy "conversation participants read hinoo"
+  on public.hinoo
+  as permissive
+  for select
+  to authenticated
+  using (public.is_conversation_participant(conversation_id));
+
+-- Un reply può iniziare esplicitamente un nuovo filo sullo stesso contenuto.
+-- Se conversation_id è omesso continua invece a ereditare il filo del padre.
+create or replace function public.enforce_conversation_integrity()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_parent_cid text;
+begin
+  if new.reply_to is null then
+    if new.conversation_id is null or btrim(new.conversation_id) = '' then
+      new.conversation_id := new.id::text;
+    end if;
+    return new;
+  end if;
+
+  select coalesce(h.conversation_id, h.id::text)
+    into v_parent_cid
+  from public.honoo h
+  where h.id = new.reply_to
+  limit 1;
+
+  if v_parent_cid is null then
+    select coalesce(x.conversation_id, x.id::text)
+      into v_parent_cid
+    from public.hinoo x
+    where x.id = new.reply_to
+    limit 1;
+  end if;
+
+  if v_parent_cid is null then
+    raise exception 'Invalid reply_to reference (%) for %',
+      new.reply_to, tg_table_name;
+  end if;
+
+  if new.conversation_id is null or btrim(new.conversation_id) = '' then
+    new.conversation_id := v_parent_cid;
+  end if;
+
+  return new;
+end
+$$;
+
+revoke all on function public.enforce_conversation_integrity() from public;

--- a/test/chest_ordering_test.dart
+++ b/test/chest_ordering_test.dart
@@ -50,9 +50,31 @@ void main() {
         _Item(createdAt: t2, id: 'normal'),
       ]);
 
-      expect(result.items.map((item) => item.id), ['a', 'b', 'c', 'normal']);
+      expect(result.items.map((item) => item.id), ['a', 'b', 'normal', 'c']);
       expect(result.conversationItemCount, 3);
     });
+
+    test(
+      'il contenuto salvato più di recente precede conversazioni più vecchie',
+      () {
+        final old = DateTime(2024, 1, 1, 12);
+        final recent = old.add(const Duration(minutes: 5));
+        final result = _organize([
+          _Item(
+            createdAt: old,
+            id: 'conversation',
+            latestReply: old.add(const Duration(minutes: 1)),
+            conversationId: 'conversation-1',
+          ),
+          _Item(createdAt: recent, id: 'just-saved'),
+        ]);
+
+        expect(result.items.map((item) => item.id), [
+          'just-saved',
+          'conversation',
+        ]);
+      },
+    );
 
     test('mostra una sola slide per conversazione usando il più recente', () {
       final t1 = DateTime(2024, 1, 1, 12);
@@ -65,14 +87,10 @@ void main() {
           conversationId: 'conversation-1',
         ),
         _Item(createdAt: t2, id: 'outside'),
-        _Item(
-          createdAt: t2,
-          id: 'reply',
-          conversationId: 'conversation-1',
-        ),
+        _Item(createdAt: t2, id: 'reply', conversationId: 'conversation-1'),
       ]);
 
-      expect(result.items.map((item) => item.id), ['reply', 'outside']);
+      expect(result.items.map((item) => item.id), ['outside', 'reply']);
     });
 
     test('non modifica la lista ricevuta', () {

--- a/test/services/conversation_service_test.dart
+++ b/test/services/conversation_service_test.dart
@@ -13,6 +13,7 @@ void main() {
   setUp(() {
     harness = SupabaseTestHarness(withAuthenticatedUser: true)
       ..enableOverrides();
+    harness.stubTable('conversation_tombstones');
   });
 
   tearDown(() {
@@ -202,4 +203,59 @@ void main() {
       expect(result.first.isFromMoonSaved, isTrue);
     },
   );
+
+  test('ricostruisce il segnaposto per una conversazione orfana', () async {
+    final honoo = harness.stubTable('honoo');
+    final hinoo = harness.stubTable('hinoo');
+    final tombstones = harness.stubTable('conversation_tombstones');
+    honoo.queueResponse(<Map<String, dynamic>>[
+      {
+        'id': 'reply-1',
+        'text': 'risposta',
+        'image_url': '',
+        'destination': 'reply',
+        'reply_to': 'deleted-root',
+        'created_at': '2026-01-01T11:00:00Z',
+        'updated_at': '2026-01-01T11:00:00Z',
+        'user_id': 'test_user',
+        'conversation_id': 'conversation-1',
+      },
+    ]);
+    hinoo.queueResponse(<Map<String, dynamic>>[]);
+    tombstones.queueResponse(<Map<String, dynamic>>[
+      {
+        'content_id': 'deleted-root',
+        'conversation_id': 'conversation-1',
+        'original_created_at': '2026-01-01T10:59:59Z',
+      },
+    ]);
+
+    final result = await ConversationService.fetchConversation(
+      'conversation-1',
+    );
+
+    expect(result.map((entry) => entry.id), ['deleted-root', 'reply-1']);
+    expect(result.first.kind, ConversationEntryKind.deleted);
+  });
+
+  test('trasforma un contenuto soft-deleted in segnaposto', () async {
+    final honoo = harness.stubTable('honoo');
+    final hinoo = harness.stubTable('hinoo');
+    honoo.queueResponse(<Map<String, dynamic>>[
+      {
+        'id': 'deleted-root',
+        'created_at': '2026-01-01T10:00:00Z',
+        'conversation_id': 'conversation-1',
+        'admin_deleted_at': '2026-01-02T10:00:00Z',
+      },
+    ]);
+    hinoo.queueResponse(<Map<String, dynamic>>[]);
+
+    final result = await ConversationService.fetchConversation(
+      'conversation-1',
+    );
+
+    expect(result.single.kind, ConversationEntryKind.deleted);
+    expect(result.single.id, 'deleted-root');
+  });
 }

--- a/test/services/conversation_service_test.dart
+++ b/test/services/conversation_service_test.dart
@@ -258,4 +258,41 @@ void main() {
     expect(result.single.kind, ConversationEntryKind.deleted);
     expect(result.single.id, 'deleted-root');
   });
+
+  test('include la radice quando una risposta avvia un nuovo filo', () async {
+    final honoo = harness.stubTable('honoo');
+    final hinoo = harness.stubTable('hinoo');
+    honoo.queueResponse(<Map<String, dynamic>>[
+      {
+        'id': 'reply-1',
+        'text': 'nuova conversazione',
+        'image_url': '',
+        'destination': 'reply',
+        'reply_to': 'moon-root',
+        'created_at': '2026-01-01T11:00:00Z',
+        'updated_at': '2026-01-01T11:00:00Z',
+        'user_id': 'test_user',
+        'conversation_id': 'forked-conversation',
+      },
+    ]);
+    hinoo.queueResponse(<Map<String, dynamic>>[]);
+    honoo.queueResponse(<Map<String, dynamic>>[
+      {
+        'id': 'moon-root',
+        'text': 'radice',
+        'image_url': 'root.png',
+        'destination': 'moon',
+        'created_at': '2026-01-01T10:00:00Z',
+        'updated_at': '2026-01-01T10:00:00Z',
+        'user_id': 'author',
+        'conversation_id': 'original-conversation',
+      },
+    ]);
+
+    final result = await ConversationService.fetchConversation(
+      'forked-conversation',
+    );
+
+    expect(result.map((entry) => entry.id), ['moon-root', 'reply-1']);
+  });
 }

--- a/test/services/reply_conversation_service_test.dart
+++ b/test/services/reply_conversation_service_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:honoo/Services/reply_conversation_service.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../test_supabase_helper.dart';
+
+void main() {
+  setUpAll(registerSupabaseFallbacks);
+
+  late SupabaseTestHarness harness;
+
+  setUp(() {
+    harness = SupabaseTestHarness(withAuthenticatedUser: true)
+      ..enableOverrides();
+  });
+
+  tearDown(() {
+    harness.disableOverrides();
+    resetMocktailState();
+  });
+
+  test('riusa l’ultima conversazione che non ha una contro-risposta', () async {
+    final result = await ReplyConversationService(
+      client: harness.client,
+      lookup: (_) async => 'conversation-1',
+    ).findPreviousUnansweredReply(parentId: 'root-1');
+
+    expect(result?.conversationId, 'conversation-1');
+  });
+
+  test('non propone il riuso dopo una contro-risposta', () async {
+    final result = await ReplyConversationService(
+      client: harness.client,
+      lookup: (_) async => null,
+    ).findPreviousUnansweredReply(parentId: 'root-1');
+
+    expect(result, isNull);
+  });
+}

--- a/test/widgets/repeated_reply_prompt_test.dart
+++ b/test/widgets/repeated_reply_prompt_test.dart
@@ -1,0 +1,100 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:honoo/Services/reply_conversation_service.dart';
+import 'package:honoo/Widgets/repeated_reply_prompt.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../test_supabase_helper.dart';
+
+void main() {
+  setUpAll(registerSupabaseFallbacks);
+
+  late SupabaseTestHarness harness;
+  late ReplyConversationService service;
+
+  setUp(() {
+    harness = SupabaseTestHarness(withAuthenticatedUser: true)
+      ..enableOverrides();
+    service = ReplyConversationService(
+      client: harness.client,
+      lookup: (_) async => 'conversation-1',
+    );
+  });
+
+  tearDown(() {
+    harness.disableOverrides();
+    resetMocktailState();
+  });
+
+  testWidgets('No aggiunge la risposta alla conversazione precedente', (
+    tester,
+  ) async {
+    String? result;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (context) => ElevatedButton(
+            onPressed: () async {
+              result = await chooseReplyConversation(
+                context: context,
+                parentId: 'root-1',
+                defaultConversationId: 'default-conversation',
+                contentName: 'honoo',
+                service: service,
+              );
+            },
+            child: const Text('Rispondi'),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Rispondi'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Hai già risposto a questo honoo'), findsOneWidget);
+    expect(
+      find.text('Vuoi che questa risposta crei una nuova conversazione?'),
+      findsOneWidget,
+    );
+    await tester.tap(find.text('No'));
+    await tester.pumpAndSettle();
+
+    expect(result, 'conversation-1');
+  });
+
+  testWidgets('Sì crea una conversazione distinta per un hinoo', (
+    tester,
+  ) async {
+    String? result;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (context) => ElevatedButton(
+            onPressed: () async {
+              result = await chooseReplyConversation(
+                context: context,
+                parentId: 'root-1',
+                defaultConversationId: 'default-conversation',
+                contentName: 'hinoo',
+                service: service,
+              );
+            },
+            child: const Text('Rispondi'),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Rispondi'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Hai già risposto a questo hinoo'), findsOneWidget);
+    await tester.tap(find.text('Sì'));
+    await tester.pumpAndSettle();
+
+    expect(result, isNotNull);
+    expect(result, isNot('conversation-1'));
+    expect(result, isNot('default-conversation'));
+  });
+}

--- a/test/widgets/unified_thread_reveal_test.dart
+++ b/test/widgets/unified_thread_reveal_test.dart
@@ -106,6 +106,78 @@ void main() {
     expect(foreground.transform.getTranslation().y, greaterThanOrEqualTo(-336));
   });
 
+  testWidgets('il bounce mostra il segnaposto del contenuto eliminato', (
+    tester,
+  ) async {
+    final deleted = ConversationEntry.deleted(
+      id: 'root-1',
+      createdAt: DateTime.parse('2026-07-20T10:00:00Z'),
+    );
+    final reply = ConversationEntry.honoo(
+      honoo(
+        id: 'reply-1',
+        text: 'Risposta conservata',
+        owner: 'other',
+        createdAt: '2026-07-20T11:00:00Z',
+        type: HonooType.answer,
+        replyTo: 'root-1',
+      ),
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: UnifiedThreadView(
+            conversationId: 'conversation-1',
+            maxWidth: 390,
+            maxHeight: 700,
+            isActive: true,
+            conversationLoader: (_) async => [deleted, reply],
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(find.text('Risposta conservata'), findsOneWidget);
+    expect(find.text('contenuto eliminato'), findsOneWidget);
+    expect(find.byKey(const Key('reply_reveal_parent')), findsOneWidget);
+  });
+
+  testWidgets('una risposta orfana non avvia un rialzamento vuoto', (
+    tester,
+  ) async {
+    final reply = ConversationEntry.honoo(
+      honoo(
+        id: 'reply-1',
+        text: 'Risposta senza padre',
+        owner: 'other',
+        createdAt: '2026-07-20T11:00:00Z',
+        type: HonooType.answer,
+        replyTo: 'missing-root',
+      ),
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: UnifiedThreadView(
+            conversationId: 'conversation-1',
+            maxWidth: 390,
+            maxHeight: 700,
+            isActive: true,
+            conversationLoader: (_) async => [reply],
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Risposta senza padre'), findsOneWidget);
+    expect(find.byKey(const Key('reply_reveal_foreground')), findsNothing);
+  });
+
   testWidgets('una conversazione senza messaggi non crea una pagina vuota', (
     tester,
   ) async {


### PR DESCRIPTION
## Cosa cambia

- preserva nelle conversazioni la posizione dei contenuti Luna eliminati e mostra `contenuto eliminato`
- rende ogni conversazione visibile integralmente e simmetricamente negli Scrigni di mittente e destinatario
- ordina Honoo, Hinoo, conversazioni e contenuti salvati per attività più recente, con l’ultimo arrivo in prima posizione
- salva Honoo e Hinoo dalla Luna con cornice bianca e apre subito lo Scrigno sull’elemento appena salvato
- quando l’utente risponde nuovamente allo stesso contenuto senza aver ricevuto una contro-risposta, propone di continuare la conversazione precedente oppure crearne una nuova
- recupera il contenuto radice anche quando la risposta avvia esplicitamente una nuova conversazione

## Perché

La visibilità basata sulla singola riga non garantiva che entrambi i partecipanti potessero ricostruire tutto il filo. Inoltre lo Scrigno anteponeva sempre le conversazioni agli altri contenuti, indipendentemente dall’effettivo ordine di arrivo, e il salvataggio dalla Luna non portava l’utente alla copia appena creata.

Il vincolo database ereditava sempre il `conversation_id` del padre: questo impediva di distinguere una nuova conversazione avviata sullo stesso contenuto.

## Database e deploy

Le migrazioni incluse:

- `20260804123000_preserve_deleted_conversation_content.sql`: conserva tombstone e riferimenti dei contenuti eliminati
- `20260804150000_conversation_participants_and_forks.sql`: aggiunge lettura per partecipanti, ricerca dell’ultima risposta senza contro-risposta e supporto alle diramazioni esplicite

La simulazione remota precedente segnalava anche `20260803120000_fix_house_request_authorization_flow.sql` come migrazione pendente. Il deploy deve applicare le migrazioni nell’ordine previsto.

## Verifiche

- `flutter analyze`: nessun problema
- `flutter test --no-pub`: 238 test superati, 7 test live saltati perché privi delle credenziali opzionali
- test mirati per ordinamento, ricostruzione dei fili, popup No/Sì, navigazione e cornice Luna
- `git diff --cached --check`: pulito
- `supabase db lint`: non eseguito perché lo stack PostgreSQL locale non è attivo