### PR TITLE
Aggiungi reset Hinoo e ritocchi homepage/info

### DIFF
--- a/lib/Pages/home_page.dart
+++ b/lib/Pages/home_page.dart
@@ -146,9 +146,9 @@ class _HomeIntro extends StatelessWidget {
   const _HomeIntro();
 
   static const double _designWidth = 360;
-  static const double _bottleIconSize = 35;
+  static const double _bottleIconSize = 37;
   static const double _moonIconSize = 23;
-  static const double _islandIconSize = 36;
+  static const double _islandIconSize = 38;
   static const double _bottleIconVerticalOffset = 9;
   static const double _moonIconVerticalOffset = 1;
   static const double _islandIconVerticalOffset = 10;

--- a/lib/Pages/new_hinoo_page.dart
+++ b/lib/Pages/new_hinoo_page.dart
@@ -545,6 +545,23 @@ class _NewHinooPageState extends State<NewHinooPage>
     builder?.confirmBackgroundPublic?.call();
   }
 
+  Future<void> _deleteEditorContent() async {
+    final bool? confirmed = await showDialog<bool>(
+      context: context,
+      barrierDismissible: true,
+      builder: (_) => const HonooConfirmDialog(
+        title: 'Vuoi davvero eliminare questo hinoo?',
+        message: 'L’operazione non è reversibile',
+        confirmLabel: 'Sì',
+        cancelLabel: 'No',
+      ),
+    );
+    if (confirmed != true || !mounted) return;
+
+    final dynamic builder = _builderKey.currentState;
+    builder?.clearContentPublic?.call();
+  }
+
   Widget _buildImageEditingControls() {
     const double confirmIconSize = 30;
     const double secondaryActionIconSize = confirmIconSize * 0.82;
@@ -602,8 +619,22 @@ class _NewHinooPageState extends State<NewHinooPage>
                 ),
               ),
             ),
-            const Expanded(
-              child: SizedBox(key: Key('hinoo-editor-right-empty-slot')),
+            Expanded(
+              child: Align(
+                alignment: Alignment.centerRight,
+                child: Tooltip(
+                  message: 'Cancella hinoo',
+                  preferBelow: false,
+                  child: IconButton(
+                    key: const Key('hinoo-delete-editing-content'),
+                    onPressed: _deleteEditorContent,
+                    padding: EdgeInsets.zero,
+                    iconSize: secondaryActionIconSize,
+                    color: HonooColor.onBackground,
+                    icon: const Icon(Icons.delete_outline),
+                  ),
+                ),
+              ),
             ),
           ],
         ),

