### PR TITLE
Polish island info and footer alignment

### DIFF
--- a/lib/IsolaDelleStorie/Pages/island_page.dart
+++ b/lib/IsolaDelleStorie/Pages/island_page.dart
@@ -57,8 +57,7 @@ class _IslandPageState extends State<IslandPage> {
                     child: Builder(
                       builder: (context) {
                         const String firstMarker = 'in forme più complesse';
-                        const String secondMarker =
-                            '<b>bianco<b> o <b>nero<b>';
+                        const String secondMarker = '<b>bianco<b> o <b>nero<b>';
                         final String full = IsolaDelleStoreContentManager.e00
                             .replaceAll('.', '');
                         final int firstMarkerIndex = full.indexOf(firstMarker);
@@ -128,16 +127,16 @@ class _IslandPageState extends State<IslandPage> {
                               color: HonooColor.onBackground,
                               fontSize: 18,
                             ),
+                            const SizedBox(height: 12),
+                            exampleImage(
+                              key: const Key('island_info_hinoo_example'),
+                              assetPath: 'assets/images/onboarding_hinoo.png',
+                            ),
+                            const SizedBox(height: 20),
                             FormattedText(
                               inputText: full.substring(secondImageOffset),
                               color: HonooColor.onBackground,
                               fontSize: 18,
-                            ),
-                            const SizedBox(height: 12),
-                            exampleImage(
-                              key: const Key('island_info_hinoo_example'),
-                              assetPath:
-                                  'assets/images/onboarding_hinoo.png',
                             ),
                           ],
                         );
@@ -522,7 +521,7 @@ class _IslandPageState extends State<IslandPage> {
                             ),
                             Positioned(
                               key: const Key('island_footer_bottle'),
-                              bottom: 13,
+                              bottom: 27,
                               left: bottleX,
                               child: IconButton(
                                 icon: SvgPicture.asset(
@@ -586,7 +585,7 @@ class _IslandPageState extends State<IslandPage> {
                             ),
                             Positioned(
                               key: const Key('island_footer_chest'),
-                              bottom: -18,
+                              bottom: -7,
                               left: chestX,
                               child: IconButton(
                                 icon: SvgPicture.asset(
@@ -608,7 +607,7 @@ class _IslandPageState extends State<IslandPage> {
                             ),
                             Positioned(
                               key: const Key('island_footer_info'),
-                              bottom: -13,
+                              bottom: -5,
                               left: logoX,
                               child: IconButton(
                                 icon: SvgPicture.asset(

--- a/test/pages/island_info_test.dart
+++ b/test/pages/island_info_test.dart
@@ -5,7 +5,7 @@ import 'package:honoo/Utility/formatted_text.dart';
 import 'package:sizer/sizer.dart';
 
 void main() {
-  testWidgets('Info Isola mostra il secondo esempio hinoo in fondo', (
+  testWidgets('Info Isola mostra il secondo esempio dopo bianco o nero', (
     tester,
   ) async {
     tester.view.devicePixelRatio = 1;
@@ -41,7 +41,10 @@ void main() {
 
     final textParts = tester
         .widgetList<FormattedText>(
-          find.descendant(of: infoContent, matching: find.byType(FormattedText)),
+          find.descendant(
+            of: infoContent,
+            matching: find.byType(FormattedText),
+          ),
         )
         .map((widget) => widget.inputText)
         .toList();
@@ -52,10 +55,15 @@ void main() {
     expect(textParts.join(), isNot(contains('.')));
 
     final infoColumn = tester.widget<Column>(infoContent);
-    expect(
-      infoColumn.children.last.key,
-      const Key('island_info_hinoo_example'),
+    final hinooExampleIndex = infoColumn.children.indexWhere(
+      (child) => child.key == const Key('island_info_hinoo_example'),
     );
+    final formattedTextIndexes = <int>[
+      for (var index = 0; index < infoColumn.children.length; index++)
+        if (infoColumn.children[index] is FormattedText) index,
+    ];
+    expect(hinooExampleIndex, greaterThan(formattedTextIndexes[1]));
+    expect(hinooExampleIndex, lessThan(formattedTextIndexes[2]));
     final hinooImage = tester.widget<Image>(
       find.descendant(
         of: find.byKey(const Key('island_info_hinoo_example')),
@@ -92,9 +100,9 @@ void main() {
       final chest = find.byKey(const Key('island_footer_chest'));
       final info = find.byKey(const Key('island_footer_info'));
 
-      expect(tester.widget<Positioned>(bottle).bottom, 13);
-      expect(tester.widget<Positioned>(chest).bottom, -18);
-      expect(tester.widget<Positioned>(info).bottom, -13);
+      expect(tester.widget<Positioned>(bottle).bottom, 27);
+      expect(tester.widget<Positioned>(chest).bottom, -7);
+      expect(tester.widget<Positioned>(info).bottom, -5);
 
       for (final icon in <Finder>[bottle, chest, info]) {
         final rect = tester.getRect(icon);


### PR DESCRIPTION
## Cosa cambia
- sposta l'esempio Hinoo subito dopo il passaggio «bianco o nero» nell'Info dell'Isola
- alza bottiglia, scrigno e info nella toolbar mobile secondo l'anteprima approvata
- aggiorna i test di ordine del contenuto e di posizionamento responsive

## Verifiche
- flutter analyze --no-pub
- flutter test --no-pub (256 test superati, 7 saltati perché live/esterni)