### PR TITLE
Fix duplicate Luna action in Chest toolbar

### DIFF
--- a/lib/Widgets/chest_footer.dart
+++ b/lib/Widgets/chest_footer.dart
@@ -80,8 +80,13 @@ class ChestFooter extends StatelessWidget {
     final hasReplies = honoo.hasReplies == true;
     final isFromMoonSaved = honoo.isFromMoonSaved == true;
     final isOnMoon = honoo.isOnMoon == true;
+    final selectedEntryToPublish = _selectedEntryToPublish(honoo);
 
-    if (isPersonal && !hasReplies && !isFromMoonSaved && !isOnMoon) {
+    if (isPersonal &&
+        !hasReplies &&
+        !isFromMoonSaved &&
+        !isOnMoon &&
+        selectedEntryToPublish == null) {
       actions.add(_moonAction(() => onSendHonooToMoon(honoo)));
     } else if (hasReplies && !isFromMoonSaved) {
       actions.add(
@@ -98,12 +103,24 @@ class ChestFooter extends StatelessWidget {
 
     actions.add(_deleteAction(() => onDeleteHonoo(honoo)));
 
+    if (selectedEntryToPublish != null) {
+      actions.add(
+        _moonAction(
+          () => onSendConversationEntryToMoon(selectedEntryToPublish),
+        ),
+      );
+    }
+  }
+
+  ConversationEntry? _selectedEntryToPublish(Honoo honoo) {
     final entry = selectedConversationEntry;
     final conversationId = honoo.conversationId;
-    if (entry == null || conversationId == null || conversationId.isEmpty) {
-      return;
+    if (entry == null ||
+        conversationId == null ||
+        conversationId.isEmpty ||
+        entry.kind == ConversationEntryKind.deleted) {
+      return null;
     }
-    if (entry.kind == ConversationEntryKind.deleted) return;
     final isMine =
         entry.ownerId != null &&
         currentUserId != null &&
@@ -111,9 +128,7 @@ class ChestFooter extends StatelessWidget {
     final isPersonalEntry = entry.kind == ConversationEntryKind.honoo
         ? entry.honoo!.type == HonooType.personal
         : entry.hinoo!.type == HinooType.personal;
-    if (isMine && isPersonalEntry) {
-      actions.add(_moonAction(() => onSendConversationEntryToMoon(entry)));
-    }
+    return isMine && isPersonalEntry ? entry : null;
   }
 
   void _addHinooActions(

--- a/test/widgets/chest_footer_test.dart
+++ b/test/widgets/chest_footer_test.dart
@@ -12,6 +12,7 @@ void main() {
     HonooType type, {
     bool isOnMoon = false,
     bool hasReplies = false,
+    String? conversationId,
   }) {
     final honoo = Honoo(
       1,
@@ -23,7 +24,8 @@ void main() {
       type,
     )
       ..isOnMoon = isOnMoon
-      ..hasReplies = hasReplies;
+      ..hasReplies = hasReplies
+      ..conversationId = conversationId;
     return ChestItem.honoo(honoo, DateTime.utc(2026));
   }
 
@@ -53,13 +55,15 @@ void main() {
     ValueChanged<Honoo>? onDeleteHonoo,
     ValueChanged<ChestHinooItem>? onSendHinooToMoon,
     ValueChanged<ChestHinooItem>? onDeleteHinoo,
+    ConversationEntry? selectedConversationEntry,
+    ValueChanged<ConversationEntry>? onSendConversationEntryToMoon,
   }) async {
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
           body: ChestFooter(
             item: item,
-            selectedConversationEntry: null,
+            selectedConversationEntry: selectedConversationEntry,
             currentUserId: 'current-user',
             iconSize: 40,
             gap: 24,
@@ -72,7 +76,8 @@ void main() {
             onSendHinooToMoon: onSendHinooToMoon ?? (_) {},
             onReplyToHinoo: (_) {},
             onDeleteHinoo: onDeleteHinoo ?? (_) {},
-            onSendConversationEntryToMoon: (ConversationEntry _) {},
+            onSendConversationEntryToMoon:
+                onSendConversationEntryToMoon ?? (ConversationEntry _) {},
           ),
         ),
       ),
@@ -166,6 +171,29 @@ void main() {
     expect(find.byTooltip('Spedisci sulla Luna'), findsNothing);
     expect(find.byTooltip('Cancella'), findsOneWidget);
   });
+
+  testWidgets(
+    'la selezione del padre della conversazione mostra una sola azione Luna',
+    (tester) async {
+      final item = honooItem(
+        HonooType.personal,
+        conversationId: 'conversation-1',
+      );
+      final selectedEntry = ConversationEntry.honoo(item.honoo!);
+      ConversationEntry? publishedEntry;
+
+      await pumpFooter(
+        tester,
+        item: item,
+        selectedConversationEntry: selectedEntry,
+        onSendConversationEntryToMoon: (entry) => publishedEntry = entry,
+      );
+
+      expect(find.byTooltip('Spedisci sulla Luna'), findsOneWidget);
+      await tester.tap(find.byTooltip('Spedisci sulla Luna'));
+      expect(publishedEntry, same(selectedEntry));
+    },
+  );
 
   testWidgets('Hinoo già sulla Luna non mostra una seconda azione Luna',
       (tester) async {


### PR DESCRIPTION
## Cosa cambia

- impedisce che la toolbar dello scrigno mostri due azioni Luna quando è selezionato il padre di una conversazione
- assegna l'unica azione Luna all'elemento della conversazione effettivamente selezionato
- aggiunge un test di regressione per il caso `conversationId` presente, `hasReplies` falso e padre selezionato

## Causa

La toolbar aggiungeva separatamente l'azione Luna generica dell'Honoo principale e quella dell'elemento selezionato. In alcune conversazioni, soprattutto quando `hasReplies` non rifletteva tutti i tipi di risposta, entrambe le condizioni risultavano vere.

## Verifiche

- `flutter analyze --no-pub`
- `flutter test --no-pub test/widgets/chest_footer_test.dart test/widgets/chest_item_view_animation_test.dart test/widgets/unified_thread_reveal_test.dart test/widgets/conversation_border_test.dart`

Risultato: analisi pulita e 27 test superati.
