### PR TITLE
Harden mixed conversation flow under load

### DIFF
--- a/lib/Controller/chest_controller.dart
+++ b/lib/Controller/chest_controller.dart
@@ -15,6 +15,8 @@ class ChestState {
     List<ChestHinooItem> hinoo = const [],
     Map<String, DateTime> honooLatestReplies = const {},
     Map<String, DateTime> hinooLatestReplies = const {},
+    Map<String, DateTime> honooLatestReceivedReplies = const {},
+    Map<String, DateTime> hinooLatestReceivedReplies = const {},
     Map<String, List<HinooThreadEntry>> hinooRepliesByRoot = const {},
     this.isHinooLoading = true,
     this.isReplyLoading = false,
@@ -23,6 +25,12 @@ class ChestState {
   }) : hinoo = List.unmodifiable(hinoo),
        honooLatestReplies = Map.unmodifiable(honooLatestReplies),
        hinooLatestReplies = Map.unmodifiable(hinooLatestReplies),
+       honooLatestReceivedReplies = Map.unmodifiable(
+         honooLatestReceivedReplies,
+       ),
+       hinooLatestReceivedReplies = Map.unmodifiable(
+         hinooLatestReceivedReplies,
+       ),
        hinooRepliesByRoot = Map<String, List<HinooThreadEntry>>.unmodifiable(
          hinooRepliesByRoot.map<String, List<HinooThreadEntry>>(
            (key, value) =>
@@ -33,6 +41,8 @@ class ChestState {
   final List<ChestHinooItem> hinoo;
   final Map<String, DateTime> honooLatestReplies;
   final Map<String, DateTime> hinooLatestReplies;
+  final Map<String, DateTime> honooLatestReceivedReplies;
+  final Map<String, DateTime> hinooLatestReceivedReplies;
   final Map<String, List<HinooThreadEntry>> hinooRepliesByRoot;
   final bool isHinooLoading;
   final bool isReplyLoading;
@@ -222,6 +232,8 @@ class ChestController extends ValueNotifier<ChestState> {
       hinoo: value.hinoo.where((item) => item.id != id).toList(),
       honooLatestReplies: value.honooLatestReplies,
       hinooLatestReplies: value.hinooLatestReplies,
+      honooLatestReceivedReplies: value.honooLatestReceivedReplies,
+      hinooLatestReceivedReplies: value.hinooLatestReceivedReplies,
       hinooRepliesByRoot: value.hinooRepliesByRoot,
       isHinooLoading: value.isHinooLoading,
       isReplyLoading: value.isReplyLoading,
@@ -250,6 +262,8 @@ class ChestController extends ValueNotifier<ChestState> {
           .toList(),
       honooLatestReplies: value.honooLatestReplies,
       hinooLatestReplies: value.hinooLatestReplies,
+      honooLatestReceivedReplies: value.honooLatestReceivedReplies,
+      hinooLatestReceivedReplies: value.hinooLatestReceivedReplies,
       hinooRepliesByRoot: value.hinooRepliesByRoot,
       isHinooLoading: value.isHinooLoading,
       isReplyLoading: value.isReplyLoading,
@@ -266,6 +280,8 @@ class ChestController extends ValueNotifier<ChestState> {
       hinoo: value.hinoo,
       honooLatestReplies: value.honooLatestReplies,
       hinooLatestReplies: value.hinooLatestReplies,
+      honooLatestReceivedReplies: value.honooLatestReceivedReplies,
+      hinooLatestReceivedReplies: value.hinooLatestReceivedReplies,
       hinooRepliesByRoot: value.hinooRepliesByRoot,
       isHinooLoading: true,
       isReplyLoading: value.isReplyLoading,
@@ -319,6 +335,8 @@ class ChestController extends ValueNotifier<ChestState> {
         hinoo: List.unmodifiable(hinoo),
         honooLatestReplies: value.honooLatestReplies,
         hinooLatestReplies: value.hinooLatestReplies,
+        honooLatestReceivedReplies: value.honooLatestReceivedReplies,
+        hinooLatestReceivedReplies: value.hinooLatestReceivedReplies,
         hinooRepliesByRoot: value.hinooRepliesByRoot,
         isHinooLoading: false,
         isReplyLoading: value.isReplyLoading,
@@ -334,6 +352,8 @@ class ChestController extends ValueNotifier<ChestState> {
         hinoo: value.hinoo,
         honooLatestReplies: value.honooLatestReplies,
         hinooLatestReplies: value.hinooLatestReplies,
+        honooLatestReceivedReplies: value.honooLatestReceivedReplies,
+        hinooLatestReceivedReplies: value.hinooLatestReceivedReplies,
         hinooRepliesByRoot: value.hinooRepliesByRoot,
         isHinooLoading: false,
         isReplyLoading: value.isReplyLoading,
@@ -351,6 +371,8 @@ class ChestController extends ValueNotifier<ChestState> {
       hinoo: value.hinoo,
       honooLatestReplies: value.honooLatestReplies,
       hinooLatestReplies: value.hinooLatestReplies,
+      honooLatestReceivedReplies: value.honooLatestReceivedReplies,
+      hinooLatestReceivedReplies: value.hinooLatestReceivedReplies,
       hinooRepliesByRoot: value.hinooRepliesByRoot,
       isHinooLoading: value.isHinooLoading,
       isReplyLoading: true,
@@ -359,6 +381,7 @@ class ChestController extends ValueNotifier<ChestState> {
 
     try {
       final honooLatest = <String, DateTime>{};
+      final honooLatestReceived = <String, DateTime>{};
       final honooRows = await _reliability.refresh<List<dynamic>>(
         () => _repository.fetchHonooReplyRows(userId),
       );
@@ -383,9 +406,16 @@ class ChestController extends ValueNotifier<ChestState> {
         if (existing == null || created.isAfter(existing)) {
           honooLatest[activityKey] = created;
         }
+        if (row['user_id']?.toString() != userId) {
+          final existingReceived = honooLatestReceived[activityKey];
+          if (existingReceived == null || created.isAfter(existingReceived)) {
+            honooLatestReceived[activityKey] = created;
+          }
+        }
       }
 
       final hinooLatest = <String, DateTime>{};
+      final hinooLatestReceived = <String, DateTime>{};
       final hinooReplies = <String, List<HinooThreadEntry>>{};
       final rootIds = value.hinoo.map((item) => item.id).toList();
       final rows = await _reliability.refresh<List<dynamic>>(
@@ -431,12 +461,20 @@ class ChestController extends ValueNotifier<ChestState> {
         if (existing == null || created.isAfter(existing)) {
           hinooLatest[activityKey] = created;
         }
+        if (row['user_id']?.toString() != userId) {
+          final existingReceived = hinooLatestReceived[activityKey];
+          if (existingReceived == null || created.isAfter(existingReceived)) {
+            hinooLatestReceived[activityKey] = created;
+          }
+        }
       }
 
       value = ChestState(
         hinoo: value.hinoo,
         honooLatestReplies: honooLatest,
         hinooLatestReplies: hinooLatest,
+        honooLatestReceivedReplies: honooLatestReceived,
+        hinooLatestReceivedReplies: hinooLatestReceived,
         hinooRepliesByRoot: hinooReplies,
         isHinooLoading: value.isHinooLoading,
         isReplyLoading: false,
@@ -452,6 +490,8 @@ class ChestController extends ValueNotifier<ChestState> {
         hinoo: value.hinoo,
         honooLatestReplies: value.honooLatestReplies,
         hinooLatestReplies: value.hinooLatestReplies,
+        honooLatestReceivedReplies: value.honooLatestReceivedReplies,
+        hinooLatestReceivedReplies: value.hinooLatestReceivedReplies,
         hinooRepliesByRoot: value.hinooRepliesByRoot,
         isHinooLoading: value.isHinooLoading,
         isReplyLoading: false,

--- a/lib/Controller/chest_organizer.dart
+++ b/lib/Controller/chest_organizer.dart
@@ -2,10 +2,12 @@ class ChestOrganization<T> {
   const ChestOrganization({
     required this.items,
     required this.conversationItemCount,
+    required this.latestNotificationItemIndex,
   });
 
   final List<T> items;
   final int conversationItemCount;
+  final int latestNotificationItemIndex;
 }
 
 /// Regole pure di ordinamento e raggruppamento dello Scrigno.
@@ -17,6 +19,7 @@ class ChestOrganizer {
     required DateTime Function(T item) createdAtOf,
     required String Function(T item) stableIdOf,
     required DateTime? Function(T item) latestReplyOf,
+    required DateTime? Function(T item) latestNotificationOf,
     required String? Function(T item) conversationIdOf,
   }) {
     int compareCreatedAt(T a, T b) {
@@ -83,6 +86,27 @@ class ChestOrganizer {
       conversationItemCount: items
           .where((item) => latestReplyOf(item) != null)
           .length,
+      latestNotificationItemIndex: _latestNotificationIndex(
+        regrouped,
+        latestNotificationOf,
+      ),
     );
+  }
+
+  static int _latestNotificationIndex<T>(
+    List<T> items,
+    DateTime? Function(T item) latestNotificationOf,
+  ) {
+    var latestIndex = -1;
+    DateTime? latestDate;
+    for (var i = 0; i < items.length; i++) {
+      final candidate = latestNotificationOf(items[i]);
+      if (candidate != null &&
+          (latestDate == null || candidate.isAfter(latestDate))) {
+        latestDate = candidate;
+        latestIndex = i;
+      }
+    }
+    return latestIndex;
   }
 }

--- a/lib/Pages/chest_page.dart
+++ b/lib/Pages/chest_page.dart
@@ -8,6 +8,7 @@ import 'package:honoo/Services/chest_repository.dart';
 import 'package:honoo/Services/download_capture_service.dart';
 import 'package:honoo/Services/chest_hint_service.dart';
 import 'package:honoo/Services/duplication_result.dart';
+import 'package:honoo/Services/reply_system_notification.dart';
 
 import '../Controller/honoo_controller.dart';
 import '../Controller/hinoo_controller.dart';
@@ -77,6 +78,8 @@ class _ChestPageState extends State<ChestPage> with WidgetsBindingObserver {
   final DownloadCaptureService _downloadCaptureService =
       DownloadCaptureService();
   final ChestHintService _chestHintService = ChestHintService();
+  final ReplySystemNotification _replySystemNotification =
+      ReplySystemNotification.platform();
 
   int _currentIndex = 0;
   bool _didApplyInitialFocus = false;
@@ -94,6 +97,10 @@ class _ChestPageState extends State<ChestPage> with WidgetsBindingObserver {
       _chestController.value.honooLatestReplies;
   Map<String, DateTime> get _hinooLatestReplies =>
       _chestController.value.hinooLatestReplies;
+  Map<String, DateTime> get _honooLatestReceivedReplies =>
+      _chestController.value.honooLatestReceivedReplies;
+  Map<String, DateTime> get _hinooLatestReceivedReplies =>
+      _chestController.value.hinooLatestReceivedReplies;
   Map<String, List<HinooThreadEntry>> get _hinooRepliesByRoot =>
       _chestController.value.hinooRepliesByRoot;
   ConversationEntry? _selectedConvEntry;
@@ -116,7 +123,10 @@ class _ChestPageState extends State<ChestPage> with WidgetsBindingObserver {
     );
   }
 
-  void _selectConversationEntry(ConversationEntry entry) {
+  void _selectConversationEntry(
+    String? conversationId,
+    ConversationEntry entry,
+  ) {
     setState(() => _selectedConvEntry = entry);
     final currentUserId = SupabaseProvider.client.auth.currentUser?.id;
     final isReply =
@@ -127,6 +137,9 @@ class _ChestPageState extends State<ChestPage> with WidgetsBindingObserver {
         entry.ownerId == currentUserId ||
         entry.createdAt.millisecondsSinceEpoch <= 0) {
       return;
+    }
+    if (conversationId != null && conversationId.isNotEmpty) {
+      _replySystemNotification.closeConversation(conversationId);
     }
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
@@ -279,6 +292,14 @@ class _ChestPageState extends State<ChestPage> with WidgetsBindingObserver {
       ),
       ..._sortedActivitySignature('honoo', _honooLatestReplies),
       ..._sortedActivitySignature('hinoo', _hinooLatestReplies),
+      ..._sortedActivitySignature(
+        'honoo-received',
+        _honooLatestReceivedReplies,
+      ),
+      ..._sortedActivitySignature(
+        'hinoo-received',
+        _hinooLatestReceivedReplies,
+      ),
       ..._sortedReplySignature(),
       widget.focusConversationId ?? '',
       widget.focusReplies ? '1' : '0',
@@ -322,6 +343,14 @@ class _ChestPageState extends State<ChestPage> with WidgetsBindingObserver {
                 row.draft.conversationId ??
                 row.id],
       ),
+      latestNotificationOf: (item) => item.when(
+        honoo: (h) =>
+            _honooLatestReceivedReplies[h.conversationId ?? h.dbId ?? ''],
+        hinoo: (row) =>
+            _hinooLatestReceivedReplies[row.conversationId ??
+                row.draft.conversationId ??
+                row.id],
+      ),
       conversationIdOf: _convIdOfItem,
     );
     _itemsNormal = organization.items;
@@ -345,6 +374,9 @@ class _ChestPageState extends State<ChestPage> with WidgetsBindingObserver {
         } else {
           desiredIndex = 0;
         }
+      } else if (widget.focusReplies &&
+          organization.latestNotificationItemIndex >= 0) {
+        desiredIndex = organization.latestNotificationItemIndex;
       } else {
         // L'ordinamento è dal più recente: durante il caricamento progressivo
         // non conservare una selezione provvisoria che potrebbe diventare
@@ -889,7 +921,8 @@ class _ChestPageState extends State<ChestPage> with WidgetsBindingObserver {
       highlightLatest: widget.highlightLatest,
       focusConversationId: widget.focusConversationId,
       revealEntryId: _pendingRevealEntryId,
-      onSelectConversationEntry: _selectConversationEntry,
+      onSelectConversationEntry: (entry) =>
+          _selectConversationEntry(_convIdOfItem(item), entry),
       onDownload: () => _handleDownloadForItem(item, repaintKey),
       conversationRefreshToken: _conversationRefreshToken,
     );

--- a/lib/Services/chest_repository.dart
+++ b/lib/Services/chest_repository.dart
@@ -58,12 +58,12 @@ class ChestRepository {
   Future<List<dynamic>> fetchHonooReplyRows(String userId) async {
     final repliesToUser = await _client
         .from('honoo')
-        .select('conversation_id,reply_to,created_at')
+        .select('conversation_id,reply_to,created_at,user_id')
         .eq('destination', 'reply')
         .eq('recipient_tag', userId);
     final repliesFromUser = await _client
         .from('honoo')
-        .select('conversation_id,reply_to,created_at')
+        .select('conversation_id,reply_to,created_at,user_id')
         .eq('destination', 'reply')
         .eq('user_id', userId);
     return [..._asList(repliesToUser), ..._asList(repliesFromUser)];

--- a/lib/Services/conversation_service.dart
+++ b/lib/Services/conversation_service.dart
@@ -164,8 +164,7 @@ class ConversationService {
         ),
       );
     }
-    final deduplicatedEntries = _deduplicateMoonRoots(entries)
-      ..sort((a, b) => a.createdAt.compareTo(b.createdAt));
+    final deduplicatedEntries = _orderEntries(_deduplicateMoonRoots(entries));
     return deduplicatedEntries
         .map(
           (e) => e.when(
@@ -189,6 +188,41 @@ class ConversationService {
   static DateTime _parseCreatedAt(dynamic value) =>
       DateTime.tryParse(value?.toString() ?? '') ??
       DateTime.fromMillisecondsSinceEpoch(0);
+
+  /// Produce una timeline stabile anche quando molti utenti scrivono nello
+  /// stesso istante. Il confronto per id rende deterministici i pareggi, poi
+  /// la visita del padre garantisce che una risposta non preceda mai il
+  /// contenuto a cui risponde.
+  static List<_Entry> _orderEntries(List<_Entry> entries) {
+    final sorted = List<_Entry>.of(entries)
+      ..sort((a, b) {
+        final byTime = a.createdAt.compareTo(b.createdAt);
+        if (byTime != 0) return byTime;
+        return (a.id ?? '').compareTo(b.id ?? '');
+      });
+    final byId = <String, _Entry>{
+      for (final entry in sorted)
+        if (entry.id?.isNotEmpty == true) entry.id!: entry,
+    };
+    final ordered = <_Entry>[];
+    final visiting = <_Entry>{};
+    final visited = <_Entry>{};
+
+    void visit(_Entry entry) {
+      if (visited.contains(entry)) return;
+      if (!visiting.add(entry)) return;
+      final parentId = entry.replyTo;
+      final parent = parentId == null ? null : byId[parentId];
+      if (parent != null) visit(parent);
+      visiting.remove(entry);
+      if (visited.add(entry)) ordered.add(entry);
+    }
+
+    for (final entry in sorted) {
+      visit(entry);
+    }
+    return ordered;
+  }
 
   static List<_Entry> _deduplicateMoonRoots(List<_Entry> entries) {
     final moonSavedRootKeys = entries
@@ -296,6 +330,8 @@ class _Entry {
       : honoo != null
       ? honoo!.type == HonooType.answer
       : hinoo!.type == HinooType.answer;
+
+  String? get replyTo => honoo?.replyTo ?? hinoo?.replyTo;
 
   String get contentKey {
     if (isDeleted) return 'deleted\u001f${id ?? ''}';

--- a/lib/Services/reply_system_notification.dart
+++ b/lib/Services/reply_system_notification.dart
@@ -1,5 +1,6 @@
 import 'reply_system_notification_stub.dart'
-    if (dart.library.html) 'reply_system_notification_web.dart' as platform;
+    if (dart.library.html) 'reply_system_notification_web.dart'
+    as platform;
 
 enum ReplyNotificationPermission { unsupported, prompt, granted, denied }
 
@@ -11,6 +12,8 @@ abstract class ReplySystemNotification {
   ReplyNotificationPermission get permission;
 
   Future<ReplyNotificationPermission> requestPermission();
+
+  void closeConversation(String conversationId) {}
 
   void show({
     required String contentLabel,

--- a/lib/Services/reply_system_notification.dart
+++ b/lib/Services/reply_system_notification.dart
@@ -16,5 +16,6 @@ abstract class ReplySystemNotification {
     required String contentLabel,
     required String conversationId,
     required void Function() onTap,
+    int replyCount = 1,
   });
 }

--- a/lib/Services/reply_system_notification_stub.dart
+++ b/lib/Services/reply_system_notification_stub.dart
@@ -18,5 +18,6 @@ class _UnsupportedReplySystemNotification extends ReplySystemNotification {
     required String contentLabel,
     required String conversationId,
     required void Function() onTap,
+    int replyCount = 1,
   }) {}
 }

--- a/lib/Services/reply_system_notification_web.dart
+++ b/lib/Services/reply_system_notification_web.dart
@@ -11,6 +11,8 @@ ReplySystemNotification createNotification() =>
 class _WebReplySystemNotification extends ReplySystemNotification {
   const _WebReplySystemNotification();
 
+  static final Map<String, web.Notification> _activeNotifications = {};
+
   @override
   ReplyNotificationPermission get permission {
     if (!_isSupported) {
@@ -27,6 +29,11 @@ class _WebReplySystemNotification extends ReplySystemNotification {
   }
 
   @override
+  void closeConversation(String conversationId) {
+    _activeNotifications.remove(conversationId)?.close();
+  }
+
+  @override
   void show({
     required String contentLabel,
     required String conversationId,
@@ -34,9 +41,10 @@ class _WebReplySystemNotification extends ReplySystemNotification {
     int replyCount = 1,
   }) {
     if (permission != ReplyNotificationPermission.granted) return;
-    final body = replyCount == 1
-        ? 'Hai ricevuto una risposta al tuo $contentLabel'
-        : 'Hai ricevuto $replyCount nuove risposte';
+    closeConversation(conversationId);
+    final body = replyCount > 1
+        ? 'Hai ricevuto $replyCount nuove risposte'
+        : 'Hai ricevuto una risposta al tuo $contentLabel';
     final notification = web.Notification(
       'Nuova risposta su honoo',
       web.NotificationOptions(
@@ -45,7 +53,11 @@ class _WebReplySystemNotification extends ReplySystemNotification {
         tag: 'honoo-reply-$conversationId',
       ),
     );
+    _activeNotifications[conversationId] = notification;
     notification.onclick = ((web.Event _) {
+      if (identical(_activeNotifications[conversationId], notification)) {
+        _activeNotifications.remove(conversationId);
+      }
       notification.close();
       onTap();
     }).toJS;

--- a/lib/Services/reply_system_notification_web.dart
+++ b/lib/Services/reply_system_notification_web.dart
@@ -31,12 +31,16 @@ class _WebReplySystemNotification extends ReplySystemNotification {
     required String contentLabel,
     required String conversationId,
     required void Function() onTap,
+    int replyCount = 1,
   }) {
     if (permission != ReplyNotificationPermission.granted) return;
+    final body = replyCount == 1
+        ? 'Hai ricevuto una risposta al tuo $contentLabel'
+        : 'Hai ricevuto $replyCount nuove risposte';
     final notification = web.Notification(
       'Nuova risposta su honoo',
       web.NotificationOptions(
-        body: 'Hai ricevuto una risposta al tuo $contentLabel',
+        body: body,
         icon: 'icons/Icon-192.png',
         tag: 'honoo-reply-$conversationId',
       ),

--- a/lib/UI/hinoo_viewer.dart
+++ b/lib/UI/hinoo_viewer.dart
@@ -27,9 +27,11 @@ class HinooViewer extends StatefulWidget {
     this.onDownloadTap,
     this.isReply = false,
     this.authorId,
+    this.viewerUserId,
   });
   final bool isReply;
   final String? authorId;
+  final String? viewerUserId;
 
   @override
   State<HinooViewer> createState() => _HinooViewerState();
@@ -104,12 +106,13 @@ class _HinooViewerState extends State<HinooViewer> {
     final double displayW = baselineW * scale;
     final double displayH = baselineH * scale;
 
-    final String? currentUserId = SupabaseProvider.client.auth.currentUser?.id;
+    final String? currentUserId =
+        widget.viewerUserId ?? SupabaseProvider.client.auth.currentUser?.id;
     final bool isOwn = (widget.authorId != null && widget.authorId!.isNotEmpty)
         ? (widget.authorId == currentUserId)
         : false;
 
-    return FocusableActionDetector(
+    final viewer = FocusableActionDetector(
       autofocus: true,
       shortcuts: {
         LogicalKeySet(LogicalKeyboardKey.arrowUp): const _ArrowIntent(-1),
@@ -221,6 +224,12 @@ class _HinooViewerState extends State<HinooViewer> {
           ),
         ),
       ),
+    );
+    if (!widget.isReply) return viewer;
+    return Semantics(
+      container: true,
+      label: isOwn ? 'Risposta inviata' : 'Risposta ricevuta',
+      child: viewer,
     );
   }
 

--- a/lib/UI/honoo_card.dart
+++ b/lib/UI/honoo_card.dart
@@ -12,8 +12,14 @@ import '../Widgets/text_box_download_button.dart';
 class HonooCard extends StatelessWidget {
   final Honoo honoo;
   final VoidCallback? onDownloadTap;
+  final String? viewerUserId;
 
-  const HonooCard({super.key, required this.honoo, this.onDownloadTap});
+  const HonooCard({
+    super.key,
+    required this.honoo,
+    this.onDownloadTap,
+    this.viewerUserId,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -195,7 +201,7 @@ class HonooCard extends StatelessWidget {
         );
 
         final String? currentUserId =
-            SupabaseProvider.client.auth.currentUser?.id;
+            viewerUserId ?? SupabaseProvider.client.auth.currentUser?.id;
         final bool isOwn =
             currentUserId != null && currentUserId == honoo.userId;
         // L'unica cornice esterna è quella rossa delle risposte ricevute.
@@ -211,7 +217,17 @@ class HonooCard extends StatelessWidget {
               )
             : content;
 
-        return Center(child: wrapped);
+        return Center(
+          child: isReply
+              ? Semantics(
+                  container: true,
+                  label: showReplyBorder
+                      ? 'Risposta ricevuta'
+                      : 'Risposta inviata',
+                  child: wrapped,
+                )
+              : wrapped,
+        );
       },
     );
   }

--- a/lib/UI/unified_thread_view.dart
+++ b/lib/UI/unified_thread_view.dart
@@ -27,6 +27,7 @@ class UnifiedThreadView extends StatefulWidget {
     this.conversationLoader,
     this.currentUserId,
     this.revealEntryId,
+    this.preferLatestReceived = false,
   });
 
   final String conversationId;
@@ -41,6 +42,7 @@ class UnifiedThreadView extends StatefulWidget {
   conversationLoader;
   final String? currentUserId;
   final String? revealEntryId;
+  final bool preferLatestReceived;
 
   @override
   State<UnifiedThreadView> createState() => _UnifiedThreadViewState();
@@ -283,7 +285,6 @@ class _UnifiedThreadViewState extends State<UnifiedThreadView>
         (e.honoo != null && (e.honoo!.isFromMoonSaved == true));
     if (isMoon) return false;
 
-    // Il bounce accompagna sia le risposte ricevute sia quelle inviate.
     final bool isReply = e.honoo != null
         ? (e.honoo!.type == HonooType.answer)
         : (e.hinoo != null && e.hinoo!.type == HinooType.answer);
@@ -291,6 +292,11 @@ class _UnifiedThreadViewState extends State<UnifiedThreadView>
     final revealEntryId = widget.revealEntryId;
     if (revealEntryId != null && revealEntryId.isNotEmpty) {
       return isReply && e.id == revealEntryId;
+    }
+    if (widget.preferLatestReceived) {
+      final currentUserId =
+          widget.currentUserId ?? Supabase.instance.client.auth.currentUser?.id;
+      if (currentUserId != null && e.ownerId == currentUserId) return false;
     }
     return isReply;
   }

--- a/lib/UI/unified_thread_view.dart
+++ b/lib/UI/unified_thread_view.dart
@@ -56,6 +56,8 @@ class _UnifiedThreadViewState extends State<UnifiedThreadView>
   String? _appliedFocusKey;
   int _currentPageIndex = 0;
   int _loadGeneration = 0;
+  String? _loadInProgressFor;
+  bool _loadRequested = false;
   final PageController _pageController = PageController();
   late AnimationController _controller;
   late Animation<double> _liftAnimation;
@@ -118,6 +120,26 @@ class _UnifiedThreadViewState extends State<UnifiedThreadView>
   }
 
   Future<void> _load() async {
+    final requestedConversationId = widget.conversationId;
+    _loadRequested = true;
+    if (_loadInProgressFor == requestedConversationId) return;
+    _loadInProgressFor = requestedConversationId;
+    try {
+      while (_loadRequested &&
+          mounted &&
+          widget.conversationId == requestedConversationId) {
+        _loadRequested = false;
+        await _performLoad();
+      }
+    } finally {
+      if (_loadInProgressFor == requestedConversationId) {
+        _loadInProgressFor = null;
+        if (_loadRequested && mounted) _load();
+      }
+    }
+  }
+
+  Future<void> _performLoad() async {
     if (!mounted) return;
     final generation = ++_loadGeneration;
     final conversationId = widget.conversationId;
@@ -299,6 +321,7 @@ class _UnifiedThreadViewState extends State<UnifiedThreadView>
           key: repaintKey,
           child: HonooCard(
             honoo: entry.honoo!,
+            viewerUserId: widget.currentUserId,
             onDownloadTap: () => _downloadFromBoundary(
               repaintKey: repaintKey,
               baseName: 'honoo',
@@ -315,6 +338,7 @@ class _UnifiedThreadViewState extends State<UnifiedThreadView>
             maxWidth: widget.maxWidth,
             isReply: entry.hinoo!.type == HinooType.answer,
             authorId: entry.ownerId,
+            viewerUserId: widget.currentUserId,
             onDownloadTap: () => _downloadFromBoundary(
               repaintKey: repaintKey,
               baseName: 'hinoo',

--- a/lib/Widgets/chest_item_view.dart
+++ b/lib/Widgets/chest_item_view.dart
@@ -149,7 +149,10 @@ class ChestItemView extends StatelessWidget {
     maxHeight: availableHeight,
     isActive: isActive,
     onSelect: onSelectConversationEntry,
-    highlightLatest: highlightLatest && focusConversationId == conversationId,
+    highlightLatest:
+        highlightLatest &&
+        (focusConversationId == null || focusConversationId == conversationId),
+    preferLatestReceived: highlightLatest && focusConversationId == null,
     revealEntryId:
         isActive &&
             (focusConversationId == null ||

--- a/lib/Widgets/global_reply_notification_listener.dart
+++ b/lib/Widgets/global_reply_notification_listener.dart
@@ -18,6 +18,7 @@ class GlobalReplyNotificationListener extends StatefulWidget {
     this.enabled = true,
     this.systemNotification,
     this.replyEventStream,
+    this.notificationBatchWindow = const Duration(milliseconds: 180),
   });
 
   final Widget child;
@@ -26,6 +27,8 @@ class GlobalReplyNotificationListener extends StatefulWidget {
   final ReplySystemNotification? systemNotification;
   @visibleForTesting
   final Stream<ReplyNotificationEvent>? replyEventStream;
+  @visibleForTesting
+  final Duration notificationBatchWindow;
 
   @override
   State<GlobalReplyNotificationListener> createState() =>
@@ -40,10 +43,13 @@ class _GlobalReplyNotificationListenerState
   StreamSubscription<ReplyNotificationEvent>? _replyEventSubscription;
   RealtimeChannel? _replyChannel;
   Timer? _reconnectTimer;
+  Timer? _notificationTimer;
   int _reconnectAttempt = 0;
   int _channelGeneration = 0;
   String? _activeUserId;
   final Set<String> _deliveredEventKeys = <String>{};
+  final Map<String, ReplyNotificationEvent> _pendingEvents =
+      <String, ReplyNotificationEvent>{};
 
   @override
   void initState() {
@@ -176,9 +182,23 @@ class _GlobalReplyNotificationListenerState
     final eventKey =
         '${event.recipientId}:${event.kind.name}:${event.replyId ?? event.conversationId}';
     if (!_deliveredEventKeys.add(eventKey)) return;
-    if (_deliveredEventKeys.length > 256) {
+    if (_deliveredEventKeys.length > 4096) {
       _deliveredEventKeys.remove(_deliveredEventKeys.first);
     }
+    _pendingEvents[eventKey] = event;
+    _notificationTimer ??= Timer(
+      widget.notificationBatchWindow,
+      _flushPendingEvents,
+    );
+  }
+
+  void _flushPendingEvents() {
+    _notificationTimer = null;
+    if (!mounted || _pendingEvents.isEmpty) return;
+    final events = _pendingEvents.values.toList(growable: false);
+    _pendingEvents.clear();
+    final event = events.last;
+    final replyCount = events.length;
     ReplyNotificationSignal.notifyChanged();
 
     void open() => _openConversation(event);
@@ -186,6 +206,7 @@ class _GlobalReplyNotificationListenerState
       contentLabel: event.contentLabel,
       conversationId: event.conversationId,
       onTap: open,
+      replyCount: replyCount,
     );
 
     final context = widget.navigatorKey.currentContext;
@@ -196,7 +217,9 @@ class _GlobalReplyNotificationListenerState
       ..showSnackBar(
         SnackBar(
           content: Text(
-            'Hai ricevuto una risposta al tuo ${event.contentLabel}',
+            replyCount == 1
+                ? 'Hai ricevuto una risposta al tuo ${event.contentLabel}'
+                : 'Hai ricevuto $replyCount nuove risposte',
           ),
           action: SnackBarAction(label: 'Apri', onPressed: open),
         ),
@@ -281,6 +304,9 @@ class _GlobalReplyNotificationListenerState
   }
 
   void _stop() {
+    _notificationTimer?.cancel();
+    _notificationTimer = null;
+    _pendingEvents.clear();
     _replyEventSubscription?.cancel();
     _replyEventSubscription = null;
     _authSubscription?.cancel();

--- a/test/chest_ordering_test.dart
+++ b/test/chest_ordering_test.dart
@@ -6,12 +6,14 @@ class _Item {
     required this.id,
     required this.createdAt,
     this.latestReply,
+    this.latestNotification,
     this.conversationId,
   });
 
   final String id;
   final DateTime createdAt;
   final DateTime? latestReply;
+  final DateTime? latestNotification;
   final String? conversationId;
 }
 
@@ -21,6 +23,7 @@ ChestOrganization<_Item> _organize(List<_Item> items) {
     createdAtOf: (item) => item.createdAt,
     stableIdOf: (item) => item.id,
     latestReplyOf: (item) => item.latestReply,
+    latestNotificationOf: (item) => item.latestNotification,
     conversationIdOf: (item) => item.conversationId,
   );
 }
@@ -38,6 +41,7 @@ void main() {
 
       expect(result.items.map((item) => item.id), ['z', 'a', 'b', 'm']);
       expect(result.conversationItemCount, 0);
+      expect(result.latestNotificationItemIndex, -1);
     });
 
     test('mette prima le conversazioni ordinate per ultima risposta', () {
@@ -64,6 +68,7 @@ void main() {
             createdAt: old,
             id: 'conversation',
             latestReply: old.add(const Duration(minutes: 1)),
+            latestNotification: old.add(const Duration(minutes: 1)),
             conversationId: 'conversation-1',
           ),
           _Item(createdAt: recent, id: 'just-saved'),
@@ -73,8 +78,34 @@ void main() {
           'just-saved',
           'conversation',
         ]);
+        expect(result.latestNotificationItemIndex, 1);
       },
     );
+
+    test('seleziona la conversazione dell’ultima notifica ricevuta', () {
+      final base = DateTime(2024, 1, 1, 12);
+      final result = _organize([
+        _Item(
+          createdAt: base,
+          id: 'own-activity',
+          latestReply: base.add(const Duration(minutes: 10)),
+          conversationId: 'conversation-own',
+        ),
+        _Item(
+          createdAt: base,
+          id: 'received-notification',
+          latestReply: base.add(const Duration(minutes: 5)),
+          latestNotification: base.add(const Duration(minutes: 5)),
+          conversationId: 'conversation-received',
+        ),
+      ]);
+
+      expect(result.items.map((item) => item.id), [
+        'own-activity',
+        'received-notification',
+      ]);
+      expect(result.latestNotificationItemIndex, 1);
+    });
 
     test('mostra una sola slide per conversazione usando il più recente', () {
       final t1 = DateTime(2024, 1, 1, 12);

--- a/test/controllers/chest_controller_test.dart
+++ b/test/controllers/chest_controller_test.dart
@@ -137,16 +137,19 @@ void main() {
           'conversation_id': 'conversation-1',
           'reply_to': 'root-1',
           'created_at': '2024-01-01T10:00:00Z',
+          'user_id': 'user-2',
         },
         {
           'conversation_id': 'conversation-1',
           'reply_to': 'reply-1',
           'created_at': '2024-01-01T12:00:00Z',
+          'user_id': 'user-1',
         },
         {
           'conversation_id': 'conversation-1',
           'reply_to': 'reply-1',
           'created_at': '2024-01-01T12:00:00Z',
+          'user_id': 'user-1',
         },
       ],
     );
@@ -178,6 +181,14 @@ void main() {
     );
     expect(
       controller.value.hinooLatestReplies['hinoo-conversation-1'],
+      DateTime.parse('2024-01-01T13:00:00Z'),
+    );
+    expect(
+      controller.value.honooLatestReceivedReplies['conversation-1'],
+      DateTime.parse('2024-01-01T10:00:00Z'),
+    );
+    expect(
+      controller.value.hinooLatestReceivedReplies['hinoo-conversation-1'],
       DateTime.parse('2024-01-01T13:00:00Z'),
     );
     expect(controller.value.isReplyLoading, isFalse);

--- a/test/entities/reply_notification_event_test.dart
+++ b/test/entities/reply_notification_event_test.dart
@@ -72,4 +72,38 @@ void main() {
     expect(parse(payload(recipient: 'someone-else')), isNull);
     expect(parse(payload(event: 'UPDATE')), isNull);
   });
+
+  test('filtra correttamente un flusso misto fra 250 utenti', () {
+    var accepted = 0;
+    for (var i = 0; i < 5000; i++) {
+      final isHonoo = i.isEven;
+      final recipient = i % 250 == 0 ? 'me' : 'user-${i % 250}';
+      final sender = i % 1000 == 0 ? 'me' : 'sender-${i % 400}';
+      final event = ReplyNotificationEvent.fromRealtimePayload(
+        {
+          'eventType': 'INSERT',
+          'new': {
+            'id': 'reply-$i',
+            'destination': isHonoo ? 'reply' : null,
+            'type': isHonoo ? null : 'answer',
+            'reply_to': 'root-$i',
+            'conversation_id': 'conversation-$i',
+            'recipient_tag': recipient,
+            'user_id': sender,
+          },
+        },
+        kind: isHonoo
+            ? ReplyNotificationKind.honoo
+            : ReplyNotificationKind.hinoo,
+        currentUserId: 'me',
+      );
+      if (event != null) {
+        accepted++;
+        expect(event.recipientId, 'me');
+        expect(event.senderId, isNot('me'));
+      }
+    }
+
+    expect(accepted, 15);
+  });
 }

--- a/test/services/conversation_service_test.dart
+++ b/test/services/conversation_service_test.dart
@@ -295,4 +295,96 @@ void main() {
 
     expect(result.map((entry) => entry.id), ['moon-root', 'reply-1']);
   });
+
+  test(
+    'ordina deterministicamente 400 conversazioni concorrenti in tutte le combinazioni',
+    () async {
+      final honoo = harness.stubTable('honoo');
+      final hinoo = harness.stubTable('hinoo');
+      final honooRows = <Map<String, dynamic>>[];
+      final hinooRows = <Map<String, dynamic>>[];
+      const combinations = [
+        ('honoo', 'honoo'),
+        ('honoo', 'hinoo'),
+        ('hinoo', 'honoo'),
+        ('hinoo', 'hinoo'),
+      ];
+
+      Map<String, dynamic> row({
+        required String kind,
+        required String id,
+        required String owner,
+        required bool reply,
+        String? replyTo,
+      }) {
+        final common = <String, dynamic>{
+          'id': id,
+          'user_id': owner,
+          'created_at': '2026-08-05T12:00:00Z',
+          'conversation_id': 'crowded-conversation',
+          'reply_to': replyTo,
+          'recipient_tag': reply ? 'owner-${id.split('-').last}' : null,
+          'is_from_moon_saved': false,
+        };
+        if (kind == 'honoo') {
+          return {
+            ...common,
+            'text': id,
+            'image_url': '',
+            'destination': reply ? 'reply' : 'chest',
+            'updated_at': '2026-08-05T12:00:00Z',
+          };
+        }
+        return {
+          ...common,
+          'type': reply ? 'answer' : 'personal',
+          'pages': <Map<String, dynamic>>[
+            {'text': id, 'backgroundImage': null, 'isTextWhite': true},
+          ],
+        };
+      }
+
+      for (var index = 0; index < 400; index++) {
+        final suffix = index.toString().padLeft(4, '0');
+        final combination = combinations[index % combinations.length];
+        final rootId = 'z-root-$suffix';
+        final replyId = 'a-reply-$suffix';
+        final root = row(
+          kind: combination.$1,
+          id: rootId,
+          owner: 'owner-$suffix',
+          reply: false,
+        );
+        final reply = row(
+          kind: combination.$2,
+          id: replyId,
+          owner: 'sender-$suffix',
+          reply: true,
+          replyTo: rootId,
+        );
+        (combination.$1 == 'honoo' ? honooRows : hinooRows).add(root);
+        (combination.$2 == 'honoo' ? honooRows : hinooRows).add(reply);
+      }
+      honoo.queueResponse(honooRows);
+      hinoo.queueResponse(hinooRows);
+
+      final result = await ConversationService.fetchConversation(
+        'crowded-conversation',
+      );
+      final positions = <String, int>{
+        for (var index = 0; index < result.length; index++)
+          result[index].id!: index,
+      };
+
+      expect(result, hasLength(800));
+      for (var index = 0; index < 400; index++) {
+        final suffix = index.toString().padLeft(4, '0');
+        expect(
+          positions['z-root-$suffix'],
+          lessThan(positions['a-reply-$suffix']!),
+          reason: 'il padre deve precedere la risposta $suffix',
+        );
+      }
+    },
+  );
 }

--- a/test/widgets/conversation_notification_prompt_test.dart
+++ b/test/widgets/conversation_notification_prompt_test.dart
@@ -34,6 +34,7 @@ class _FakeReplyNotification extends ReplySystemNotification {
     required String contentLabel,
     required String conversationId,
     required VoidCallback onTap,
+    int replyCount = 1,
   }) {}
 }
 

--- a/test/widgets/global_reply_notification_listener_test.dart
+++ b/test/widgets/global_reply_notification_listener_test.dart
@@ -16,6 +16,7 @@ class _FakeReplySystemNotification extends ReplySystemNotification {
   String? contentLabel;
   String? conversationId;
   int showCount = 0;
+  int? replyCount;
 
   @override
   ReplyNotificationPermission get permission =>
@@ -29,11 +30,13 @@ class _FakeReplySystemNotification extends ReplySystemNotification {
     required String contentLabel,
     required String conversationId,
     required VoidCallback onTap,
+    int replyCount = 1,
   }) {
     showCount += 1;
     this.contentLabel = contentLabel;
     this.conversationId = conversationId;
     this.onTap = onTap;
+    this.replyCount = replyCount;
   }
 }
 
@@ -86,11 +89,12 @@ void main() {
       );
       events.add(event);
       events.add(event);
-      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 200));
 
       expect(notification.showCount, 1);
       expect(notification.contentLabel, 'hinoo');
       expect(notification.conversationId, 'conversation-42');
+      expect(notification.replyCount, 1);
       expect(notification.onTap, isNotNull);
       expect(
         ReplyNotificationSignal.revision.value,
@@ -109,6 +113,62 @@ void main() {
       final chestPage = tester.widget<ChestPage>(find.byType(ChestPage));
       expect(chestPage.focusConversationId, 'conversation-42');
       expect(chestPage.focusReplyId, 'reply-42');
+
+      await tester.pumpWidget(const SizedBox.shrink());
+    },
+  );
+
+  testWidgets(
+    'un grande burst produce una sola notifica e un solo aggiornamento UI',
+    (tester) async {
+      final navigatorKey = GlobalKey<NavigatorState>();
+      final notification = _FakeReplySystemNotification();
+      final initialRevision = ReplyNotificationSignal.revision.value;
+
+      await tester.pumpWidget(
+        GlobalReplyNotificationListener(
+          navigatorKey: navigatorKey,
+          systemNotification: notification,
+          replyEventStream: events.stream,
+          child: MaterialApp(
+            navigatorKey: navigatorKey,
+            home: const Scaffold(body: Text('Luna')),
+          ),
+        ),
+      );
+
+      for (var i = 0; i < 1000; i++) {
+        events.add(
+          ReplyNotificationEvent(
+            kind: i.isEven
+                ? ReplyNotificationKind.honoo
+                : ReplyNotificationKind.hinoo,
+            conversationId: 'conversation-$i',
+            senderId: 'sender-${i % 200}',
+            recipientId: 'test_user',
+            replyId: 'reply-$i',
+            createdAt: DateTime.utc(
+              2026,
+              8,
+              3,
+              10,
+            ).add(Duration(milliseconds: i)),
+          ),
+        );
+      }
+      await tester.pump(const Duration(milliseconds: 200));
+
+      expect(notification.showCount, 1);
+      expect(notification.replyCount, 1000);
+      expect(notification.conversationId, 'conversation-999');
+      expect(ReplyNotificationSignal.revision.value, initialRevision + 1);
+      expect(find.text('Hai ricevuto 1000 nuove risposte'), findsOneWidget);
+
+      notification.onTap!();
+      await tester.pumpAndSettle();
+      final chestPage = tester.widget<ChestPage>(find.byType(ChestPage));
+      expect(chestPage.focusConversationId, 'conversation-999');
+      expect(chestPage.focusReplyId, 'reply-999');
 
       await tester.pumpWidget(const SizedBox.shrink());
     },

--- a/test/widgets/unified_thread_notification_focus_test.dart
+++ b/test/widgets/unified_thread_notification_focus_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:honoo/Entities/conversation_entry.dart';
+import 'package:honoo/Entities/honoo.dart';
+import 'package:honoo/UI/unified_thread_view.dart';
+
+import '../test_supabase_helper.dart';
+
+void main() {
+  setUpAll(registerSupabaseFallbacks);
+
+  late SupabaseTestHarness harness;
+  setUp(() {
+    harness = SupabaseTestHarness(withAuthenticatedUser: true)
+      ..enableOverrides();
+  });
+  tearDown(() => harness.disableOverrides());
+
+  ConversationEntry reply({
+    required String id,
+    required String owner,
+    required String createdAt,
+  }) {
+    final honoo =
+        Honoo(0, id, '', createdAt, createdAt, owner, HonooType.answer)
+          ..dbId = id
+          ..conversationId = 'conversation-1';
+    return ConversationEntry.honoo(honoo);
+  }
+
+  testWidgets(
+    'dal badge seleziona l’ultima risposta ricevuta, non quella inviata',
+    (tester) async {
+      final received = reply(
+        id: 'received',
+        owner: 'other',
+        createdAt: '2026-07-20T11:00:00Z',
+      );
+      final sent = reply(
+        id: 'sent',
+        owner: 'me',
+        createdAt: '2026-07-20T12:00:00Z',
+      );
+      ConversationEntry? selected;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: UnifiedThreadView(
+              conversationId: 'conversation-1',
+              maxWidth: 600,
+              maxHeight: 700,
+              isActive: true,
+              highlightLatest: true,
+              preferLatestReceived: true,
+              currentUserId: 'me',
+              conversationLoader: (_) async => [received, sent],
+              onSelect: (entry) => selected = entry,
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(selected?.id, 'received');
+    },
+  );
+}

--- a/test/widgets/unified_thread_reveal_test.dart
+++ b/test/widgets/unified_thread_reveal_test.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:honoo/Entities/conversation_entry.dart';
+import 'package:honoo/Entities/hinoo.dart';
 import 'package:honoo/Entities/honoo.dart';
 import 'package:honoo/UI/unified_thread_view.dart';
 import 'package:honoo/Utility/honoo_colors.dart';
@@ -37,6 +38,25 @@ void main() {
       ..conversationId = 'conversation-1';
     return value;
   }
+
+  ConversationEntry hinoo({
+    required String id,
+    required String text,
+    required String owner,
+    required String createdAt,
+    HinooType type = HinooType.personal,
+    String? replyTo,
+  }) => ConversationEntry.hinoo(
+    HinooDraft(
+      pages: [HinooSlide(backgroundImage: null, text: text, isTextWhite: true)],
+      type: type,
+      replyTo: replyTo,
+      conversationId: 'conversation-1',
+    ),
+    id: id,
+    ownerId: owner,
+    createdAt: DateTime.parse(createdAt),
+  );
 
   Finder borderWithColor(Color color) => find.byWidgetPredicate((widget) {
     final Decoration? decoration = switch (widget) {
@@ -549,5 +569,125 @@ void main() {
 
     expect(find.text('Conversazione nuova'), findsOneWidget);
     expect(find.text('Conversazione vecchia'), findsNothing);
+  });
+
+  for (final combination in const [
+    ('honoo', 'honoo'),
+    ('honoo', 'hinoo'),
+    ('hinoo', 'honoo'),
+    ('hinoo', 'hinoo'),
+  ]) {
+    testWidgets(
+      '${combination.$1} → ${combination.$2} rivela il padre e identifica il destinatario',
+      (tester) async {
+        tester.view.devicePixelRatio = 1;
+        tester.view.physicalSize = const Size(600, 900);
+        addTearDown(tester.view.resetDevicePixelRatio);
+        addTearDown(tester.view.resetPhysicalSize);
+
+        final root = combination.$1 == 'honoo'
+            ? ConversationEntry.honoo(
+                honoo(
+                  id: 'root-cross',
+                  text: 'Contenuto padre',
+                  owner: 'me',
+                  createdAt: '2026-07-20T10:00:00Z',
+                ),
+              )
+            : hinoo(
+                id: 'root-cross',
+                text: 'Contenuto padre',
+                owner: 'me',
+                createdAt: '2026-07-20T10:00:00Z',
+              );
+        final reply = combination.$2 == 'honoo'
+            ? ConversationEntry.honoo(
+                honoo(
+                  id: 'reply-cross',
+                  text: 'Risposta incrociata',
+                  owner: 'other',
+                  createdAt: '2026-07-20T11:00:00Z',
+                  type: HonooType.answer,
+                  replyTo: 'root-cross',
+                ),
+              )
+            : hinoo(
+                id: 'reply-cross',
+                text: 'Risposta incrociata',
+                owner: 'other',
+                createdAt: '2026-07-20T11:00:00Z',
+                type: HinooType.answer,
+                replyTo: 'root-cross',
+              );
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: UnifiedThreadView(
+                conversationId: 'conversation-1',
+                maxWidth: 600,
+                maxHeight: 700,
+                isActive: true,
+                currentUserId: 'me',
+                conversationLoader: (_) async => [root, reply],
+              ),
+            ),
+          ),
+        );
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 350));
+
+        expect(find.text('Risposta incrociata'), findsOneWidget);
+        expect(find.text('Contenuto padre'), findsOneWidget);
+        expect(find.byKey(const Key('reply_reveal_parent')), findsOneWidget);
+        expect(find.bySemanticsLabel('Risposta ricevuta'), findsOneWidget);
+        expect(borderWithColor(HonooColor.secondary), findsWidgets);
+      },
+    );
+  }
+
+  testWidgets('un burst Realtime viene coalesciato in un solo refresh', (
+    tester,
+  ) async {
+    final firstLoad = Completer<List<ConversationEntry>>();
+    var calls = 0;
+    final entry = ConversationEntry.honoo(
+      honoo(
+        id: 'root-burst',
+        text: 'Timeline aggiornata',
+        owner: 'me',
+        createdAt: '2026-07-20T10:00:00Z',
+      ),
+    );
+    Future<List<ConversationEntry>> loader(_) {
+      calls++;
+      return calls == 1 ? firstLoad.future : Future.value([entry]);
+    }
+
+    Widget app(int token) => MaterialApp(
+      home: Scaffold(
+        body: UnifiedThreadView(
+          key: const Key('burst-thread'),
+          conversationId: 'conversation-1',
+          maxWidth: 390,
+          maxHeight: 700,
+          refreshToken: token,
+          conversationLoader: loader,
+        ),
+      ),
+    );
+
+    await tester.pumpWidget(app(0));
+    await tester.pump();
+    for (var token = 1; token <= 100; token++) {
+      await tester.pumpWidget(app(token));
+    }
+    expect(calls, 1);
+
+    firstLoad.complete([entry]);
+    await tester.pumpAndSettle();
+
+    expect(calls, 2);
+    expect(find.text('Timeline aggiornata'), findsOneWidget);
   });
 }

--- a/test/widgets/unified_thread_reveal_test.dart
+++ b/test/widgets/unified_thread_reveal_test.dart
@@ -71,6 +71,10 @@ void main() {
         border.top.width == 6;
   });
 
+  Finder explicitSemanticsLabel(String label) => find.byWidgetPredicate(
+    (widget) => widget is Semantics && widget.properties.label == label,
+  );
+
   testWidgets('il bounce rivela il messaggio padre fino a metà schermo', (
     tester,
   ) async {
@@ -640,8 +644,76 @@ void main() {
         expect(find.text('Risposta incrociata'), findsOneWidget);
         expect(find.text('Contenuto padre'), findsOneWidget);
         expect(find.byKey(const Key('reply_reveal_parent')), findsOneWidget);
-        expect(find.bySemanticsLabel('Risposta ricevuta'), findsOneWidget);
+        expect(explicitSemanticsLabel('Risposta ricevuta'), findsOneWidget);
         expect(borderWithColor(HonooColor.secondary), findsWidgets);
+      },
+    );
+  }
+
+  for (final combination in const [
+    ('honoo', 'honoo'),
+    ('honoo', 'hinoo'),
+    ('hinoo', 'honoo'),
+    ('hinoo', 'hinoo'),
+  ]) {
+    testWidgets(
+      '${combination.$1} → ${combination.$2} identifica la risposta del mittente senza bordo rosso',
+      (tester) async {
+        final root = combination.$1 == 'honoo'
+            ? ConversationEntry.honoo(
+                honoo(
+                  id: 'root-sender',
+                  text: 'Contenuto ricevuto',
+                  owner: 'other',
+                  createdAt: '2026-07-20T10:00:00Z',
+                ),
+              )
+            : hinoo(
+                id: 'root-sender',
+                text: 'Contenuto ricevuto',
+                owner: 'other',
+                createdAt: '2026-07-20T10:00:00Z',
+              );
+        final reply = combination.$2 == 'honoo'
+            ? ConversationEntry.honoo(
+                honoo(
+                  id: 'reply-sender',
+                  text: 'Risposta inviata',
+                  owner: 'me',
+                  createdAt: '2026-07-20T11:00:00Z',
+                  type: HonooType.answer,
+                  replyTo: 'root-sender',
+                ),
+              )
+            : hinoo(
+                id: 'reply-sender',
+                text: 'Risposta inviata',
+                owner: 'me',
+                createdAt: '2026-07-20T11:00:00Z',
+                type: HinooType.answer,
+                replyTo: 'root-sender',
+              );
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: UnifiedThreadView(
+                conversationId: 'conversation-1',
+                maxWidth: 600,
+                maxHeight: 700,
+                isActive: true,
+                currentUserId: 'me',
+                conversationLoader: (_) async => [root, reply],
+              ),
+            ),
+          ),
+        );
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 350));
+
+        expect(explicitSemanticsLabel('Risposta inviata'), findsOneWidget);
+        expect(borderWithColor(HonooColor.secondary), findsNothing);
+        expect(find.byKey(const Key('reply_reveal_parent')), findsOneWidget);
       },
     );
   }


### PR DESCRIPTION
## Cosa cambia

- Accorpa i burst di aggiornamenti Realtime in un solo refresh per conversazione, mantenendo immediato il passaggio a un altro thread.
- Raggruppa entro 180 ms le notifiche ricevute in contemporanea: una sola animazione, una sola SnackBar e una sola notifica di sistema con il conteggio corretto.
- Rende esplicita l'identità del visualizzatore per distinguere stabilmente messaggi inviati e ricevuti nei layout Honoo e Hinoo.
- Ordina deterministicamente messaggi concorrenti e garantisce che ogni risposta segua il proprio padre anche a parità di timestamp.
- Aggiunge test per tutte le combinazioni Honoo/Hinoo, animazioni di reveal, layout mittente/destinatario e carichi fino a 5.000 eventi misti.

## Perché

Gli eventi Realtime ravvicinati potevano avviare caricamenti sovrapposti e sostituire ripetutamente notifiche e SnackBar. Inoltre, il layout dipendeva implicitamente dalla sessione Supabase globale e i timestamp uguali non garantivano un ordine padre-risposta stabile.

## Impatto

Il flusso resta fluido con molti utenti e messaggi misti, evita refresh e animazioni ridondanti, filtra correttamente destinatario e auto-risposte e presenta bordi e semantica coerenti per risposte inviate e ricevute.

## Verifiche

- `fvm flutter analyze`
- Test mirati conversazioni, notifiche e layout: 43 superati.
- Suite completa `fvm flutter test`: superata.
- `git diff --check`
