### PR TITLE
Fix received reply conversation controls

### DIFF
--- a/lib/Pages/chest_page.dart
+++ b/lib/Pages/chest_page.dart
@@ -86,6 +86,7 @@ class _ChestPageState extends State<ChestPage> with WidgetsBindingObserver {
   int _currentIndex = 0;
   bool _didApplyInitialFocus = false;
   String? _detachedFocusedConversationId;
+  bool _detachedConversationVisible = true;
   bool _initialLoadCompleted = false;
   int _conversationRefreshToken = 0;
   String? _pendingRevealEntryId;
@@ -509,6 +510,7 @@ class _ChestPageState extends State<ChestPage> with WidgetsBindingObserver {
           onSendHinooToMoon: _sendHinooToMoon,
           onReplyToHinoo: _showReplyChoiceForHinoo,
           onDeleteHinoo: _deleteHinoo,
+          onReplyToConversationEntry: _showReplyChoiceForConversationEntry,
           onSendConversationEntryToMoon: _sendConversationEntryToMoon,
         ),
       ),
@@ -739,6 +741,32 @@ class _ChestPageState extends State<ChestPage> with WidgetsBindingObserver {
         ),
       );
       _refreshConversationInPlace(result);
+    }
+  }
+
+  Future<void> _showReplyChoiceForConversationEntry(
+    ConversationEntry entry,
+  ) async {
+    switch (entry.kind) {
+      case ConversationEntryKind.honoo:
+        await _showReplyChoiceForHonoo(entry.honoo!);
+        return;
+      case ConversationEntryKind.hinoo:
+        final id = entry.id;
+        if (id == null || id.isEmpty) return;
+        await _showReplyChoiceForHinoo(
+          ChestHinooItem(
+            id: id,
+            draft: entry.hinoo!,
+            createdAt: entry.createdAt,
+            isFromMoonSaved: entry.isFromMoonSaved,
+            ownerId: entry.ownerId,
+            conversationId: entry.hinoo!.conversationId,
+          ),
+        );
+        return;
+      case ConversationEntryKind.deleted:
+        return;
     }
   }
 
