### PR TITLE
Fix reply navigation and Moon Honoo separator

### DIFF
--- a/lib/Controller/chest_organizer.dart
+++ b/lib/Controller/chest_organizer.dart
@@ -10,6 +10,18 @@ class ChestOrganization<T> {
   final int latestNotificationItemIndex;
 }
 
+class ChestNotificationTarget {
+  const ChestNotificationTarget({
+    required this.conversationId,
+    required this.itemIndex,
+  });
+
+  final String conversationId;
+  final int itemIndex;
+
+  bool get isDetached => itemIndex < 0;
+}
+
 /// Regole pure di ordinamento e raggruppamento dello Scrigno.
 class ChestOrganizer {
   const ChestOrganizer._();
@@ -108,5 +120,34 @@ class ChestOrganizer {
       }
     }
     return latestIndex;
+  }
+
+  /// Individua la conversazione dell'ultima risposta ricevuta anche quando
+  /// usa un conversation_id nuovo e quindi non ha ancora una slide radice
+  /// nello Scrigno.
+  static ChestNotificationTarget? latestNotificationTarget<T>({
+    required List<T> items,
+    required String? Function(T item) conversationIdOf,
+    required Iterable<Map<String, DateTime>> notifications,
+  }) {
+    String? latestConversationId;
+    DateTime? latestDate;
+    for (final notificationMap in notifications) {
+      for (final entry in notificationMap.entries) {
+        if (entry.key.isEmpty ||
+            (latestDate != null && !entry.value.isAfter(latestDate))) {
+          continue;
+        }
+        latestConversationId = entry.key;
+        latestDate = entry.value;
+      }
+    }
+    if (latestConversationId == null) return null;
+    return ChestNotificationTarget(
+      conversationId: latestConversationId,
+      itemIndex: items.indexWhere(
+        (item) => conversationIdOf(item) == latestConversationId,
+      ),
+    );
   }
 }

--- a/lib/Pages/casa_builder_page.dart
+++ b/lib/Pages/casa_builder_page.dart
@@ -174,6 +174,9 @@ class _CasaBuilderPageState extends State<CasaBuilderPage> {
         bytes: pngBytes,
         ext: 'png',
         userId: user.id,
+        // Il PNG della casa comprende l'intero canvas e sui collegamenti più
+        // lenti può richiedere più dei 15 secondi usati dagli upload normali.
+        writeTimeout: const Duration(minutes: 1),
       );
       setState(() => _isUploadingImage = false);
 

--- a/lib/Pages/chest_page.dart
+++ b/lib/Pages/chest_page.dart
@@ -85,6 +85,7 @@ class _ChestPageState extends State<ChestPage> with WidgetsBindingObserver {
 
   int _currentIndex = 0;
   bool _didApplyInitialFocus = false;
+  String? _detachedFocusedConversationId;
   bool _initialLoadCompleted = false;
   int _conversationRefreshToken = 0;
   String? _pendingRevealEntryId;
@@ -380,16 +381,30 @@ class _ChestPageState extends State<ChestPage> with WidgetsBindingObserver {
         } else {
           desiredIndex = 0;
         }
-      } else if (widget.focusReplies &&
-          organization.latestNotificationItemIndex >= 0) {
-        desiredIndex = organization.latestNotificationItemIndex;
+      } else if (widget.focusReplies) {
+        final notificationTarget = ChestOrganizer.latestNotificationTarget(
+          items: _itemsNormal,
+          conversationIdOf: _convIdOfItem,
+          notifications: [
+            _honooLatestReceivedReplies,
+            _hinooLatestReceivedReplies,
+          ],
+        );
+        if (notificationTarget != null) {
+          if (notificationTarget.isDetached) {
+            _detachedFocusedConversationId = notificationTarget.conversationId;
+          } else {
+            desiredIndex = notificationTarget.itemIndex;
+          }
+        }
       } else {
         // L'ordinamento è dal più recente: durante il caricamento progressivo
         // non conservare una selezione provvisoria che potrebbe diventare
         // meno recente quando arrivano anche gli altri tipi di contenuto.
         desiredIndex = 0;
       }
-      if (_initialLoadCompleted && _itemsNormal.isNotEmpty) {
+      if (_initialLoadCompleted &&
+          (_itemsNormal.isNotEmpty || _detachedFocusedConversationId != null)) {
         _didApplyInitialFocus = true;
       }
     }
