### PR TITLE
Fix conversation notifications and participant visibility

### DIFF
--- a/integration_test/live_conversation_flow_test.dart
+++ b/integration_test/live_conversation_flow_test.dart
@@ -203,10 +203,37 @@ void main() {
           .select('id,created_at,conversation_id')
           .eq('conversation_id', hinooConversationId)
           .order('created_at');
-      expect((secondHonooThread as List).length, 1);
-      expect((secondHinooThread as List).length, 2);
+        expect((secondHonooThread as List).length, 1);
+        expect((secondHinooThread as List).length, 2);
 
-      a.realtime.setAuth(a.auth.currentSession!.accessToken);
+        // Anche il mittente B deve vedere gli stessi thread completi, non solo
+        // le righe create dal proprio account.
+        final senderFirstHonooThread = await b
+            .from('honoo')
+            .select('id,created_at,conversation_id')
+            .eq('conversation_id', honooConversationId)
+            .order('created_at');
+        final senderFirstHinooThread = await b
+            .from('hinoo')
+            .select('id,created_at,conversation_id')
+            .eq('conversation_id', honooConversationId)
+            .order('created_at');
+        final senderSecondHonooThread = await b
+            .from('honoo')
+            .select('id,created_at,conversation_id')
+            .eq('conversation_id', hinooConversationId)
+            .order('created_at');
+        final senderSecondHinooThread = await b
+            .from('hinoo')
+            .select('id,created_at,conversation_id')
+            .eq('conversation_id', hinooConversationId)
+            .order('created_at');
+        expect((senderFirstHonooThread as List).length, 2);
+        expect((senderFirstHinooThread as List).length, 1);
+        expect((senderSecondHonooThread as List).length, 1);
+        expect((senderSecondHinooThread as List).length, 2);
+
+        a.realtime.setAuth(a.auth.currentSession!.accessToken);
       var realtimeInsert = Completer<void>();
       final realtimeDelete = Completer<void>();
       var subscribed = Completer<void>();

--- a/lib/Pages/chest_page.dart
+++ b/lib/Pages/chest_page.dart
@@ -144,7 +144,11 @@ class _ChestPageState extends State<ChestPage> with WidgetsBindingObserver {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
       unawaited(
-        RepliesSeenTracker.markAt(entry.createdAt, userId: currentUserId),
+        RepliesSeenTracker.markAt(
+          entry.createdAt,
+          userId: currentUserId,
+          conversationId: conversationId,
+        ),
       );
     });
   }

