### PR TITLE
Fix received reply full-screen honoo red

### DIFF
--- a/lib/UI/honoo_card.dart
+++ b/lib/UI/honoo_card.dart
@@ -5,6 +5,7 @@ import 'package:google_fonts/google_fonts.dart';
 
 import '../Entities/honoo.dart';
 import 'package:honoo/Services/supabase_provider.dart';
+import '../Utility/chest_content_style.dart';
 import '../Utility/honoo_colors.dart';
 import '../Widgets/smooth_image.dart';
 import '../Widgets/text_box_download_button.dart';
@@ -24,19 +25,23 @@ class HonooCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final media = MediaQuery.of(context);
-
-    Color cardBg;
-    switch (honoo.type) {
-      case HonooType.moon:
-        cardBg = HonooColor.tertiary;
-        break;
-      case HonooType.answer:
-        cardBg = HonooColor.secondary;
-        break;
-      case HonooType.personal:
-        cardBg = HonooColor.background;
-        break;
-    }
+    final String? currentUserId =
+        viewerUserId ?? SupabaseProvider.client.auth.currentUser?.id;
+    final contentStyle = ChestContentStyle.forHonoo(
+      honoo,
+      viewerUserId: currentUserId,
+    );
+    final Color cardBg = contentStyle.backgroundColor;
+    final bool isReceivedReply = identical(
+      contentStyle,
+      ChestContentStyle.receivedReply,
+    );
+    final Color textPanelColor = isReceivedReply
+        ? HonooColor.secondary
+        : HonooColor.tertiary;
+    final Color textColor = isReceivedReply
+        ? Colors.white
+        : HonooColor.onTertiary;
 
     return LayoutBuilder(
       builder: (context, constraints) {
@@ -67,9 +72,7 @@ class HonooCard extends StatelessWidget {
 
         const double cornerRadius = 5;
 
-        final Color gapColor = honoo.type == HonooType.moon
-            ? HonooColor.tertiary
-            : cardBg;
+        final Color gapColor = cardBg;
 
         final Widget content = Card(
           color: cardBg,
@@ -92,16 +95,20 @@ class HonooCard extends StatelessWidget {
                   child: Container(
                     padding: const EdgeInsets.all(8),
                     decoration: BoxDecoration(
-                      color: HonooColor.tertiary,
-                      border: Border.all(color: Colors.black12),
+                      color: textPanelColor,
+                      border: isReceivedReply
+                          ? null
+                          : Border.all(color: Colors.black12),
                       borderRadius: BorderRadius.circular(cornerRadius),
-                      boxShadow: [
-                        BoxShadow(
-                          color: Colors.black.withValues(alpha: 0.05),
-                          blurRadius: 4,
-                          offset: const Offset(0, 2),
-                        ),
-                      ],
+                      boxShadow: isReceivedReply
+                          ? null
+                          : [
+                              BoxShadow(
+                                color: Colors.black.withValues(alpha: 0.05),
+                                blurRadius: 4,
+                                offset: const Offset(0, 2),
+                              ),
+                            ],
                     ),
                     child: Stack(
                       children: [
@@ -110,7 +117,7 @@ class HonooCard extends StatelessWidget {
                             honoo.text,
                             textAlign: TextAlign.center,
                             style: GoogleFonts.arvo(
-                              color: HonooColor.onTertiary,
+                              color: textColor,
                               fontSize: 18,
                               height: 1.4,
                               fontWeight: FontWeight.w400,
@@ -199,8 +206,6 @@ class HonooCard extends StatelessWidget {
         );
 
         final bool isReply = honoo.type == HonooType.answer;
-        final String? currentUserId =
-            viewerUserId ?? SupabaseProvider.client.auth.currentUser?.id;
         final bool isOwn =
             currentUserId != null && currentUserId == honoo.userId;
         return Center(

--- a/test/widgets/conversation_border_test.dart
+++ b/test/widgets/conversation_border_test.dart
@@ -39,6 +39,14 @@ void main() {
         border.top.width == 6;
   });
 
+  Finder decoratedPanelWithColor(Color color) =>
+      find.byWidgetPredicate((widget) {
+        if (widget is! Container || widget.decoration is! BoxDecoration) {
+          return false;
+        }
+        return (widget.decoration! as BoxDecoration).color == color;
+      });
+
   Honoo honoo({
     required HonooType type,
     String owner = 'other_user',
@@ -126,6 +134,10 @@ void main() {
       ChestContentStyle.forHonoo(value, viewerUserId: 'test_user'),
       same(ChestContentStyle.own),
     );
+    final ownGap = tester.widget<ColoredBox>(
+      find.byKey(const Key('honoo-card-gap')),
+    );
+    expect(ownGap.color, HonooColor.background);
     expect(borderWithColor(HonooColor.secondary), findsNothing);
     expect(borderWithColor(Colors.white), findsNothing);
   });
@@ -140,6 +152,9 @@ void main() {
       ChestContentStyle.forHonoo(value, viewerUserId: 'test_user'),
       same(ChestContentStyle.receivedReply),
     );
+    expect(decoratedPanelWithColor(HonooColor.secondary), findsOneWidget);
+    final replyText = tester.widget<Text>(find.text('Test conversazione'));
+    expect(replyText.style?.color, Colors.white);
     expect(borderWithColor(HonooColor.secondary), findsNothing);
     expect(borderWithColor(Colors.white), findsNothing);
   });


### PR DESCRIPTION
## Correzione\n- usa lo stile centralizzato dello Scrigno anche dentro la scheda Honoo\n- riempie di rosso honoo il pannello testuale delle risposte ricevute\n- rende bianco il testo della risposta e mantiene bianco il logo honoo tramite lo stile pagina esistente\n- elimina bordo e ombra dal pannello rosso, evitando l'effetto cornice\n- mantiene blu le risposte proprie senza strisce rosse interne\n\n## Verifiche\n- flutter analyze --no-pub\n- flutter test --no-pub test/widgets/conversation_border_test.dart\n- flutter test --no-pub test/widgets/unified_thread_reveal_test.dart test/widgets/thread_layout_scaffold_responsive_test.dart