### PR TITLE
Fix Moon backfill Hinoo type

### DIFF
--- a/supabase/migrations/20260805100000_backfill_moon_saved_content.sql
+++ b/supabase/migrations/20260805100000_backfill_moon_saved_content.sql
@@ -19,6 +19,6 @@ from public.hinoo as original
 where saved.type = 'personal'
   and coalesce(saved.is_from_moon_saved, false) = false
   and saved.conversation_id = original.id::text
-  and original.type in ('moon', 'public')
+  and original.type = 'moon'
   and saved.user_id <> original.user_id
   and saved.pages = original.pages;


### PR DESCRIPTION
## Correzione

La migrazione retroattiva confrontava `hinoo.type` anche con `public`, valore non presente nell'enum `hinoo_type`.

Il filtro ora seleziona esclusivamente `moon`, che è il tipo effettivo dei contenuti Hinoo pubblicati sulla Luna.

## Verifica

- `./tool/check_supabase_migrations.sh`
- migrazione non applicata né registrata in produzione nel tentativo precedente