--- a/lib/Services/home_service.dart
+++ b/lib/Services/home_service.dart
@@ -9,16 +9,16 @@ class HomeService {
 
   Future<int> fetchUnreadReplyCount(String userId) async {
     return policy.read(() async {
-      final lastSeen = await RepliesSeenTracker.lastSeen(userId: userId);
+      final seenState = await RepliesSeenTracker.load(userId: userId);
       final honooRows = await SupabaseProvider.client
           .from('honoo')
-          .select('created_at,user_id')
+          .select('created_at,user_id,conversation_id')
           .eq('destination', 'reply')
           .eq('recipient_tag', userId)
           .neq('user_id', userId);
       final hinooRows = await SupabaseProvider.client
           .from('hinoo')
-          .select('created_at,user_id')
+          .select('created_at,user_id,conversation_id')
           .eq('type', 'answer')
           .eq('recipient_tag', userId)
           .neq('user_id', userId);
@@ -28,8 +28,12 @@ class HomeService {
         final createdAt = DateTime.tryParse(
           (row['created_at'] ?? '').toString(),
         );
+        final conversationId = (row['conversation_id'] ?? '').toString();
         if (createdAt != null &&
-            (lastSeen == null || createdAt.isAfter(lastSeen))) {
+            !seenState.isSeen(
+              conversationId: conversationId,
+              createdAt: createdAt,
+            )) {
           count++;
         }
       }

--- a/lib/Services/reply_system_notification_web.dart
+++ b/lib/Services/reply_system_notification_web.dart
@@ -44,7 +44,7 @@ class _WebReplySystemNotification extends ReplySystemNotification {
     closeConversation(conversationId);
     final body = replyCount > 1
         ? 'Hai ricevuto $replyCount nuove risposte'
-        : 'Hai ricevuto una risposta al tuo $contentLabel';
+        : 'Hai ricevuto una nuova risposta';
     final notification = web.Notification(
       'Nuova risposta su honoo',
       web.NotificationOptions(

--- a/lib/Utility/replies_seen_tracker.dart
+++ b/lib/Utility/replies_seen_tracker.dart
@@ -1,13 +1,49 @@
+import 'dart:convert';
+
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'reply_notification_signal.dart';
 
 class RepliesSeenTracker {
   static const _key = 'last_seen_reply_at_v1';
+  static const _conversationKey = 'last_seen_reply_by_conversation_v1';
 
   static String _keyFor(String? userId) {
     final normalized = userId?.trim() ?? '';
     return normalized.isEmpty ? _key : '${_key}_$normalized';
+  }
+
+  static String _conversationKeyFor(String? userId) {
+    final normalized = userId?.trim() ?? '';
+    return normalized.isEmpty
+        ? _conversationKey
+        : '${_conversationKey}_$normalized';
+  }
+
+  static Future<ReplySeenState> load({String? userId}) async {
+    final prefs = await SharedPreferences.getInstance();
+    final baseline = DateTime.tryParse(prefs.getString(_keyFor(userId)) ?? '');
+    final encoded = prefs.getString(_conversationKeyFor(userId));
+    final byConversation = <String, DateTime>{};
+    if (encoded != null && encoded.isNotEmpty) {
+      try {
+        final decoded = jsonDecode(encoded);
+        if (decoded is Map) {
+          for (final entry in decoded.entries) {
+            final parsed = DateTime.tryParse(entry.value.toString());
+            if (parsed != null && entry.key.toString().isNotEmpty) {
+              byConversation[entry.key.toString()] = parsed;
+            }
+          }
+        }
+      } catch (_) {
+        // Una preferenza corrotta non deve impedire il caricamento dello Scrigno.
+      }
+    }
+    return ReplySeenState(
+      baseline: baseline,
+      byConversation: Map.unmodifiable(byConversation),
+    );
   }
 
   static Future<DateTime?> lastSeen({String? userId}) async {
@@ -26,12 +62,44 @@ class RepliesSeenTracker {
     ReplyNotificationSignal.notifyChanged();
   }
 
-  static Future<void> markAt(DateTime dt, {String? userId}) async {
+  static Future<void> markAt(
+    DateTime dt, {
+    String? userId,
+    String? conversationId,
+  }) async {
+    final normalizedConversation = conversationId?.trim() ?? '';
+    if (normalizedConversation.isNotEmpty) {
+      final prefs = await SharedPreferences.getInstance();
+      final state = await load(userId: userId);
+      final current = state.byConversation[normalizedConversation];
+      if (current != null && !dt.isAfter(current)) return;
+      final updated = <String, String>{
+        for (final entry in state.byConversation.entries)
+          entry.key: entry.value.toUtc().toIso8601String(),
+        normalizedConversation: dt.toUtc().toIso8601String(),
+      };
+      await prefs.setString(_conversationKeyFor(userId), jsonEncode(updated));
+      ReplyNotificationSignal.notifyChanged();
+      return;
+    }
+
     final prefs = await SharedPreferences.getInstance();
     final key = _keyFor(userId);
     final current = DateTime.tryParse(prefs.getString(key) ?? '');
     if (current != null && !dt.isAfter(current)) return;
     await prefs.setString(key, dt.toUtc().toIso8601String());
     ReplyNotificationSignal.notifyChanged();
+  }
+}
+
+class ReplySeenState {
+  const ReplySeenState({required this.baseline, required this.byConversation});
+
+  final DateTime? baseline;
+  final Map<String, DateTime> byConversation;
+
+  bool isSeen({required String conversationId, required DateTime createdAt}) {
+    final threshold = byConversation[conversationId] ?? baseline;
+    return threshold != null && !createdAt.isAfter(threshold);
   }
 }

--- a/lib/Widgets/global_reply_notification_listener.dart
+++ b/lib/Widgets/global_reply_notification_listener.dart
@@ -199,12 +199,18 @@ class _GlobalReplyNotificationListenerState
     _pendingEvents.clear();
     final event = events.last;
     final replyCount = events.length;
+    final conversationIds = events.map((item) => item.conversationId).toSet();
+    final hasMultipleConversations = conversationIds.length > 1;
     ReplyNotificationSignal.notifyChanged();
 
-    void open() => _openConversation(event);
+    void open() => hasMultipleConversations
+        ? _openRepliesInbox()
+        : _openConversation(event);
     _systemNotification.show(
       contentLabel: event.contentLabel,
-      conversationId: event.conversationId,
+      conversationId: hasMultipleConversations
+          ? 'multiple-conversations'
+          : event.conversationId,
       onTap: open,
       replyCount: replyCount,
     );
@@ -218,7 +224,7 @@ class _GlobalReplyNotificationListenerState
         SnackBar(
           content: Text(
             replyCount == 1
-                ? 'Hai ricevuto una risposta al tuo ${event.contentLabel}'
+                ? 'Hai ricevuto una nuova risposta'
                 : 'Hai ricevuto $replyCount nuove risposte',
           ),
           action: SnackBarAction(label: 'Apri', onPressed: open),
@@ -227,31 +233,33 @@ class _GlobalReplyNotificationListenerState
   }
 
   Future<void> _catchUpMissedReplies(String userId, int generation) async {
-    final lastSeen = await RepliesSeenTracker.lastSeen(userId: userId);
-    if (!mounted || generation != _channelGeneration || lastSeen == null) {
+    final seenState = await RepliesSeenTracker.load(userId: userId);
+    if (!mounted || generation != _channelGeneration) {
       return;
     }
     try {
-      final since = lastSeen.toUtc().toIso8601String();
+      final since = seenState.baseline?.toUtc().toIso8601String();
+      dynamic honooQuery = SupabaseProvider.client
+          .from('honoo')
+          .select(
+            'id,destination,reply_to,recipient_tag,created_at,user_id,conversation_id',
+          )
+          .eq('destination', 'reply')
+          .eq('recipient_tag', userId);
+      dynamic hinooQuery = SupabaseProvider.client
+          .from('hinoo')
+          .select(
+            'id,type,reply_to,recipient_tag,created_at,user_id,conversation_id',
+          )
+          .eq('type', 'answer')
+          .eq('recipient_tag', userId);
+      if (since != null) {
+        honooQuery = honooQuery.gt('created_at', since);
+        hinooQuery = hinooQuery.gt('created_at', since);
+      }
       final results = await Future.wait<dynamic>([
-        SupabaseProvider.client
-            .from('honoo')
-            .select(
-              'id,destination,reply_to,recipient_tag,created_at,user_id,conversation_id',
-            )
-            .eq('destination', 'reply')
-            .eq('recipient_tag', userId)
-            .gt('created_at', since)
-            .order('created_at'),
-        SupabaseProvider.client
-            .from('hinoo')
-            .select(
-              'id,type,reply_to,recipient_tag,created_at,user_id,conversation_id',
-            )
-            .eq('type', 'answer')
-            .eq('recipient_tag', userId)
-            .gt('created_at', since)
-            .order('created_at'),
+        honooQuery.order('created_at', ascending: false).limit(100),
+        hinooQuery.order('created_at', ascending: false).limit(100),
       ]);
       if (!mounted || generation != _channelGeneration) return;
       final pending = <ReplyNotificationEvent>[];
@@ -265,7 +273,15 @@ class _GlobalReplyNotificationListenerState
             kind: kind,
             currentUserId: userId,
           );
-          if (event != null) pending.add(event);
+          final createdAt = event?.createdAt;
+          if (event != null &&
+              createdAt != null &&
+              !seenState.isSeen(
+                conversationId: event.conversationId,
+                createdAt: createdAt,
+              )) {
+            pending.add(event);
+          }
         }
       }
       pending.sort(
@@ -289,6 +305,15 @@ class _GlobalReplyNotificationListenerState
           focusReplyId: event.replyId,
           highlightLatest: true,
         ),
+      ),
+    );
+  }
+
+  void _openRepliesInbox() {
+    widget.navigatorKey.currentState?.push(
+      MaterialPageRoute(
+        builder: (_) =>
+            const ChestPage(focusReplies: true, highlightLatest: true),
       ),
     );
   }

--- a/supabase/migrations/20260805120000_restore_conversation_participant_visibility.sql
+++ b/supabase/migrations/20260805120000_restore_conversation_participant_visibility.sql
@@ -1,0 +1,63 @@
+-- Reinstalla esplicitamente la visibilità dell'intero filo per entrambi i
+-- partecipanti. Alcuni ambienti avevano avanzato il registro migrazioni senza
+-- avere le policy introdotte in 20260804150000, lasciando il mittente capace di
+-- leggere soltanto le proprie risposte.
+create or replace function public.is_conversation_participant(
+  target_conversation_id text
+)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public, pg_temp
+as $$
+  select exists (
+    select 1
+    from public.honoo h
+    where h.conversation_id = target_conversation_id
+      and (
+        h.user_id = auth.uid()
+        or h.recipient_tag = auth.uid()::text
+        or h.recipient_tag in (
+          select u.address
+          from public.users u
+          where u.auth_user_id = auth.uid()
+        )
+      )
+    union all
+    select 1
+    from public.hinoo x
+    where x.conversation_id = target_conversation_id
+      and (
+        x.user_id = auth.uid()
+        or x.recipient_tag = auth.uid()::text
+        or x.recipient_tag in (
+          select u.address
+          from public.users u
+          where u.auth_user_id = auth.uid()
+        )
+      )
+  );
+$$;
+
+revoke all on function public.is_conversation_participant(text) from public;
+grant execute on function public.is_conversation_participant(text)
+  to authenticated;
+
+drop policy if exists "conversation participants read honoo"
+  on public.honoo;
+create policy "conversation participants read honoo"
+  on public.honoo
+  as permissive
+  for select
+  to authenticated
+  using (public.is_conversation_participant(conversation_id));
+
+drop policy if exists "conversation participants read hinoo"
+  on public.hinoo;
+create policy "conversation participants read hinoo"
+  on public.hinoo
+  as permissive
+  for select
+  to authenticated
+  using (public.is_conversation_participant(conversation_id));

--- a/test/services/home_service_test.dart
+++ b/test/services/home_service_test.dart
@@ -1,0 +1,74 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:honoo/Services/home_service.dart';
+import 'package:honoo/Utility/replies_seen_tracker.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../test_supabase_helper.dart';
+
+void main() {
+  setUpAll(registerSupabaseFallbacks);
+
+  late SupabaseTestHarness harness;
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    harness = SupabaseTestHarness(withAuthenticatedUser: true)
+      ..enableOverrides();
+  });
+
+  tearDown(() => harness.disableOverrides());
+
+  test('conta le risposte non lette separatamente per conversazione', () async {
+    final honoo = harness.stubTable('honoo');
+    final hinoo = harness.stubTable('hinoo');
+    honoo.queueResponse(<Map<String, dynamic>>[
+      {
+        'created_at': '2026-08-03T11:00:00Z',
+        'user_id': 'sender-1',
+        'conversation_id': 'conversation-opened',
+      },
+      {
+        'created_at': '2026-08-03T11:00:00Z',
+        'user_id': 'sender-2',
+        'conversation_id': 'conversation-unopened',
+      },
+    ]);
+    hinoo.queueResponse(<Map<String, dynamic>>[]);
+    await RepliesSeenTracker.markAt(
+      DateTime.parse('2026-08-03T09:00:00Z'),
+      userId: 'test_user',
+    );
+    await RepliesSeenTracker.markAt(
+      DateTime.parse('2026-08-03T12:00:00Z'),
+      userId: 'test_user',
+      conversationId: 'conversation-opened',
+    );
+
+    final count = await const HomeService().fetchUnreadReplyCount('test_user');
+
+    expect(count, 1);
+  });
+
+  test('al primo utilizzo considera non lette tutte le risposte', () async {
+    final honoo = harness.stubTable('honoo');
+    final hinoo = harness.stubTable('hinoo');
+    honoo.queueResponse(<Map<String, dynamic>>[
+      {
+        'created_at': '2026-08-03T11:00:00Z',
+        'user_id': 'sender-1',
+        'conversation_id': 'conversation-1',
+      },
+    ]);
+    hinoo.queueResponse(<Map<String, dynamic>>[
+      {
+        'created_at': '2026-08-03T12:00:00Z',
+        'user_id': 'sender-2',
+        'conversation_id': 'conversation-2',
+      },
+    ]);
+
+    final count = await const HomeService().fetchUnreadReplyCount('test_user');
+
+    expect(count, 2);
+  });
+}

--- a/test/test_supabase_helper.dart
+++ b/test/test_supabase_helper.dart
@@ -94,6 +94,8 @@ class SupabaseTestHarness {
     when(() => chain.select(any())).thenAnswer((_) => chain);
     when(() => chain.insert(any())).thenAnswer((_) => chain);
     when(() => chain.eq(any(), any())).thenAnswer((_) => chain);
+    when(() => chain.neq(any(), any())).thenAnswer((_) => chain);
+    when(() => chain.gt(any(), any())).thenAnswer((_) => chain);
     when(() => chain.order(any(), ascending: any(named: 'ascending')))
         .thenAnswer((_) => chain);
     when(() => chain.limit(any())).thenAnswer((_) => chain);

--- a/test/utility/replies_seen_tracker_test.dart
+++ b/test/utility/replies_seen_tracker_test.dart
@@ -25,4 +25,42 @@ void main() {
 
     expect(await RepliesSeenTracker.lastSeen(userId: 'user-1'), newest);
   });
+
+  test('mantiene lo stato letto separato per ogni conversazione', () async {
+    final baseline = DateTime.parse('2026-08-03T09:00:00Z');
+    final openedAt = DateTime.parse('2026-08-03T12:00:00Z');
+    await RepliesSeenTracker.markAt(baseline, userId: 'user-1');
+
+    await RepliesSeenTracker.markAt(
+      openedAt,
+      userId: 'user-1',
+      conversationId: 'conversation-new',
+    );
+
+    final state = await RepliesSeenTracker.load(userId: 'user-1');
+    expect(
+      state.isSeen(
+        conversationId: 'conversation-new',
+        createdAt: DateTime.parse('2026-08-03T11:00:00Z'),
+      ),
+      isTrue,
+    );
+    expect(
+      state.isSeen(
+        conversationId: 'conversation-unopened',
+        createdAt: DateTime.parse('2026-08-03T11:00:00Z'),
+      ),
+      isFalse,
+    );
+  });
+
+  test('ignora una preferenza per conversazione non valida', () async {
+    SharedPreferences.setMockInitialValues({
+      'last_seen_reply_by_conversation_v1_user-1': '{not-json',
+    });
+
+    final state = await RepliesSeenTracker.load(userId: 'user-1');
+
+    expect(state.byConversation, isEmpty);
+  });
 }

--- a/test/widgets/global_reply_notification_listener_test.dart
+++ b/test/widgets/global_reply_notification_listener_test.dart
@@ -100,10 +100,7 @@ void main() {
         ReplyNotificationSignal.revision.value,
         greaterThan(initialRevision),
       );
-      expect(
-        find.text('Hai ricevuto una risposta al tuo hinoo'),
-        findsOneWidget,
-      );
+      expect(find.text('Hai ricevuto una nuova risposta'), findsOneWidget);
 
       notification.onTap!();
       await tester.pumpAndSettle();
@@ -160,15 +157,15 @@ void main() {
 
       expect(notification.showCount, 1);
       expect(notification.replyCount, 1000);
-      expect(notification.conversationId, 'conversation-999');
+      expect(notification.conversationId, 'multiple-conversations');
       expect(ReplyNotificationSignal.revision.value, initialRevision + 1);
       expect(find.text('Hai ricevuto 1000 nuove risposte'), findsOneWidget);
 
       notification.onTap!();
       await tester.pumpAndSettle();
       final chestPage = tester.widget<ChestPage>(find.byType(ChestPage));
-      expect(chestPage.focusConversationId, 'conversation-999');
-      expect(chestPage.focusReplyId, 'reply-999');
+      expect(chestPage.focusConversationId, isNull);
+      expect(chestPage.focusReplyId, isNull);
 
       await tester.pumpWidget(const SizedBox.shrink());
     },

--- a/test/widgets/unified_thread_reveal_test.dart
+++ b/test/widgets/unified_thread_reveal_test.dart
@@ -407,7 +407,7 @@ void main() {
   });
 
   testWidgets(
-    'il bounce resta attivo senza bordi sulla risposta propria e sul padre Luna',
+    'il bounce conserva la cornice bianca sul padre Luna e nessuna rossa sulla risposta propria',
     (tester) async {
       tester.view.devicePixelRatio = 1;
       tester.view.physicalSize = const Size(600, 900);
@@ -452,7 +452,13 @@ void main() {
       await tester.pump(const Duration(milliseconds: 600));
 
       expect(find.byKey(const Key('reply_reveal_parent')), findsOneWidget);
-      expect(borderWithColor(Colors.white), findsNothing);
+      expect(
+        find.descendant(
+          of: find.byKey(const Key('reply_reveal_parent')),
+          matching: borderWithColor(Colors.white),
+        ),
+        findsOneWidget,
+      );
       expect(borderWithColor(HonooColor.secondary), findsNothing);
     },
   );


### PR DESCRIPTION
## Sintesi

- conserva lo stato letto separatamente per ogni conversazione, senza nascondere notifiche appartenenti ad altri thread
- apre la conversazione corretta quando il batch riguarda un solo thread e l'elenco Risposte quando coinvolge più conversazioni
- rende neutro il testo delle notifiche miste Honoo/Hinoo e recupera le risposte perse anche al primo avvio
- ripristina con una migrazione idempotente la visibilità RLS dell'intero thread per entrambi i partecipanti
- estende il test live verificando gli stessi contenuti dal punto di vista di mittente e destinatario

## Verifiche

- `flutter analyze` — superato
- test mirati notifiche/stato letto/HomeService — 8 superati
- test mirati bounce e cornici — 26 superati
- suite completa — 281 superati, 7 saltati perché richiedono configurazione live
- live conversation E2E — la nuova asserzione simmetrica rileva correttamente la policy mancante in staging; diventerà verificabile dopo l'applicazione della migrazione inclusa

## Deploy

Questa PR contiene una migrazione Supabase. Applicarla prima o insieme al deploy web, poi rieseguire il live conversation E2E.
