### PR TITLE
Align agent credits link styling

### DIFF
--- a/lib/Pages/placeholder_page.dart
+++ b/lib/Pages/placeholder_page.dart
@@ -50,8 +50,9 @@ class _PlaceholderPageState extends State<PlaceholderPage> {
   static const double _honooBottomSpacing = 15;
   static const double _libriTopSpacing = 5;
   static const double _libriBottomSpacing = 30;
-  static const double _regiaAgentiTopSpacing = 5;
-  static const double _regiaAgentiBottomSpacing = 30;
+  static const double _regiaAgentiTopSpacing = _podcastTopSpacing;
+  static const double _regiaAgentiBottomSpacing = _podcastBottomSpacing;
+  static const double _regiaAgentiIconSizeReduction = 3;
   static const Color _linkIconColor = Color.fromRGBO(183, 183, 206, 1);
 
   List<Widget> _iconBlockWithSpacing(
@@ -420,7 +421,7 @@ class _PlaceholderPageState extends State<PlaceholderPage> {
       ),
       ..._svgIconBlockWithSpacing(
         'assets/icons/ai.svg',
-        inlineIconHeight - 3,
+        inlineIconHeight - _regiaAgentiIconSizeReduction,
         topSpacing: _regiaAgentiTopSpacing,
         bottomSpacing: _regiaAgentiBottomSpacing,
         color: _linkIconColor,

--- a/lib/Pages/regia_agenti_page.dart
+++ b/lib/Pages/regia_agenti_page.dart
@@ -72,6 +72,7 @@ class RegiaAgentiPage extends StatelessWidget {
               style: bodyStyle.copyWith(
                 decoration: TextDecoration.underline,
                 decorationColor: bodyStyle.color,
+                decorationThickness: 3,
               ),
               recognizer: TapGestureRecognizer()
                 ..onTap = () async {

--- a/test/pages/regia_agenti_page_test.dart
+++ b/test/pages/regia_agenti_page_test.dart
@@ -88,5 +88,6 @@ void main() {
     );
     expect(alessandroSpan.recognizer, isA<TapGestureRecognizer>());
     expect(alessandroSpan.style?.decoration, TextDecoration.underline);
+    expect(alessandroSpan.style?.decorationThickness, 3);
   });
 }


### PR DESCRIPTION
## Cosa cambia
- rende la sottolineatura di Alessandro Molina uguale agli altri link, con spessore 3
- vincola la spaziatura del blocco Regia degli Agenti agli stessi valori di Podcast e dirette
- mantiene l'icona AI esattamente 3 punti più piccola delle altre icone

## Verifiche
- flutter test --no-pub test/pages/regia_agenti_page_test.dart
- flutter analyze --no-pub