### PR TITLE
Update gallery save confirmation

### DIFF
--- a/lib/Widgets/gallery_save_dialog.dart
+++ b/lib/Widgets/gallery_save_dialog.dart
@@ -19,7 +19,9 @@ Future<void> showDownloadSaveResult({
     context: context,
     barrierDismissible: true,
     builder: (_) => HonooConfirmDialog(
-      title: "L'$contentName è stato salvato nella tua galleria delle foto",
+      title:
+          'L’$contentName è stato salvato\n'
+          'nella tua Galleria delle Foto',
       confirmLabel: 'Apri galleria',
       cancelLabel: 'Ignora',
     ),

--- a/test/widgets/gallery_save_dialog_test.dart
+++ b/test/widgets/gallery_save_dialog_test.dart
@@ -28,7 +28,11 @@ void main() {
     savedItemUri: 'content://gallery/honoo.png',
   );
 
-  Future<void> pumpDialog(WidgetTester tester, _FakeDownloadSaver saver) async {
+  Future<void> pumpDialog(
+    WidgetTester tester,
+    _FakeDownloadSaver saver, {
+    String contentName = 'honoo',
+  }) async {
     await tester.pumpWidget(
       MaterialApp(
         home: Builder(
@@ -36,7 +40,7 @@ void main() {
             body: TextButton(
               onPressed: () => showDownloadSaveResult(
                 context: context,
-                contentName: 'honoo',
+                contentName: contentName,
                 openSavedImage: saver.openSavedImage,
                 result: result,
               ),
@@ -57,7 +61,10 @@ void main() {
     await pumpDialog(tester, saver);
 
     expect(
-      find.text("L'honoo è stato salvato nella tua galleria delle foto"),
+      find.text(
+        'L’honoo è stato salvato\n'
+        'nella tua Galleria delle Foto',
+      ),
       findsOneWidget,
     );
 
@@ -77,5 +84,18 @@ void main() {
 
     expect(saver.openCalled, isTrue);
     expect(find.text('Salva'), findsOneWidget);
+  });
+
+  testWidgets('il messaggio usa correttamente il nome hinoo', (tester) async {
+    final saver = _FakeDownloadSaver();
+    await pumpDialog(tester, saver, contentName: 'hinoo');
+
+    expect(
+      find.text(
+        'L’hinoo è stato salvato\n'
+        'nella tua Galleria delle Foto',
+      ),
+      findsOneWidget,
+    );
   });
 }


### PR DESCRIPTION
## Cosa cambia

- aggiorna centralmente il popup mostrato dopo il salvataggio nella galleria
- usa l’apostrofo tipografico e un ritorno a capo esplicito
- mostra `Galleria delle Foto` con le maiuscole richieste
- mantiene dinamico il nome del contenuto per ottenere correttamente sia `L’honoo` sia `L’hinoo`
- estende i test widget a entrambe le varianti

## Nuovo testo

```text
L’honoo/L’hinoo è stato salvato
nella tua Galleria delle Foto
```

## Verifiche

- `flutter test --no-pub test/widgets/gallery_save_dialog_test.dart`
- `flutter analyze --no-pub`
- `git diff --check`