### PR TITLE
Protect content saved from Moon

### DIFF
--- a/lib/Services/hinoo_service.dart
+++ b/lib/Services/hinoo_service.dart
@@ -101,6 +101,11 @@ class HinooService {
 
   /// Inserisce un record type='moon' se non già presente (dedup su fingerprint)
   static Future<DuplicationResult> duplicateToMoon(HinooDraft draft) async {
+    if (draft.isFromMoonSaved) {
+      throw ArgumentError(
+        'Un hinoo salvato dalla Luna non può essere ripubblicato.',
+      );
+    }
     final userId = _client.auth.currentUser?.id;
     if (userId == null) throw 'Utente non autenticato';
 

--- a/lib/Services/honoo_service.dart
+++ b/lib/Services/honoo_service.dart
@@ -134,6 +134,11 @@ class HonooService {
   /// Duplica un honoo dello scrigno pubblicandolo sulla Luna (nuova INSERT).
   /// Non tocca l'originale in 'chest'.
   static Future<DuplicationResult> duplicateToMoon(Honoo h) async {
+    if (h.isFromMoonSaved) {
+      throw ArgumentError(
+        'Un honoo salvato dalla Luna non può essere ripubblicato.',
+      );
+    }
     final session = _client.auth.currentSession;
     if (session == null) {
       throw Exception('Nessuna sessione attiva');

--- a/lib/UI/honoo_card.dart
+++ b/lib/UI/honoo_card.dart
@@ -198,14 +198,18 @@ class HonooCard extends StatelessWidget {
             SupabaseProvider.client.auth.currentUser?.id;
         final bool isOwn =
             currentUserId != null && currentUserId == honoo.userId;
-        // L'unica cornice esterna è quella rossa delle risposte ricevute.
-        // Gli honoo propri e quelli salvati dalla Luna restano senza cornice.
         final bool showReplyBorder = isReply && !isOwn;
-        final Widget wrapped = showReplyBorder
+        final bool showMoonSavedBorder = honoo.isFromMoonSaved && !isReply;
+        final Widget wrapped = showReplyBorder || showMoonSavedBorder
             ? DecoratedBox(
                 decoration: BoxDecoration(
                   borderRadius: BorderRadius.circular(12),
-                  border: Border.all(color: HonooColor.secondary, width: 6),
+                  border: Border.all(
+                    color: showReplyBorder
+                        ? HonooColor.secondary
+                        : Colors.white,
+                    width: 6,
+                  ),
                 ),
                 child: content,
               )

--- a/lib/Widgets/chest_footer.dart
+++ b/lib/Widgets/chest_footer.dart
@@ -128,7 +128,7 @@ class ChestFooter extends StatelessWidget {
     final isPersonalEntry = entry.kind == ConversationEntryKind.honoo
         ? entry.honoo!.type == HonooType.personal
         : entry.hinoo!.type == HinooType.personal;
-    return isMine && isPersonalEntry ? entry : null;
+    return isMine && isPersonalEntry && !entry.isFromMoonSaved ? entry : null;
   }
 
   void _addHinooActions(

--- a/supabase/migrations/20260805100000_backfill_moon_saved_content.sql
+++ b/supabase/migrations/20260805100000_backfill_moon_saved_content.sql
@@ -1,0 +1,24 @@
+-- Riconosce retroattivamente le copie personali salvate dalla Luna tramite il
+-- collegamento stabile alla riga pubblica originale. Il confronto del contenuto
+-- evita di classificare come salvataggi eventuali radici con id riutilizzati.
+
+update public.honoo as saved
+set is_from_moon_saved = true
+from public.honoo as original
+where saved.destination = 'chest'
+  and coalesce(saved.is_from_moon_saved, false) = false
+  and saved.conversation_id = original.id::text
+  and original.destination = 'moon'
+  and saved.user_id <> original.user_id
+  and saved.text = original.text
+  and coalesce(saved.image_url, '') = coalesce(original.image_url, '');
+
+update public.hinoo as saved
+set is_from_moon_saved = true
+from public.hinoo as original
+where saved.type = 'personal'
+  and coalesce(saved.is_from_moon_saved, false) = false
+  and saved.conversation_id = original.id::text
+  and original.type in ('moon', 'public')
+  and saved.user_id <> original.user_id
+  and saved.pages = original.pages;

--- a/test/services/honoo_service_test.dart
+++ b/test/services/honoo_service_test.dart
@@ -130,4 +130,22 @@ void main() {
     expect(captured['recipient_tag'], 'recipient-1');
     expect(captured['image_url'], isNull);
   });
+
+  test('duplicateToMoon rifiuta un honoo salvato dalla Luna', () async {
+    final honoo = Honoo(
+      1,
+      'testo',
+      '',
+      '2024-01-01T00:00:00Z',
+      '2024-01-01T00:00:00Z',
+      'user-1',
+      HonooType.personal,
+    )..isFromMoonSaved = true;
+
+    await expectLater(
+      HonooService.duplicateToMoon(honoo),
+      throwsArgumentError,
+    );
+    verifyNever(() => client.from('honoo'));
+  });
 }

--- a/test/services/honoo_service_update_duplicate_test.dart
+++ b/test/services/honoo_service_update_duplicate_test.dart
@@ -121,5 +121,15 @@ void main() {
       verify(() => chain.insert(any())).called(1);
       verifyNever(() => chain.select(any()));
     });
+
+    test('rifiuta un hinoo salvato dalla Luna', () async {
+      await expectLater(
+        HinooService.duplicateToMoon(
+          sampleDraft().copyWith(isFromMoonSaved: true),
+        ),
+        throwsArgumentError,
+      );
+      verifyNever(() => client.from('hinoo'));
+    });
   });
 }

--- a/test/widgets/chest_footer_test.dart
+++ b/test/widgets/chest_footer_test.dart
@@ -12,6 +12,7 @@ void main() {
   ChestItem honooItem(
     HonooType type, {
     bool isOnMoon = false,
+    bool isFromMoonSaved = false,
     bool hasReplies = false,
     String? conversationId,
   }) {
@@ -26,12 +27,16 @@ void main() {
             type,
           )
           ..isOnMoon = isOnMoon
+          ..isFromMoonSaved = isFromMoonSaved
           ..hasReplies = hasReplies
           ..conversationId = conversationId;
     return ChestItem.honoo(honoo, DateTime.utc(2026));
   }
 
-  ChestItem hinooItem({bool isOnMoon = false}) => ChestItem.hinoo(
+  ChestItem hinooItem({
+    bool isOnMoon = false,
+    bool isFromMoonSaved = false,
+  }) => ChestItem.hinoo(
     ChestHinooItem(
       id: 'hinoo-1',
       draft: const HinooDraft(
@@ -40,7 +45,7 @@ void main() {
         ],
       ),
       createdAt: DateTime.utc(2026),
-      isFromMoonSaved: false,
+      isFromMoonSaved: isFromMoonSaved,
       ownerId: 'current-user',
       isOnMoon: isOnMoon,
     ),
@@ -183,6 +188,18 @@ void main() {
     expect(find.byTooltip('Cancella'), findsOneWidget);
   });
 
+  testWidgets('Honoo salvato dalla Luna non mostra l’azione Luna', (
+    tester,
+  ) async {
+    await pumpFooter(
+      tester,
+      item: honooItem(HonooType.personal, isFromMoonSaved: true),
+    );
+
+    expect(find.byTooltip('Spedisci sulla Luna'), findsNothing);
+    expect(find.byTooltip('Rispondi'), findsOneWidget);
+  });
+
   testWidgets(
     'la selezione del padre della conversazione mostra una sola azione Luna',
     (tester) async {
@@ -206,6 +223,27 @@ void main() {
     },
   );
 
+  testWidgets(
+    'la selezione di un contenuto salvato dalla Luna non mostra Luna',
+    (tester) async {
+      final item = honooItem(
+        HonooType.personal,
+        isFromMoonSaved: true,
+        conversationId: 'conversation-1',
+      );
+      final selectedEntry = ConversationEntry.honoo(item.honoo!);
+
+      await pumpFooter(
+        tester,
+        item: item,
+        selectedConversationEntry: selectedEntry,
+      );
+
+      expect(find.byTooltip('Spedisci sulla Luna'), findsNothing);
+      expect(find.byTooltip('Rispondi'), findsOneWidget);
+    },
+  );
+
   testWidgets('Hinoo già sulla Luna non mostra una seconda azione Luna', (
     tester,
   ) async {
@@ -213,6 +251,18 @@ void main() {
 
     expect(find.byTooltip('Spedisci sulla Luna'), findsNothing);
     expect(find.byTooltip('Cancella'), findsOneWidget);
+  });
+
+  testWidgets('Hinoo salvato dalla Luna non mostra l’azione Luna', (
+    tester,
+  ) async {
+    await pumpFooter(
+      tester,
+      item: hinooItem(isFromMoonSaved: true),
+    );
+
+    expect(find.byTooltip('Spedisci sulla Luna'), findsNothing);
+    expect(find.byTooltip('Rispondi'), findsOneWidget);
   });
 
   testWidgets('contenuto ricevuto mostra solo Home, Info e Cancella', (

--- a/test/widgets/conversation_border_test.dart
+++ b/test/widgets/conversation_border_test.dart
@@ -128,13 +128,13 @@ void main() {
     expect(borderWithColor(Colors.white), findsNothing);
   });
 
-  testWidgets('Honoo salvato dalla Luna non ha cornice', (tester) async {
+  testWidgets('Honoo salvato dalla Luna ha solo cornice bianca', (tester) async {
     await pumpHonoo(
       tester,
       honoo(type: HonooType.personal, owner: 'test_user', fromMoon: true),
     );
 
-    expect(borderWithColor(Colors.white), findsNothing);
+    expect(borderWithColor(Colors.white), findsWidgets);
     expect(borderWithColor(HonooColor.secondary), findsNothing);
   });
 


### PR DESCRIPTION
## Cosa cambia

- aggiunge la cornice bianca agli Honoo salvati dalla Luna, anche per i contenuti già esistenti
- nasconde l'azione Luna nel menu inferiore quando il contenuto selezionato proviene dalla Luna
- impedisce anche a livello di servizio di ripubblicare sulla Luna contenuti altrui salvati dalla Luna
- include una migrazione retroattiva per marcare correttamente Honoo e Hinoo già salvati

## Motivo

Il rendering degli Honoo non applicava la cornice ai contenuti salvati dalla Luna e il percorso del menu relativo alla conversazione selezionata non verificava `isFromMoonSaved`.

## Verifiche

- 25 test mirati superati
- `flutter analyze --no-pub`: nessun problema