### PR TITLE
Fix production conversation migration auth column

### DIFF
--- a/supabase/migrations/20260804150000_conversation_participants_and_forks.sql
+++ b/supabase/migrations/20260804150000_conversation_participants_and_forks.sql
@@ -17,7 +17,7 @@ as $$
         h.user_id = auth.uid()
         or h.recipient_tag = auth.uid()::text
         or h.recipient_tag in (
-          select u.address from public.users u where u.auth_id = auth.uid()
+          select u.address from public.users u where u.auth_user_id = auth.uid()
         )
       )
     union all
@@ -28,7 +28,7 @@ as $$
         x.user_id = auth.uid()
         or x.recipient_tag = auth.uid()::text
         or x.recipient_tag in (
-          select u.address from public.users u where u.auth_id = auth.uid()
+          select u.address from public.users u where u.auth_user_id = auth.uid()
         )
       )
   );


### PR DESCRIPTION
## Summary
- use the current users.auth_user_id column in the conversation participant function
- unblock the pending production Supabase migration and web deploy

## Validation
- bash tool/check_supabase_migrations.sh
- git diff --check

## Failure addressed
Production deploy run 30924736480 failed because users.auth_id does not exist in production.