--- a/lib/UI/hinoo_builder.dart
+++ b/lib/UI/hinoo_builder.dart
@@ -400,6 +400,7 @@ class _HinooBuilderState extends State<HinooBuilder> {
   void reorderPagesPublic(int oldIndex, int newIndex) {}
 
   void deleteCurrentPagePublic() => _deleteCurrentPage(); // già usata
+  void clearContentPublic() => _clearContent();
   Future<void> openPreviewDialogPublic() => _openPreviewDialog();
   Future<void> openDownloadDialogPublic() => _openDownloadDialog();
   Future<void> downloadAllPagesPublic({String? baseName}) =>
@@ -633,6 +634,23 @@ class _HinooBuilderState extends State<HinooBuilder> {
         _pages[0] = _createEmptySlide();
         _current = 0;
       }
+    });
+
+    _scheduleAutosave();
+    _notifyChanged();
+  }
+
+  void _clearContent() {
+    if (_pages.isEmpty) {
+      _pages.add(_createEmptySlide());
+    }
+
+    setState(() {
+      _resetToBlankState();
+      _pages
+        ..clear()
+        ..add(_createEmptySlide());
+      _current = 0;
     });
 
     _scheduleAutosave();

--- a/lib/Widgets/chest_info_dialog.dart
+++ b/lib/Widgets/chest_info_dialog.dart
@@ -6,32 +6,32 @@ import '../Utility/honoo_colors.dart';
 import 'honoo_dialogs.dart';
 
 const chestInfoText =
-    "Questo è il tuo Scrigno.\n\n"
+    "Questo è il tuo Scrigno\n\n"
     "Qui sono custoditi\n"
     "gli honoo e gli hinoo\n"
     "che hai scritto,\n\n"
     "quelli che hai salvato dalla Luna,\n\n"
-    "e quelli che hai ricevuto.\n\n"
+    "e quelli che hai ricevuto\n\n"
     "Blu\n"
-    "sono i tuoi.\n\n"
+    "sono i tuoi\n\n"
     "Bianco\n"
-    "quelli della Luna.\n\n"
+    "quelli della Luna\n\n"
     "Rosso\n"
-    "quelli che ti sono stati inviati.\n\n"
+    "quelli che ti sono stati inviati\n\n"
     "Scorri verso destra\n"
     "per rivedere ciò che hai scritto\n"
-    "e ciò che hai salvato.\n\n"
+    "e ciò che hai salvato\n\n"
     "Scorri dall’alto verso il basso\n"
     "per seguire\n"
-    "le conversazioni.\n\n"
+    "le conversazioni\n\n"
     "In alto\n"
-    "l’honoo della Luna.\n\n"
+    "l’honoo della Luna\n\n"
     "Sotto\n"
-    "la tua risposta.\n\n"
+    "la tua risposta\n\n"
     "E, sotto ancora,\n"
     "se arriva,\n"
     "la risposta\n"
-    "alla tua risposta.\n";
+    "alla tua risposta\n";
 
 Future<void> showChestInfoDialog(BuildContext context) => showDialog<void>(
   context: context,

--- a/test/pages/new_hinoo_page_test.dart
+++ b/test/pages/new_hinoo_page_test.dart
@@ -21,7 +21,7 @@ void main() {
     expect(find.byTooltip('Apri il tuo Cuore'), findsOneWidget);
   });
 
-  testWidgets('il cestino hinoo non è mostrato sopra il box di editing', (
+  testWidgets('il cestino hinoo appare nella toolbar di modifica immagine', (
     tester,
   ) async {
     await tester.pumpWidget(
@@ -33,8 +33,47 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(find.byTooltip('Cancella hinoo'), findsNothing);
+    final dynamic pageState = tester.state(find.byType(NewHinooPage));
+    pageState.setEditorStateForTesting(step: 'changeBg', hasBackground: true);
+    await tester.pump();
+
+    expect(find.byTooltip('Cancella hinoo'), findsOneWidget);
     expect(find.byType(HinooBuilder), findsOneWidget);
+  });
+
+  testWidgets('il cestino conferma e riporta l editor hinoo allo stato vuoto', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      Sizer(
+        builder: (context, orientation, deviceType) {
+          return const MaterialApp(home: NewHinooPage());
+        },
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final dynamic pageState = tester.state(find.byType(NewHinooPage));
+    pageState.setEditorStateForTesting(
+      step: 'changeBg',
+      hasBackground: true,
+      textLength: 12,
+    );
+    await tester.pump();
+
+    await tester.tap(find.byTooltip('Cancella hinoo'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Vuoi davvero eliminare questo hinoo?'), findsOneWidget);
+    expect(find.text('L’operazione non è reversibile'), findsOneWidget);
+    expect(find.text('Sì'), findsOneWidget);
+    expect(find.text('No'), findsOneWidget);
+
+    await tester.tap(find.text('Sì'));
+    await tester.pumpAndSettle();
+
+    expect(find.byTooltip('Cancella hinoo'), findsNothing);
+    expect(find.byTooltip('Salva immagine'), findsNothing);
   });
 
   testWidgets('controlli immagine allineati come nell editor honoo', (
@@ -55,12 +94,10 @@ void main() {
 
     final saveImage = find.byTooltip('Salva immagine');
     final replaceImage = find.byTooltip('Sostituisci immagine');
-    final rightEmptySlot = find.byKey(
-      const Key('hinoo-editor-right-empty-slot'),
-    );
+    final deleteContent = find.byTooltip('Cancella hinoo');
     expect(saveImage, findsOneWidget);
     expect(replaceImage, findsOneWidget);
-    expect(rightEmptySlot, findsOneWidget);
+    expect(deleteContent, findsOneWidget);
     final replaceIcon = tester.widget<SvgPicture>(
       find.descendant(of: replaceImage, matching: find.byType(SvgPicture)),
     );
@@ -74,11 +111,7 @@ void main() {
     );
     expect(
       tester.getCenter(saveImage).dx,
-      lessThan(tester.getCenter(rightEmptySlot).dx),
-    );
-    expect(
-      find.descendant(of: rightEmptySlot, matching: find.byType(IconButton)),
-      findsNothing,
+      lessThan(tester.getCenter(deleteContent).dx),
     );
 
     pageState.setEditorStateForTesting(step: 'writeText', hasBackground: true);

--- a/test/widgets/chest_info_dialog_test.dart
+++ b/test/widgets/chest_info_dialog_test.dart
@@ -22,6 +22,7 @@ void main() {
     expect(find.byType(ChestInfoDialog), findsOneWidget);
     expect(find.byType(SingleChildScrollView), findsOneWidget);
     expect(find.textContaining('Questo è il tuo Scrigno'), findsOneWidget);
+    expect(chestInfoText, isNot(contains('.')));
     expect(find.text(BuildMetadata.displayLabel), findsNothing);
     expect(find.byTooltip('Chiudi'), findsOneWidget);
 


### PR DESCRIPTION
## Cosa cambia

- aggiunge il cestino in alto a destra nella toolbar di modifica immagine Hinoo
- mostra la conferma esplicita con pulsanti Sì e No e ripristina editor, immagine e testo allo stato iniziale
- aumenta di 2 px le icone inline Bottiglia e Isola nella homepage
- rimuove i punti dal testo Info dello Scrigno
- aggiorna i test widget per coprire toolbar, conferma, reset e testo Info

## Perché

L’editor Hinoo non offriva un’azione visibile per abbandonare completamente il contenuto in corso. La nuova azione rende il reset intenzionale e protetto da conferma, mantenendo coerente lo stato del builder e della pagina.

## Verifiche

- `flutter test --no-pub test/pages/new_hinoo_page_test.dart test/widgets/chest_info_dialog_test.dart`
- `flutter analyze lib/UI/hinoo_builder.dart lib/Pages/new_hinoo_page.dart lib/Pages/home_page.dart lib/Widgets/chest_info_dialog.dart test/pages/new_hinoo_page_test.dart test/widgets/chest_info_dialog_test.dart`
- `git diff --check`
