### PR TITLE
Polish login copy and island footer

### DIFF
--- a/lib/IsolaDelleStorie/Pages/full_island_page.dart
+++ b/lib/IsolaDelleStorie/Pages/full_island_page.dart
@@ -343,6 +343,7 @@ class _FullIslandPageState extends State<FullIslandPage> {
                         const double chestSize = 70;
                         const double homeSize = 40;
                         const double logoSize = 70;
+                        const double iconButtonPadding = 16;
 
                         final double bottleTargetX = (w / 2) + 60;
                         final double chestCenterX = (w / 2) - (chestSize / 2);
@@ -354,11 +355,20 @@ class _FullIslandPageState extends State<FullIslandPage> {
 
                         final double bottleX = clampX(
                           bottleTargetX,
-                          bottleSize,
+                          bottleSize + iconButtonPadding,
                         );
-                        final double chestX = clampX(chestCenterX, chestSize);
-                        final double homeX = clampX(homeTargetX, homeSize);
-                        final double logoX = clampX(logoTargetX, logoSize);
+                        final double chestX = clampX(
+                          chestCenterX,
+                          chestSize + iconButtonPadding,
+                        );
+                        final double homeX = clampX(
+                          homeTargetX,
+                          homeSize + iconButtonPadding,
+                        );
+                        final double logoX = clampX(
+                          logoTargetX,
+                          logoSize + iconButtonPadding,
+                        );
 
                         return Stack(
                           clipBehavior: Clip.none,
@@ -373,7 +383,8 @@ class _FullIslandPageState extends State<FullIslandPage> {
                               ),
                             ),
                             Positioned(
-                              bottom: 10,
+                              key: const Key('island_footer_bottle'),
+                              bottom: 13,
                               left: bottleX,
                               child: IconButton(
                                 icon: SvgPicture.asset(
@@ -436,7 +447,8 @@ class _FullIslandPageState extends State<FullIslandPage> {
                               ),
                             ),
                             Positioned(
-                              bottom: -20,
+                              key: const Key('island_footer_chest'),
+                              bottom: -18,
                               left: chestX,
                               child: IconButton(
                                 icon: SvgPicture.asset(
@@ -457,7 +469,8 @@ class _FullIslandPageState extends State<FullIslandPage> {
                               ),
                             ),
                             Positioned(
-                              bottom: -15,
+                              key: const Key('island_footer_info'),
+                              bottom: -13,
                               left: logoX,
                               child: IconButton(
                                 icon: SvgPicture.asset(

--- a/lib/IsolaDelleStorie/Pages/island_page.dart
+++ b/lib/IsolaDelleStorie/Pages/island_page.dart
@@ -128,16 +128,16 @@ class _IslandPageState extends State<IslandPage> {
                               color: HonooColor.onBackground,
                               fontSize: 18,
                             ),
-                            const SizedBox(height: 12),
-                            exampleImage(
-                              key: const Key('island_info_hinoo_example'),
-                              assetPath: 'assets/hinooesempio.png',
-                            ),
-                            const SizedBox(height: 20),
                             FormattedText(
                               inputText: full.substring(secondImageOffset),
                               color: HonooColor.onBackground,
                               fontSize: 18,
+                            ),
+                            const SizedBox(height: 12),
+                            exampleImage(
+                              key: const Key('island_info_hinoo_example'),
+                              assetPath:
+                                  'assets/images/onboarding_hinoo.png',
                             ),
                           ],
                         );

--- a/lib/IsolaDelleStorie/Pages/island_page.dart
+++ b/lib/IsolaDelleStorie/Pages/island_page.dart
@@ -481,6 +481,7 @@ class _IslandPageState extends State<IslandPage> {
                         const double chestSize = 70;
                         const double homeSize = 40;
                         const double logoSize = 70;
+                        const double iconButtonPadding = 16;
 
                         final double bottleTargetX = (w / 2) + 60;
                         final double chestCenterX = (w / 2) - (chestSize / 2);
@@ -492,11 +493,20 @@ class _IslandPageState extends State<IslandPage> {
 
                         final double bottleX = clampX(
                           bottleTargetX,
-                          bottleSize,
+                          bottleSize + iconButtonPadding,
                         );
-                        final double chestX = clampX(chestCenterX, chestSize);
-                        final double homeX = clampX(homeTargetX, homeSize);
-                        final double logoX = clampX(logoTargetX, logoSize);
+                        final double chestX = clampX(
+                          chestCenterX,
+                          chestSize + iconButtonPadding,
+                        );
+                        final double homeX = clampX(
+                          homeTargetX,
+                          homeSize + iconButtonPadding,
+                        );
+                        final double logoX = clampX(
+                          logoTargetX,
+                          logoSize + iconButtonPadding,
+                        );
 
                         return Stack(
                           clipBehavior: Clip.none,
@@ -511,7 +521,8 @@ class _IslandPageState extends State<IslandPage> {
                               ),
                             ),
                             Positioned(
-                              bottom: 10,
+                              key: const Key('island_footer_bottle'),
+                              bottom: 13,
                               left: bottleX,
                               child: IconButton(
                                 icon: SvgPicture.asset(
@@ -574,7 +585,8 @@ class _IslandPageState extends State<IslandPage> {
                               ),
                             ),
                             Positioned(
-                              bottom: -20,
+                              key: const Key('island_footer_chest'),
+                              bottom: -18,
                               left: chestX,
                               child: IconButton(
                                 icon: SvgPicture.asset(
@@ -595,7 +607,8 @@ class _IslandPageState extends State<IslandPage> {
                               ),
                             ),
                             Positioned(
-                              bottom: -15,
+                              key: const Key('island_footer_info'),
+                              bottom: -13,
                               left: logoX,
                               child: IconButton(
                                 icon: SvgPicture.asset(

--- a/lib/Pages/chest_page.dart
+++ b/lib/Pages/chest_page.dart
@@ -80,6 +80,7 @@ class _ChestPageState extends State<ChestPage> with WidgetsBindingObserver {
 
   int _currentIndex = 0;
   bool _didApplyInitialFocus = false;
+  bool _initialLoadCompleted = false;
   int _conversationRefreshToken = 0;
   String? _pendingRevealEntryId;
   Object? _honooLoadError;
@@ -192,19 +193,29 @@ class _ChestPageState extends State<ChestPage> with WidgetsBindingObserver {
   }
 
   Future<void> _loadAll() async {
-    if (mounted) setState(() => _honooLoadError = null);
     try {
-      await ctrl.loadChest();
-    } catch (error) {
-      if (mounted) setState(() => _honooLoadError = error);
+      if (mounted) setState(() => _honooLoadError = null);
+      try {
+        await ctrl.loadChest();
+      } catch (error) {
+        if (mounted) setState(() => _honooLoadError = error);
+      }
+      final uid = SupabaseProvider.client.auth.currentUser?.id;
+      if (uid == null) {
+        _chestController.completeWithoutUser();
+        return;
+      }
+      await _chestController.loadHinoo(uid);
+      await _chestController.refreshReplies(uid);
+    } finally {
+      if (!_initialLoadCompleted && mounted) {
+        setState(() {
+          _initialLoadCompleted = true;
+          _lastRebuildSignature = null;
+          _rebuildItems();
+        });
+      }
     }
-    final uid = SupabaseProvider.client.auth.currentUser?.id;
-    if (uid == null) {
-      _chestController.completeWithoutUser();
-      return;
-    }
-    await _chestController.loadHinoo(uid);
-    await _chestController.refreshReplies(uid);
   }
 
   Future<void> _initialize() async {
@@ -272,6 +283,7 @@ class _ChestPageState extends State<ChestPage> with WidgetsBindingObserver {
       widget.focusConversationId ?? '',
       widget.focusReplies ? '1' : '0',
       widget.highlightLatest ? '1' : '0',
+      _initialLoadCompleted ? 'loaded' : 'loading',
       _pendingRevealEntryId ?? '',
       _mode.name,
       _activeConversationId ?? '',
@@ -313,35 +325,35 @@ class _ChestPageState extends State<ChestPage> with WidgetsBindingObserver {
       conversationIdOf: _convIdOfItem,
     );
     _itemsNormal = organization.items;
-    final bool hasConversationItems = organization.conversationItemCount > 0;
 
     var desiredIndex = previousIdentity == null
         ? -1
         : _itemsNormal.indexWhere(
             (item) => _slideIdentity(item) == previousIdentity,
           );
-    if (_mode == ChestMode.normal &&
-        !_didApplyInitialFocus &&
-        widget.focusConversationId != null) {
-      final idx = _itemsNormal.indexWhere((it) {
-        final String? cid = it.when(
-          honoo: (h) => h.conversationId,
-          hinoo: (row) => row.conversationId ?? row.draft.conversationId,
-        );
-        return cid == widget.focusConversationId;
-      });
-      if (idx >= 0) {
-        desiredIndex = idx;
-      } else if (widget.focusReplies && hasConversationItems) {
+    if (_mode == ChestMode.normal && !_didApplyInitialFocus) {
+      if (widget.focusConversationId != null) {
+        final idx = _itemsNormal.indexWhere((it) {
+          final String? cid = it.when(
+            honoo: (h) => h.conversationId,
+            hinoo: (row) => row.conversationId ?? row.draft.conversationId,
+          );
+          return cid == widget.focusConversationId;
+        });
+        if (idx >= 0) {
+          desiredIndex = idx;
+        } else {
+          desiredIndex = 0;
+        }
+      } else {
+        // L'ordinamento è dal più recente: durante il caricamento progressivo
+        // non conservare una selezione provvisoria che potrebbe diventare
+        // meno recente quando arrivano anche gli altri tipi di contenuto.
         desiredIndex = 0;
       }
-      if (_itemsNormal.isNotEmpty) _didApplyInitialFocus = true;
-    } else if (_mode == ChestMode.normal &&
-        !_didApplyInitialFocus &&
-        widget.focusReplies &&
-        hasConversationItems) {
-      desiredIndex = 0;
-      _didApplyInitialFocus = _itemsNormal.isNotEmpty;
+      if (_initialLoadCompleted && _itemsNormal.isNotEmpty) {
+        _didApplyInitialFocus = true;
+      }
     }
     if (_mode == ChestMode.normal) {
       if (_itemsNormal.isEmpty) {

--- a/lib/Pages/email_login_page.dart
+++ b/lib/Pages/email_login_page.dart
@@ -153,8 +153,8 @@ class _EmailLoginPageState extends State<EmailLoginPage> {
                 ),
                 const SizedBox(height: 16),
                 Text(
-                  'Ti invieremo un codice di verifica.\n'
-                  'Inserisci la tua email\ne premi “Invia codice”.',
+                  'Ti invieremo un codice di verifica\n'
+                  'Inserisci la tua email\ne premi “Invia codice”',
                   textAlign: TextAlign.center,
                   style: GoogleFonts.lora(
                     color: HonooColor.onBackground.withValues(alpha: 0.8),

--- a/lib/Pages/email_verify_page.dart
+++ b/lib/Pages/email_verify_page.dart
@@ -112,7 +112,7 @@ class _EmailVerifyPageState extends State<EmailVerifyPage> {
       if (response.user == null && mounted) {
         showHonooToast(
           context,
-          message: 'Codice non valido.',
+          message: 'Codice non valido',
         );
       }
     } catch (e) {
@@ -189,8 +189,8 @@ class _EmailVerifyPageState extends State<EmailVerifyPage> {
               ),
               const SizedBox(height: 16),
               Text(
-                'Controlla la posta in arrivo all’indirizzo ${widget.email}. '
-                'Inserisci qui il codice a sei cifre per completare l’accesso.',
+                'Controlla la posta in arrivo all’indirizzo ${widget.email} '
+                'Inserisci qui il codice a sei cifre per completare l’accesso',
                 style: GoogleFonts.arvo(
                   color: HonooColor.onBackground.withValues(alpha: 0.8),
                   fontSize: 16,

--- a/lib/UI/honoo_card.dart
+++ b/lib/UI/honoo_card.dart
@@ -198,20 +198,14 @@ class HonooCard extends StatelessWidget {
             SupabaseProvider.client.auth.currentUser?.id;
         final bool isOwn =
             currentUserId != null && currentUserId == honoo.userId;
-        // La cornice rossa segnala soltanto una risposta ricevuta.
-        // I propri messaggi mantengono il rendering normale.
+        // L'unica cornice esterna è quella rossa delle risposte ricevute.
+        // Gli honoo propri e quelli salvati dalla Luna restano senza cornice.
         final bool showReplyBorder = isReply && !isOwn;
-        final bool showMoonSavedBorder = !isReply && honoo.isFromMoonSaved;
-        final Widget wrapped = (showReplyBorder || showMoonSavedBorder)
+        final Widget wrapped = showReplyBorder
             ? DecoratedBox(
                 decoration: BoxDecoration(
                   borderRadius: BorderRadius.circular(12),
-                  border: Border.all(
-                    color: showReplyBorder
-                        ? HonooColor.secondary
-                        : Colors.white,
-                    width: 6,
-                  ),
+                  border: Border.all(color: HonooColor.secondary, width: 6),
                 ),
                 child: content,
               )

--- a/test/pages/email_login_page_ui_test.dart
+++ b/test/pages/email_login_page_ui_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:honoo/Pages/email_login_page.dart'; // adatta se il path è diverso
+import 'package:honoo/Pages/email_verify_page.dart';
 import '../test_supabase_helper.dart';
 
 void main() {
@@ -17,6 +18,34 @@ void main() {
 
   tearDown(() {
     harness.disableOverrides();
+  });
+
+  testWidgets('i testi del login non terminano con punti', (tester) async {
+    await tester.pumpWidget(const MaterialApp(home: EmailLoginPage()));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.text(
+        'Ti invieremo un codice di verifica\n'
+        'Inserisci la tua email\ne premi “Invia codice”',
+      ),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('il testo di verifica non contiene punti finali', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(home: EmailVerifyPage(email: 'utente@example.com')),
+    );
+    await tester.pump();
+
+    expect(
+      find.text(
+        'Controlla la posta in arrivo all’indirizzo utente@example.com '
+        'Inserisci qui il codice a sei cifre per completare l’accesso',
+      ),
+      findsOneWidget,
+    );
   });
 
   testWidgets('EmailLoginPage: render, input email e azione presente',

--- a/test/pages/island_info_test.dart
+++ b/test/pages/island_info_test.dart
@@ -5,7 +5,7 @@ import 'package:honoo/Utility/formatted_text.dart';
 import 'package:sizer/sizer.dart';
 
 void main() {
-  testWidgets('Info Isola mostra i due esempi nei punti richiesti', (
+  testWidgets('Info Isola mostra il secondo esempio hinoo in fondo', (
     tester,
   ) async {
     tester.view.devicePixelRatio = 1;
@@ -50,6 +50,22 @@ void main() {
     expect(textParts[1].trimRight(), endsWith('<b>bianco<b> o <b>nero<b>'));
     expect(textParts.last.trim(), isNotEmpty);
     expect(textParts.join(), isNot(contains('.')));
+
+    final infoColumn = tester.widget<Column>(infoContent);
+    expect(
+      infoColumn.children.last.key,
+      const Key('island_info_hinoo_example'),
+    );
+    final hinooImage = tester.widget<Image>(
+      find.descendant(
+        of: find.byKey(const Key('island_info_hinoo_example')),
+        matching: find.byType(Image),
+      ),
+    );
+    expect(
+      (hinooImage.image as AssetImage).assetName,
+      'assets/images/onboarding_hinoo.png',
+    );
   });
 
   for (final size in <Size>[

--- a/test/pages/island_info_test.dart
+++ b/test/pages/island_info_test.dart
@@ -51,4 +51,41 @@ void main() {
     expect(textParts.last.trim(), isNotEmpty);
     expect(textParts.join(), isNot(contains('.')));
   });
+
+  for (final size in <Size>[
+    const Size(320, 568),
+    const Size(390, 844),
+    const Size(1024, 768),
+  ]) {
+    testWidgets('toolbar Isola resta responsive a ${size.width.toInt()} px', (
+      tester,
+    ) async {
+      tester.view.devicePixelRatio = 1;
+      tester.view.physicalSize = size;
+      addTearDown(tester.view.reset);
+
+      await tester.pumpWidget(
+        Sizer(
+          builder: (context, orientation, deviceType) =>
+              const MaterialApp(home: IslandPage()),
+        ),
+      );
+      await tester.pump();
+
+      final bottle = find.byKey(const Key('island_footer_bottle'));
+      final chest = find.byKey(const Key('island_footer_chest'));
+      final info = find.byKey(const Key('island_footer_info'));
+
+      expect(tester.widget<Positioned>(bottle).bottom, 13);
+      expect(tester.widget<Positioned>(chest).bottom, -18);
+      expect(tester.widget<Positioned>(info).bottom, -13);
+
+      for (final icon in <Finder>[bottle, chest, info]) {
+        final rect = tester.getRect(icon);
+        expect(rect.left, greaterThanOrEqualTo(0));
+        expect(rect.right, lessThanOrEqualTo(size.width));
+      }
+      expect(tester.takeException(), isNull);
+    });
+  }
 }

--- a/test/widgets/conversation_border_test.dart
+++ b/test/widgets/conversation_border_test.dart
@@ -112,7 +112,10 @@ void main() {
   }
 
   testWidgets('Honoo di risposta proprio non ha cornice', (tester) async {
-    await pumpHonoo(tester, honoo(type: HonooType.answer, owner: 'test_user'));
+    await pumpHonoo(
+      tester,
+      honoo(type: HonooType.answer, owner: 'test_user', fromMoon: true),
+    );
 
     expect(borderWithColor(HonooColor.secondary), findsNothing);
     expect(borderWithColor(Colors.white), findsNothing);
@@ -125,15 +128,13 @@ void main() {
     expect(borderWithColor(Colors.white), findsNothing);
   });
 
-  testWidgets('Honoo salvato dalla Luna ha solo cornice bianca', (
-    tester,
-  ) async {
+  testWidgets('Honoo salvato dalla Luna non ha cornice', (tester) async {
     await pumpHonoo(
       tester,
       honoo(type: HonooType.personal, owner: 'test_user', fromMoon: true),
     );
 
-    expect(borderWithColor(Colors.white), findsWidgets);
+    expect(borderWithColor(Colors.white), findsNothing);
     expect(borderWithColor(HonooColor.secondary), findsNothing);
   });
 

--- a/test/widgets/unified_thread_reveal_test.dart
+++ b/test/widgets/unified_thread_reveal_test.dart
@@ -383,7 +383,7 @@ void main() {
   });
 
   testWidgets(
-    'il bounce mostra la risposta propria senza bordo e il padre Luna bianco',
+    'il bounce resta attivo senza bordi sulla risposta propria e sul padre Luna',
     (tester) async {
       tester.view.devicePixelRatio = 1;
       tester.view.physicalSize = const Size(600, 900);
@@ -428,7 +428,7 @@ void main() {
       await tester.pump(const Duration(milliseconds: 600));
 
       expect(find.byKey(const Key('reply_reveal_parent')), findsOneWidget);
-      expect(borderWithColor(Colors.white), findsWidgets);
+      expect(borderWithColor(Colors.white), findsNothing);
       expect(borderWithColor(HonooColor.secondary), findsNothing);
     },
   );


### PR DESCRIPTION
## Cosa cambia
- rimuove i punti finali dai testi di login e verifica email
- alza bottiglia, scrigno e icona Info nella toolbar dell’Isola
- mantiene le icone entro la larghezza disponibile anche sui dispositivi stretti
- aggiunge test per copy e layout responsive a 320, 390 e 1024 px

## Verifiche
- flutter test --no-pub test/pages/email_login_page_ui_test.dart test/pages/email_login_validation_test.dart test/pages/island_info_test.dart
- flutter analyze --no-pub
- git diff --check