@@ -1003,7 +1031,9 @@ class _ChestPageState extends State<ChestPage> with WidgetsBindingObserver {
             focusedConversationId != null &&
             focusedConversationId.isNotEmpty &&
             focusedItemIndex < 0;
-        final currentItem = showDetachedFocusedConversation || items.isEmpty
+        final detachedConversationVisible =
+            showDetachedFocusedConversation && _detachedConversationVisible;
+        final currentItem = detachedConversationVisible || items.isEmpty
             ? null
             : items[_currentIndex.clamp(0, items.length - 1)];
         final currentUserId = SupabaseProvider.client.auth.currentUser?.id;
@@ -1040,21 +1070,7 @@ class _ChestPageState extends State<ChestPage> with WidgetsBindingObserver {
             if ((ctrl.isLoading.value || _isHinooLoading) && items.isEmpty) {
               return const Center(child: LoadingSpinner(color: Colors.white));
             }
-            if (showDetachedFocusedConversation) {
-              return UnifiedThreadView(
-                conversationId: focusedConversationId,
-                maxWidth: viewW,
-                maxHeight: availableH,
-                isActive: true,
-                highlightLatest: widget.highlightLatest,
-                currentUserId: currentUserId,
-                revealEntryId: _pendingRevealEntryId,
-                refreshToken: _conversationRefreshToken,
-                onSelect: (entry) =>
-                    _selectConversationEntry(focusedConversationId, entry),
-              );
-            }
-            if (items.isEmpty) {
+            if (items.isEmpty && !showDetachedFocusedConversation) {
               if (loadError != null) {
                 return Center(child: _buildLoadError(compact: false));
               }
@@ -1073,9 +1089,14 @@ class _ChestPageState extends State<ChestPage> with WidgetsBindingObserver {
             const horizPhysics = PageScrollPhysics(
               parent: ClampingScrollPhysics(),
             );
+            final detachedOffset = showDetachedFocusedConversation ? 1 : 0;
+            final carouselItemCount = items.length + detachedOffset;
+            final currentCarouselIndex = detachedConversationVisible
+                ? 0
+                : _currentIndex + detachedOffset;
             final slider = cs.CarouselSlider.builder(
               carouselController: _carouselController,
-              itemCount: items.length,
+              itemCount: carouselItemCount,
               options: cs.CarouselOptions(
                 height: availableH,
                 viewportFraction: 1.0,
@@ -1085,17 +1106,41 @@ class _ChestPageState extends State<ChestPage> with WidgetsBindingObserver {
                 disableCenter: true,
                 scrollPhysics: horizPhysics,
                 onPageChanged: (i, _) {
+                  final isDetachedPage =
+                      showDetachedFocusedConversation && i == 0;
                   setState(() {
-                    _currentIndex = i;
+                    _detachedConversationVisible = isDetachedPage;
+                    if (!isDetachedPage) {
+                      _currentIndex = i - detachedOffset;
+                    }
                     _selectedConvEntry = null;
                   });
-                  _prefetchChestFrom(i);
+                  if (!isDetachedPage) {
+                    _prefetchChestFrom(i - detachedOffset);
+                  }
                 },
               ),
               itemBuilder: (context, index, realIdx) {
-                final bool isActive = _currentIndex == index;
+                if (showDetachedFocusedConversation && index == 0) {
+                  return UnifiedThreadView(
+                    key: ValueKey('detached:$focusedConversationId'),
+                    conversationId: focusedConversationId,
+                    maxWidth: viewW,
+                    maxHeight: availableH,
+                    isActive: detachedConversationVisible,
+                    highlightLatest: widget.highlightLatest,
+                    currentUserId: currentUserId,
+                    revealEntryId: _pendingRevealEntryId,
+                    refreshToken: _conversationRefreshToken,
+                    onSelect: (entry) =>
+                        _selectConversationEntry(focusedConversationId, entry),
+                  );
+                }
+                final itemIndex = index - detachedOffset;
+                final bool isActive =
+                    !detachedConversationVisible && _currentIndex == itemIndex;
                 return _buildChestItem(
-                  items[index],
+                  items[itemIndex],
                   availableH,
                   viewW,
                   honooMetrics,
@@ -1123,19 +1168,19 @@ class _ChestPageState extends State<ChestPage> with WidgetsBindingObserver {
                 layoutMode == ResponsiveLayoutMode.desktop ||
                 layoutMode == ResponsiveLayoutMode.wideDesktop ||
                 layoutMode == ResponsiveLayoutMode.largeDesktop;
-            if (!isDesktop || items.length <= 1) {
+            if (!isDesktop || carouselItemCount <= 1) {
               return visibleSlider;
             }
             return DesktopCarouselArrows(
-              canPrev: _currentIndex > 0,
-              canNext: _currentIndex < items.length - 1,
+              canPrev: currentCarouselIndex > 0,
+              canNext: currentCarouselIndex < carouselItemCount - 1,
               onPrev: () => _carouselController.animateToPage(
-                (_currentIndex - 1).clamp(0, items.length - 1),
+                (currentCarouselIndex - 1).clamp(0, carouselItemCount - 1),
                 duration: const Duration(milliseconds: 220),
                 curve: Curves.easeOutCubic,
               ),
               onNext: () => _carouselController.animateToPage(
-                (_currentIndex + 1).clamp(0, items.length - 1),
+                (currentCarouselIndex + 1).clamp(0, carouselItemCount - 1),
                 duration: const Duration(milliseconds: 220),
                 curve: Curves.easeOutCubic,
               ),
@@ -1154,7 +1199,7 @@ class _ChestPageState extends State<ChestPage> with WidgetsBindingObserver {
               ) {
                 final items = _itemsNormal;
                 final ChestItem? current =
-                    showDetachedFocusedConversation || items.isEmpty
+                    detachedConversationVisible || items.isEmpty
                     ? null
                     : items[_currentIndex];
                 return _footerForItem(

--- a/lib/UI/honoo_card.dart
+++ b/lib/UI/honoo_card.dart
@@ -37,10 +37,10 @@ class HonooCard extends StatelessWidget {
       ChestContentStyle.receivedReply,
     );
     final Color textPanelColor = isReceivedReply
-        ? HonooColor.secondary
+        ? Colors.white
         : HonooColor.tertiary;
     final Color textColor = isReceivedReply
-        ? Colors.white
+        ? Colors.black
         : HonooColor.onTertiary;
 
     return LayoutBuilder(
@@ -93,6 +93,7 @@ class HonooCard extends StatelessWidget {
                   width: imageSize,
                   height: textHeight,
                   child: Container(
+                    key: const Key('honoo-card-text-panel'),
                     padding: const EdgeInsets.all(8),
                     decoration: BoxDecoration(
                       color: textPanelColor,

--- a/lib/Widgets/chest_footer.dart
+++ b/lib/Widgets/chest_footer.dart
@@ -24,6 +24,7 @@ class ChestFooter extends StatelessWidget {
     required this.onSendHinooToMoon,
     required this.onReplyToHinoo,
     required this.onDeleteHinoo,
+    required this.onReplyToConversationEntry,
     required this.onSendConversationEntryToMoon,
     this.foregroundColor = HonooColor.onBackground,
   });
@@ -42,6 +43,7 @@ class ChestFooter extends StatelessWidget {
   final ValueChanged<ChestHinooItem> onSendHinooToMoon;
   final ValueChanged<ChestHinooItem> onReplyToHinoo;
   final ValueChanged<ChestHinooItem> onDeleteHinoo;
+  final ValueChanged<ConversationEntry> onReplyToConversationEntry;
   final ValueChanged<ConversationEntry> onSendConversationEntryToMoon;
   final Color foregroundColor;
 
@@ -67,6 +69,16 @@ class ChestFooter extends StatelessWidget {
       hinoo: (hinoo) => _addHinooActions(actions, hinoo),
     );
 
+    final selectedEntry = selectedConversationEntry;
+    if (_canReplyTo(selectedEntry)) {
+      actions.add(
+        _replyAction(
+          () => onReplyToConversationEntry(selectedEntry!),
+          color: Colors.white,
+        ),
+      );
+    }
+
     return ResponsiveFooterBar(
       useSafeArea: false,
       bottomPadding: bottomPadding,
@@ -90,7 +102,9 @@ class ChestFooter extends StatelessWidget {
         !isOnMoon &&
         selectedEntryToPublish == null) {
       actions.add(_moonAction(() => onSendHonooToMoon(honoo)));
-    } else if (hasReplies && !isFromMoonSaved) {
+    } else if (hasReplies &&
+        !isFromMoonSaved &&
+        selectedConversationEntry == null) {
       actions.add(
         _action(
           asset: 'assets/icons/reply.svg',
@@ -133,6 +147,12 @@ class ChestFooter extends StatelessWidget {
     return isMine && isPersonalEntry && !entry.isFromMoonSaved ? entry : null;
   }
 
+  bool _canReplyTo(ConversationEntry? entry) =>
+      entry != null &&
+      entry.kind != ConversationEntryKind.deleted &&
+      entry.id != null &&
+      entry.id!.isNotEmpty;
+
   void _addHinooActions(
     List<ResponsiveFooterAction> actions,
     ChestHinooItem hinoo,
@@ -154,12 +174,14 @@ class ChestFooter extends StatelessWidget {
     onPressed: onPressed,
   );
 
-  ResponsiveFooterAction _replyAction(VoidCallback onPressed) => _action(
-    asset: 'assets/icons/reply.svg',
-    label: 'Rispondi',
-    tooltip: 'Rispondi',
-    onPressed: onPressed,
-  );
+  ResponsiveFooterAction _replyAction(VoidCallback onPressed, {Color? color}) =>
+      _action(
+        asset: 'assets/icons/reply.svg',
+        label: 'Rispondi',
+        tooltip: 'Rispondi',
+        onPressed: onPressed,
+        color: color,
+      );
 
   ResponsiveFooterAction _deleteAction(VoidCallback onPressed) => _action(
     asset: 'assets/Cestino.svg',
@@ -174,11 +196,12 @@ class ChestFooter extends StatelessWidget {
     required String tooltip,
     required VoidCallback onPressed,
     bool applyColorFilter = true,
+    Color? color,
   }) => ResponsiveFooterAction(
     asset: asset,
     semanticsLabel: label,
     colorFilter: applyColorFilter
-        ? ColorFilter.mode(foregroundColor, BlendMode.srcIn)
+        ? ColorFilter.mode(color ?? foregroundColor, BlendMode.srcIn)
         : null,
     size: iconSize,
     splashRadius: 25,

--- a/test/widgets/chest_footer_test.dart
+++ b/test/widgets/chest_footer_test.dart
@@ -61,6 +61,7 @@ void main() {
     ValueChanged<ChestHinooItem>? onSendHinooToMoon,
     ValueChanged<ChestHinooItem>? onDeleteHinoo,
     ConversationEntry? selectedConversationEntry,
+    ValueChanged<ConversationEntry>? onReplyToConversationEntry,
     ValueChanged<ConversationEntry>? onSendConversationEntryToMoon,
   }) async {
     await tester.pumpWidget(
@@ -81,6 +82,8 @@ void main() {
             onSendHinooToMoon: onSendHinooToMoon ?? (_) {},
             onReplyToHinoo: (_) {},
             onDeleteHinoo: onDeleteHinoo ?? (_) {},
+            onReplyToConversationEntry:
+                onReplyToConversationEntry ?? (ConversationEntry _) {},
             onSendConversationEntryToMoon:
                 onSendConversationEntryToMoon ?? (ConversationEntry _) {},
           ),
@@ -212,6 +215,7 @@ void main() {
         HonooType.personal,
         conversationId: 'conversation-1',
       );
+      item.honoo!.dbId = 'root-1';
       final selectedEntry = ConversationEntry.honoo(item.honoo!);
       ConversationEntry? publishedEntry;
 
@@ -223,8 +227,43 @@ void main() {
       );
 
       expect(find.byTooltip('Spedisci sulla Luna'), findsOneWidget);
+      expect(find.byTooltip('Rispondi'), findsOneWidget);
       await tester.tap(find.byTooltip('Spedisci sulla Luna'));
       expect(publishedEntry, same(selectedEntry));
+    },
+  );
+
+  testWidgets(
+    'la conversazione dedicata mostra Rispondi bianco e inoltra la selezione',
+    (tester) async {
+      final honoo = honooItem(
+        HonooType.answer,
+        conversationId: 'conversation-1',
+      ).honoo!;
+      honoo.dbId = 'reply-1';
+      final selectedEntry = ConversationEntry.honoo(honoo);
+      ConversationEntry? repliedEntry;
+
+      await pumpFooter(
+        tester,
+        item: null,
+        selectedConversationEntry: selectedEntry,
+        onReplyToConversationEntry: (entry) => repliedEntry = entry,
+      );
+
+      expect(find.byTooltip('Rispondi'), findsOneWidget);
+      final replyIcon = tester.widget<SvgPicture>(
+        find.descendant(
+          of: find.byTooltip('Rispondi'),
+          matching: find.byType(SvgPicture),
+        ),
+      );
+      expect(
+        replyIcon.colorFilter,
+        const ColorFilter.mode(Colors.white, BlendMode.srcIn),
+      );
+      await tester.tap(find.byTooltip('Rispondi'));
+      expect(repliedEntry, same(selectedEntry));
     },
   );
 

--- a/test/widgets/conversation_border_test.dart
+++ b/test/widgets/conversation_border_test.dart
@@ -39,14 +39,6 @@ void main() {
         border.top.width == 6;
   });
 
-  Finder decoratedPanelWithColor(Color color) =>
-      find.byWidgetPredicate((widget) {
-        if (widget is! Container || widget.decoration is! BoxDecoration) {
-          return false;
-        }
-        return (widget.decoration! as BoxDecoration).color == color;
-      });
-
   Honoo honoo({
     required HonooType type,
     String owner = 'other_user',
@@ -142,7 +134,7 @@ void main() {
     expect(borderWithColor(Colors.white), findsNothing);
   });
 
-  testWidgets('Honoo ricevuto in risposta usa sfondo rosso e non ha cornice', (
+  testWidgets('Honoo ricevuto usa sfondo esterno rosso e box testo bianco', (
     tester,
   ) async {
     final value = honoo(type: HonooType.answer);
@@ -152,9 +144,12 @@ void main() {
       ChestContentStyle.forHonoo(value, viewerUserId: 'test_user'),
       same(ChestContentStyle.receivedReply),
     );
-    expect(decoratedPanelWithColor(HonooColor.secondary), findsOneWidget);
+    final textPanel = tester.widget<Container>(
+      find.byKey(const Key('honoo-card-text-panel')),
+    );
+    expect((textPanel.decoration! as BoxDecoration).color, Colors.white);
     final replyText = tester.widget<Text>(find.text('Test conversazione'));
-    expect(replyText.style?.color, Colors.white);
+    expect(replyText.style?.color, Colors.black);
     expect(borderWithColor(HonooColor.secondary), findsNothing);
     expect(borderWithColor(Colors.white), findsNothing);
   });


### PR DESCRIPTION
## Cosa cambia
- mantiene rosso lo sfondo esterno delle risposte ricevute, con box testo bianco e testo nero
- aggiunge il pulsante bianco Rispondi alla toolbar della conversazione e lo collega all'elemento visibile
- integra anche le conversazioni dedicate aperte dal badge nel carosello orizzontale dello Scrigno

## Verifiche
- flutter analyze --no-pub
- flutter test --no-pub test/widgets/chest_footer_test.dart test/widgets/conversation_border_test.dart test/widgets/unified_thread_notification_focus_test.dart
- flutter test --no-pub test/widgets/unified_thread_reveal_test.dart