@@ -976,7 +991,8 @@ class _ChestPageState extends State<ChestPage> with WidgetsBindingObserver {
       builder: (context, _) {
         _rebuildItems();
         final items = _itemsNormal;
-        final focusedConversationId = widget.focusConversationId;
+        final focusedConversationId =
+            widget.focusConversationId ?? _detachedFocusedConversationId;
         final focusedItemIndex = focusedConversationId == null
             ? -1
             : items.indexWhere(

--- a/lib/Pages/chest_page.dart
+++ b/lib/Pages/chest_page.dart
@@ -35,6 +35,7 @@ import '../Widgets/chest_item_view.dart';
 import '../Widgets/chest_info_dialog.dart';
 import '../Widgets/desktop_carousel_arrows.dart';
 import '../UI/thread_layout_scaffold.dart';
+import '../UI/unified_thread_view.dart';
 
 import 'reply_honoo_page.dart';
 import 'new_hinoo_page.dart';
@@ -975,7 +976,18 @@ class _ChestPageState extends State<ChestPage> with WidgetsBindingObserver {
       builder: (context, _) {
         _rebuildItems();
         final items = _itemsNormal;
-        final currentItem = items.isEmpty
+        final focusedConversationId = widget.focusConversationId;
+        final focusedItemIndex = focusedConversationId == null
+            ? -1
+            : items.indexWhere(
+                (item) => _convIdOfItem(item) == focusedConversationId,
+              );
+        final showDetachedFocusedConversation =
+            _initialLoadCompleted &&
+            focusedConversationId != null &&
+            focusedConversationId.isNotEmpty &&
+            focusedItemIndex < 0;
+        final currentItem = showDetachedFocusedConversation || items.isEmpty
             ? null
             : items[_currentIndex.clamp(0, items.length - 1)];
         final currentUserId = SupabaseProvider.client.auth.currentUser?.id;
@@ -1011,6 +1023,20 @@ class _ChestPageState extends State<ChestPage> with WidgetsBindingObserver {
             final loadError = _loadError;
             if ((ctrl.isLoading.value || _isHinooLoading) && items.isEmpty) {
               return const Center(child: LoadingSpinner(color: Colors.white));
+            }
+            if (showDetachedFocusedConversation) {
+              return UnifiedThreadView(
+                conversationId: focusedConversationId,
+                maxWidth: viewW,
+                maxHeight: availableH,
+                isActive: true,
+                highlightLatest: widget.highlightLatest,
+                currentUserId: currentUserId,
+                revealEntryId: _pendingRevealEntryId,
+                refreshToken: _conversationRefreshToken,
+                onSelect: (entry) =>
+                    _selectConversationEntry(focusedConversationId, entry),
+              );
             }
             if (items.isEmpty) {
               if (loadError != null) {
@@ -1111,7 +1137,8 @@ class _ChestPageState extends State<ChestPage> with WidgetsBindingObserver {
                 footerBottomSpacing,
               ) {
                 final items = _itemsNormal;
-                final ChestItem? current = items.isEmpty
+                final ChestItem? current =
+                    showDetachedFocusedConversation || items.isEmpty
                     ? null
                     : items[_currentIndex];
                 return _footerForItem(

--- a/lib/Pages/moon_page.dart
+++ b/lib/Pages/moon_page.dart
@@ -39,6 +39,11 @@ class MoonPage extends StatefulWidget {
 
   final String? initialItemId;
 
+  @visibleForTesting
+  static Honoo honooFromMoonRow(Map<String, dynamic> row) {
+    return Honoo.fromMap(row)..type = HonooType.moon;
+  }
+
   @override
   State<MoonPage> createState() => _MoonPageState();
 }
@@ -92,7 +97,7 @@ class _MoonPageState extends State<MoonPage> {
             DateTime.tryParse((row['created_at'] ?? '').toString()) ??
             DateTime.fromMillisecondsSinceEpoch(0);
         if (kind == 'honoo') {
-          final honoo = Honoo.fromMap(row.cast<String, dynamic>());
+          final honoo = MoonPage.honooFromMoonRow(row.cast<String, dynamic>());
           final String? ownerId = row['user_id']?.toString();
           if ((honoo.recipientTag ?? '').isEmpty && ownerId != null) {
             honoo.recipientTag = ownerId;

--- a/lib/Services/hinoo_storage_uploader.dart
+++ b/lib/Services/hinoo_storage_uploader.dart
@@ -61,6 +61,7 @@ class HinooStorageUploader {
     required String filenameExt, // es: "jpg" | "png" | "webp" | "jpeg"
     required String userId,
     String folder = 'backgrounds', // default sicuro
+    Duration? writeTimeout,
   }) async {
     _assertUserId(userId);
     final safeExt = _normalizeExt(filenameExt);
@@ -69,8 +70,13 @@ class HinooStorageUploader {
     final id = _uuid.v4();
     final path = '$userId/$safeFolder/$id.$safeExt';
 
-    await _reliability.write(
-      () => _client.storage.from(bucket).uploadBinary(
+    final reliability = writeTimeout == null
+        ? _reliability
+        : ReliabilityPolicy(writeTimeout: writeTimeout);
+    await reliability.write(
+      () => _client.storage
+          .from(bucket)
+          .uploadBinary(
             path,
             bytes,
             fileOptions: FileOptions(
@@ -91,12 +97,14 @@ class HinooStorageUploader {
     required Uint8List bytes,
     required String ext,
     required String userId,
+    Duration? writeTimeout,
   }) {
     return uploadBytes(
       bytes: bytes,
       filenameExt: ext,
       userId: userId,
       folder: 'backgrounds',
+      writeTimeout: writeTimeout,
     );
   }
 

--- a/lib/UI/unified_thread_view.dart
+++ b/lib/UI/unified_thread_view.dart
@@ -249,6 +249,12 @@ class _UnifiedThreadViewState extends State<UnifiedThreadView>
         (entry) => entry.id == revealEntryId,
       );
       if (exactIndex >= 0) return exactIndex;
+
+      // Se la riga indicata dalla notifica non è ancora disponibile, non
+      // ricadere sulla radice della conversazione (che può essere un contenuto
+      // salvato dalla Luna): mostra comunque l'ultima risposta ricevuta.
+      final latestReceivedIndex = reversed.indexWhere(_isReceivedReply);
+      if (latestReceivedIndex >= 0) return latestReceivedIndex;
     }
     final receivedIndex = reversed.indexWhere(_shouldReveal);
     return receivedIndex < 0 ? 0 : receivedIndex;
@@ -301,6 +307,22 @@ class _UnifiedThreadViewState extends State<UnifiedThreadView>
       if (currentUserId != null && e.ownerId == currentUserId) return false;
     }
     return isReply;
+  }
+
+  bool _isReceivedReply(ConversationEntry entry) {
+    if (!_isDisplayableReply(entry)) return false;
+    final currentUserId =
+        widget.currentUserId ?? Supabase.instance.client.auth.currentUser?.id;
+    return currentUserId == null || entry.ownerId != currentUserId;
+  }
+
+  bool _isDisplayableReply(ConversationEntry entry) {
+    if (entry.kind == ConversationEntryKind.deleted || entry.isFromMoonSaved) {
+      return false;
+    }
+    if (entry.honoo?.isFromMoonSaved == true) return false;
+    return entry.honoo?.type == HonooType.answer ||
+        entry.hinoo?.type == HinooType.answer;
   }
 
   ConversationEntry? _answeredEntryFor(ConversationEntry reply) {

--- a/lib/Widgets/global_reply_notification_listener.dart
+++ b/lib/Widgets/global_reply_notification_listener.dart
@@ -9,6 +9,7 @@ import '../Services/reply_system_notification.dart';
 import '../Services/supabase_provider.dart';
 import '../Utility/reply_notification_signal.dart';
 import '../Utility/replies_seen_tracker.dart';
+import 'honoo_dialogs.dart';
 
 class GlobalReplyNotificationListener extends StatefulWidget {
   const GlobalReplyNotificationListener({
@@ -216,20 +217,32 @@ class _GlobalReplyNotificationListenerState
     );
 
     final context = widget.navigatorKey.currentContext;
-    if (context == null) return;
-    final messenger = ScaffoldMessenger.maybeOf(context);
-    messenger
-      ?..hideCurrentSnackBar()
-      ..showSnackBar(
-        SnackBar(
-          content: Text(
-            replyCount == 1
-                ? 'Hai ricevuto una nuova risposta'
-                : 'Hai ricevuto $replyCount nuove risposte',
-          ),
-          action: SnackBarAction(label: 'Apri', onPressed: open),
-        ),
+    if (context != null) {
+      unawaited(
+        _showReplyDialog(context, replyCount: replyCount, onOpen: open),
       );
+    }
+  }
+
+  Future<void> _showReplyDialog(
+    BuildContext context, {
+    required int replyCount,
+    required VoidCallback onOpen,
+  }) async {
+    final shouldOpen = await showDialog<bool>(
+      context: context,
+      useRootNavigator: true,
+      barrierDismissible: true,
+      builder: (_) => HonooConfirmDialog(
+        title: replyCount == 1
+            ? 'Hai ricevuto una nuova risposta'
+            : 'Hai ricevuto $replyCount nuove risposte',
+        confirmLabel: 'Apri',
+        cancelLabel: 'Ignora',
+      ),
+    );
+    if (!mounted || shouldOpen != true) return;
+    onOpen();
   }
 
   Future<void> _catchUpMissedReplies(String userId, int generation) async {

--- a/supabase/migrations/20260805150000_publish_house_campanelli.sql
+++ b/supabase/migrations/20260805150000_publish_house_campanelli.sql
@@ -1,0 +1,16 @@
+-- A house is listed for every authenticated island visitor. Its associated
+-- personal hinoo is the public-facing campanello and must be readable with it.
+-- Other personal hinoo remain private.
+
+drop policy if exists "hinoo read house campanelli" on public.hinoo;
+create policy "hinoo read house campanelli"
+  on public.hinoo
+  for select
+  to authenticated
+  using (
+    exists (
+      select 1
+      from public."case" houses
+      where houses.campanello_hinoo_id = hinoo.id
+    )
+  );

--- a/test/chest_ordering_test.dart
+++ b/test/chest_ordering_test.dart
@@ -136,4 +136,51 @@ void main() {
       expect(() => result.items.add(input.first), throwsUnsupportedError);
     });
   });
+
+  group('latestNotificationTarget', () {
+    test('mantiene la conversazione dedicata anche senza una slide radice', () {
+      final items = [
+        _Item(
+          id: 'root',
+          conversationId: 'original-conversation',
+          createdAt: DateTime.parse('2026-08-05T10:00:00Z'),
+        ),
+      ];
+
+      final target = ChestOrganizer.latestNotificationTarget(
+        items: items,
+        conversationIdOf: (item) => item.conversationId,
+        notifications: [
+          {
+            'original-conversation': DateTime.parse('2026-08-05T11:00:00Z'),
+            'dedicated-conversation': DateTime.parse('2026-08-05T12:00:00Z'),
+          },
+        ],
+      );
+
+      expect(target?.conversationId, 'dedicated-conversation');
+      expect(target?.isDetached, isTrue);
+    });
+
+    test('seleziona la slide quando la conversazione è già nello Scrigno', () {
+      final items = [
+        _Item(
+          id: 'root',
+          conversationId: 'conversation-1',
+          createdAt: DateTime.parse('2026-08-05T10:00:00Z'),
+        ),
+      ];
+
+      final target = ChestOrganizer.latestNotificationTarget(
+        items: items,
+        conversationIdOf: (item) => item.conversationId,
+        notifications: [
+          {'conversation-1': DateTime.parse('2026-08-05T11:00:00Z')},
+        ],
+      );
+
+      expect(target?.itemIndex, 0);
+      expect(target?.isDetached, isFalse);
+    });
+  });
 }

--- a/test/controllers/campanelli_controller_test.dart
+++ b/test/controllers/campanelli_controller_test.dart
@@ -137,6 +137,38 @@ void main() {
         )).called(1);
   });
 
+  test('compone campanello e casa appartenenti a un altro utente', () async {
+    when(repository.fetchHouseRows).thenAnswer((_) async => const [
+          {
+            'campanello_hinoo_id': 'hinoo-other',
+            'owner_id': 'user-2',
+            'house_image_url': 'other-house.png',
+          },
+        ]);
+    when(() => repository.fetchShareSettingsRows(any()))
+        .thenAnswer((_) async => const []);
+    when(() => repository.fetchHinooRows(any())).thenAnswer((_) async => const [
+          {
+            'id': 'hinoo-other',
+            'pages': [
+              {
+                'text': 'Campanello pubblico',
+                'backgroundImage': 'other-bell.png',
+                'isTextWhite': false,
+              }
+            ],
+          },
+        ]);
+
+    final state = await controller.load('user-1');
+
+    expect(state.hasOwnHouse, isFalse);
+    expect(state.entries, hasLength(1));
+    expect(state.entries.single.ownerId, 'user-2');
+    expect(state.entries.single.campanelloBackgroundUrl, 'other-bell.png');
+    expect(state.entries.single.houseImageUrl, 'other-house.png');
+  });
+
   test('pubblica uno stato di errore senza conservare dati parziali', () async {
     when(repository.fetchHouseRows).thenThrow(StateError('offline'));
 

--- a/test/services/hinoo_storage_uploader_test.dart
+++ b/test/services/hinoo_storage_uploader_test.dart
@@ -100,6 +100,26 @@ void main() {
     verify(() => fileApi.getPublicUrl(path)).called(1);
   });
 
+  test('uploadBackground accetta un timeout esteso per la casa', () async {
+    when(() => fileApi.uploadBinary(
+          any(),
+          any<Uint8List>(),
+          fileOptions: any(named: 'fileOptions'),
+        )).thenAnswer((_) async {
+      await Future<void>.delayed(const Duration(milliseconds: 30));
+      return 'slow-house-upload';
+    });
+
+    final url = await HinooStorageUploader.uploadBackground(
+      bytes: Uint8List.fromList([1, 2, 3]),
+      ext: 'png',
+      userId: 'u-house',
+      writeTimeout: const Duration(milliseconds: 100),
+    );
+
+    expect(url, 'https://cdn.example.com/hinoo/mock-url.png');
+  });
+
   test(
       'uploadBytes: folder custom e normalizzazione estensioni non permesse → jpg',
       () async {

--- a/test/widgets/global_reply_notification_listener_test.dart
+++ b/test/widgets/global_reply_notification_listener_test.dart
@@ -7,6 +7,7 @@ import 'package:honoo/Pages/chest_page.dart';
 import 'package:honoo/Services/reply_system_notification.dart';
 import 'package:honoo/Widgets/global_reply_notification_listener.dart';
 import 'package:honoo/Utility/reply_notification_signal.dart';
+import 'package:honoo/Utility/replies_seen_tracker.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../test_supabase_helper.dart';
@@ -52,6 +53,7 @@ void main() {
       ..enableOverrides();
     harness.stubTable('honoo');
     harness.stubTable('hinoo');
+    harness.stubTable('conversation_tombstones');
     events = StreamController<ReplyNotificationEvent>();
   });
 
@@ -102,7 +104,10 @@ void main() {
       );
       expect(find.text('Hai ricevuto una nuova risposta'), findsOneWidget);
 
-      notification.onTap!();
+      expect(find.text('Apri'), findsOneWidget);
+      expect(find.text('Ignora'), findsOneWidget);
+
+      await tester.tap(find.text('Apri'));
       await tester.pumpAndSettle();
 
       expect(navigatorKey.currentState!.canPop(), isTrue);
@@ -114,6 +119,54 @@ void main() {
       await tester.pumpWidget(const SizedBox.shrink());
     },
   );
+
+  testWidgets('Ignora chiude il popup senza aprire né consumare la risposta', (
+    tester,
+  ) async {
+    final navigatorKey = GlobalKey<NavigatorState>();
+    final notification = _FakeReplySystemNotification();
+
+    await tester.pumpWidget(
+      GlobalReplyNotificationListener(
+        navigatorKey: navigatorKey,
+        systemNotification: notification,
+        replyEventStream: events.stream,
+        child: MaterialApp(
+          navigatorKey: navigatorKey,
+          home: const Scaffold(body: Text('Luna')),
+        ),
+      ),
+    );
+
+    events.add(
+      ReplyNotificationEvent(
+        kind: ReplyNotificationKind.honoo,
+        conversationId: 'conversation-pending',
+        senderId: 'other_user',
+        recipientId: 'test_user',
+        replyId: 'reply-pending',
+        createdAt: DateTime.utc(2026, 8, 3, 10),
+      ),
+    );
+    await tester.pump(const Duration(milliseconds: 200));
+
+    expect(find.text('Ignora'), findsOneWidget);
+    await tester.tap(find.text('Ignora'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(ChestPage), findsNothing);
+    expect(find.text('Luna'), findsOneWidget);
+    expect(notification.showCount, 1);
+    expect(notification.onTap, isNotNull);
+    final seenState = await RepliesSeenTracker.load(userId: 'test_user');
+    expect(
+      seenState.isSeen(
+        conversationId: 'conversation-pending',
+        createdAt: DateTime.utc(2026, 8, 3, 10),
+      ),
+      isFalse,
+    );
+  });
 
   testWidgets(
     'un grande burst produce una sola notifica e un solo aggiornamento UI',
@@ -161,6 +214,8 @@ void main() {
       expect(ReplyNotificationSignal.revision.value, initialRevision + 1);
       expect(find.text('Hai ricevuto 1000 nuove risposte'), findsOneWidget);
 
+      await tester.tap(find.text('Ignora'));
+      await tester.pumpAndSettle();
       notification.onTap!();
       await tester.pumpAndSettle();
       final chestPage = tester.widget<ChestPage>(find.byType(ChestPage));

--- a/test/widgets/honoo_card_layout_test.dart
+++ b/test/widgets/honoo_card_layout_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:honoo/Entities/honoo.dart';
+import 'package:honoo/Pages/moon_page.dart';
 import 'package:honoo/UI/honoo_card.dart';
 import 'package:honoo/Utility/honoo_colors.dart';
 import 'package:honoo/Widgets/smooth_image.dart';
@@ -23,15 +24,16 @@ void main() {
   testWidgets('il separatore dell honoo Luna usa il bianco dello sfondo', (
     tester,
   ) async {
-    final honoo = Honoo(
-      1,
-      'Ciao Luna',
-      '',
-      '2026-01-01T00:00:00Z',
-      '2026-01-01T00:00:00Z',
-      'user-id',
-      HonooType.moon,
-    );
+    final honoo = MoonPage.honooFromMoonRow({
+      'id': 'moon-honoo-id',
+      'text': 'Ciao Luna',
+      'image_url': '',
+      'created_at': '2026-01-01T00:00:00Z',
+      'user_id': 'user-id',
+      // moon_public non espone il campo destination.
+    });
+
+    expect(honoo.type, HonooType.moon);
 
     await tester.pumpWidget(
       MaterialApp(

--- a/test/widgets/unified_thread_notification_focus_test.dart
+++ b/test/widgets/unified_thread_notification_focus_test.dart
@@ -28,6 +28,23 @@ void main() {
     return ConversationEntry.honoo(honoo);
   }
 
+  ConversationEntry moonRoot() {
+    final honoo =
+        Honoo(
+            0,
+            'moon-root',
+            '',
+            '2026-07-20T10:00:00Z',
+            '2026-07-20T10:00:00Z',
+            'me',
+            HonooType.personal,
+          )
+          ..dbId = 'moon-root'
+          ..conversationId = 'conversation-1'
+          ..isFromMoonSaved = true;
+    return ConversationEntry.honoo(honoo);
+  }
+
   testWidgets(
     'dal badge seleziona l’ultima risposta ricevuta, non quella inviata',
     (tester) async {
@@ -64,6 +81,41 @@ void main() {
       await tester.pump(const Duration(milliseconds: 100));
 
       expect(selected?.id, 'received');
+    },
+  );
+
+  testWidgets(
+    'se l’id notificato manca non ricade sul contenuto salvato dalla Luna',
+    (tester) async {
+      final received = reply(
+        id: 'latest-received',
+        owner: 'other',
+        createdAt: '2026-07-20T11:00:00Z',
+      );
+      ConversationEntry? selected;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: UnifiedThreadView(
+              conversationId: 'conversation-1',
+              maxWidth: 600,
+              maxHeight: 700,
+              isActive: true,
+              highlightLatest: true,
+              revealEntryId: 'reply-not-yet-loaded',
+              currentUserId: 'me',
+              conversationLoader: (_) async => [moonRoot(), received],
+              onSelect: (entry) => selected = entry,
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(selected?.id, 'latest-received');
+      expect(selected?.isFromMoonSaved, isFalse);
     },
   );
 }


### PR DESCRIPTION
## What
- replace the reply SnackBar with an Honoo-styled dialog offering Apri and Ignora
- keep ignored replies pending and preserve the chest badge
- open the requested conversation directly when it has no local chest card
- fall back to the latest received reply instead of Moon-saved content when the notified row is temporarily unavailable
- map Honoo rows from moon_public as Moon content so the separator between text and image stays white

## Why
Reply notifications could open an unrelated Moon-saved root. Separately, moon_public does not expose destination, so Honoo.fromMap defaulted Moon cards to the personal type and painted the separator with the dark frame color.

## Impact
Notification, chest navigation, and Moon Honoo rendering only. Box outlines are unchanged. No schema or backend changes.

## Checks
- flutter analyze
- targeted reply notification, thread focus, unread count, seen tracker, and Honoo Moon layout tests