### PR TITLE
Refine homepage icons and agent credits

### DIFF
--- a/lib/Pages/home_page.dart
+++ b/lib/Pages/home_page.dart
@@ -146,9 +146,9 @@ class _HomeIntro extends StatelessWidget {
   const _HomeIntro();
 
   static const double _designWidth = 360;
-  static const double _bottleIconSize = 39;
-  static const double _moonIconSize = 25;
-  static const double _islandIconSize = 40;
+  static const double _bottleIconSize = 42;
+  static const double _moonIconSize = 28;
+  static const double _islandIconSize = 43;
   static const double _bottleIconVerticalOffset = 9;
   static const double _moonIconVerticalOffset = 1;
   static const double _islandIconVerticalOffset = 10;

--- a/lib/Pages/placeholder_page.dart
+++ b/lib/Pages/placeholder_page.dart
@@ -95,21 +95,27 @@ class _PlaceholderPageState extends State<PlaceholderPage> {
     double topSpacing = 0,
     double bottomSpacing = 0,
     VoidCallback? onTap,
+    Color? color,
+    Key? iconKey,
+    Key? topSpacingKey,
+    Key? bottomSpacingKey,
   }) {
     return [
-      if (topSpacing > 0) SizedBox(height: topSpacing),
+      if (topSpacing > 0) SizedBox(key: topSpacingKey, height: topSpacing),
       GestureDetector(
         onTap: onTap,
         child: SvgPicture.asset(
+          key: iconKey,
           asset,
           height: size,
-          colorFilter: const ColorFilter.mode(
-            HonooColor.onBackground,
+          colorFilter: ColorFilter.mode(
+            color ?? HonooColor.onBackground,
             BlendMode.srcIn,
           ),
         ),
       ),
-      if (bottomSpacing > 0) SizedBox(height: bottomSpacing),
+      if (bottomSpacing > 0)
+        SizedBox(key: bottomSpacingKey, height: bottomSpacing),
     ];
   }
 
@@ -414,9 +420,13 @@ class _PlaceholderPageState extends State<PlaceholderPage> {
       ),
       ..._svgIconBlockWithSpacing(
         'assets/icons/ai.svg',
-        inlineIconHeight,
+        inlineIconHeight - 3,
         topSpacing: _regiaAgentiTopSpacing,
         bottomSpacing: _regiaAgentiBottomSpacing,
+        color: _linkIconColor,
+        iconKey: const Key('regia_agenti_icon'),
+        topSpacingKey: const Key('regia_agenti_icon_top_spacing'),
+        bottomSpacingKey: const Key('regia_agenti_icon_bottom_spacing'),
         onTap: () {
           Navigator.of(
             context,

--- a/lib/Pages/regia_agenti_page.dart
+++ b/lib/Pages/regia_agenti_page.dart
@@ -1,16 +1,23 @@
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:honoo/Utility/honoo_colors.dart';
 import 'package:honoo/Widgets/honoo_standard_page.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 class RegiaAgentiPage extends StatelessWidget {
   const RegiaAgentiPage({super.key});
 
-  static const String regiaAgentiText =
+  static const String alessandroMolinaUrl =
+      'https://www.linkedin.com/authwall?trk=gf&trkInfo=AQEKiDvNCY9k5wAAAZ_TKfSQOVjSt8GjBHYntEjt-HPxCMb7xQr32j-xeaqLUkZnvfqrUpn83qHvXKKKYHIKY1acgmDf7htNSAFpkUS9bOm7DEa8a16eUbCCpTlD4T-EdrqpifM=&original_referer=&sessionRedirect=https%3A%2F%2Fwww.linkedin.com%2Fin%2Falessandro-molina1%3Futm_source%3Dshare_via%26utm_content%3Dprofile%26utm_medium%3Dmember_ios';
+
+  static const String _textBeforeAlessandro =
       '“Regia degli Agenti”\n'
       'non è una mia espressione,\n'
-      'ma del mio amico\n'
-      'Alessandro Molina,\n'
+      'ma del mio amico\n';
+
+  static const String _textAfterAlessandro =
+      ',\n'
       'che è Capo Consigliere\n'
       'di honoo\n'
       'per tutto quello che riguarda\n'
@@ -41,6 +48,9 @@ class RegiaAgentiPage extends StatelessWidget {
       'di scrivere\n'
       'prodotti digitali\n';
 
+  static const String regiaAgentiText =
+      '${_textBeforeAlessandro}Alessandro Molina$_textAfterAlessandro';
+
   @override
   Widget build(BuildContext context) {
     final TextStyle bodyStyle = GoogleFonts.arvo(
@@ -52,10 +62,29 @@ class RegiaAgentiPage extends StatelessWidget {
 
     return HonooStandardPage(
       contentWidthFactor: 0.45,
-      child: Text(
-        regiaAgentiText,
+      child: Text.rich(
+        TextSpan(
+          style: bodyStyle,
+          children: [
+            const TextSpan(text: _textBeforeAlessandro),
+            TextSpan(
+              text: 'Alessandro Molina',
+              style: bodyStyle.copyWith(
+                decoration: TextDecoration.underline,
+                decorationColor: bodyStyle.color,
+              ),
+              recognizer: TapGestureRecognizer()
+                ..onTap = () async {
+                  await launchUrl(
+                    Uri.parse(alessandroMolinaUrl),
+                    mode: LaunchMode.externalApplication,
+                  );
+                },
+            ),
+            const TextSpan(text: _textAfterAlessandro),
+          ],
+        ),
         key: const Key('regia_agenti_text'),
-        style: bodyStyle,
         textAlign: TextAlign.center,
       ),
     );

--- a/test/pages/home_page_layout_test.dart
+++ b/test/pages/home_page_layout_test.dart
@@ -60,9 +60,9 @@ void main() {
     }
 
     for (final entry in const [
-      (Key('home_inline_bottle'), 39.0),
-      (Key('home_inline_moon'), 25.0),
-      (Key('home_inline_island'), 40.0),
+      (Key('home_inline_bottle'), 42.0),
+      (Key('home_inline_moon'), 28.0),
+      (Key('home_inline_island'), 43.0),
     ]) {
       final key = entry.$1;
       final button = tester.widget<IconButton>(find.byKey(key));

--- a/test/pages/regia_agenti_page_test.dart
+++ b/test/pages/regia_agenti_page_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -29,6 +30,24 @@ void main() {
               'assets/icons/ai.svg',
     );
     expect(aiIcon, findsOneWidget);
+    final svg = tester.widget<SvgPicture>(aiIcon);
+    expect(svg.height, 57);
+    expect(
+      svg.colorFilter,
+      const ColorFilter.mode(Color.fromRGBO(183, 183, 206, 1), BlendMode.srcIn),
+    );
+    expect(
+      tester
+          .getSize(find.byKey(const Key('regia_agenti_icon_top_spacing')))
+          .height,
+      5,
+    );
+    expect(
+      tester
+          .getSize(find.byKey(const Key('regia_agenti_icon_bottom_spacing')))
+          .height,
+      30,
+    );
 
     final visibleTexts = tester
         .widgetList<Text>(find.byType(Text))
@@ -57,10 +76,17 @@ void main() {
     final text = tester.widget<Text>(
       find.byKey(const Key('regia_agenti_text')),
     );
-    expect(text.data, RegiaAgentiPage.regiaAgentiText);
+    expect(text.textSpan?.toPlainText(), RegiaAgentiPage.regiaAgentiText);
     expect(text.textAlign, TextAlign.center);
-    expect(text.data, contains('Alessandro Molina'));
-    expect(text.data, contains('Behavior Driven Design'));
-    expect(text.data, contains('Sì,\nstiamo parlando'));
+    expect(text.textSpan?.toPlainText(), contains('Alessandro Molina'));
+    expect(text.textSpan?.toPlainText(), contains('Behavior Driven Design'));
+    expect(text.textSpan?.toPlainText(), contains('Sì,\nstiamo parlando'));
+
+    final rootSpan = text.textSpan! as TextSpan;
+    final alessandroSpan = rootSpan.children!.whereType<TextSpan>().singleWhere(
+      (span) => span.text == 'Alessandro Molina',
+    );
+    expect(alessandroSpan.recognizer, isA<TapGestureRecognizer>());
+    expect(alessandroSpan.style?.decoration, TextDecoration.underline);
   });
 }


### PR DESCRIPTION
## Cosa cambia

- aumenta di 3 punti tutte le icone inline nel testo della homepage, mantenendo il ridimensionamento responsive esistente
- rende l’icona AI della placeholder più piccola di 3 punti rispetto alle altre icone responsive
- applica all’icona AI lo stesso colore di microfono e libro e uniforma gli spazi prima e dopo
- trasforma “Alessandro Molina” in un link esterno al profilo LinkedIn indicato
- aggiorna i test widget per dimensioni, colore, spaziatura e link

## Impatto

La gerarchia visiva risulta uniforme su mobile, tablet e desktop senza modificare la navigazione o gli altri contenuti.

## Verifiche

- `flutter test --no-pub test/pages/home_page_layout_test.dart test/pages/regia_agenti_page_test.dart`
- `flutter analyze --no-pub`
- `git diff --check`