### PR TITLE
Show owned reply parents in blue

### DIFF
--- a/lib/UI/honoo_card.dart
+++ b/lib/UI/honoo_card.dart
@@ -14,12 +14,14 @@ class HonooCard extends StatelessWidget {
   final Honoo honoo;
   final VoidCallback? onDownloadTap;
   final String? viewerUserId;
+  final ChestContentStyle? contentStyleOverride;
 
   const HonooCard({
     super.key,
     required this.honoo,
     this.onDownloadTap,
     this.viewerUserId,
+    this.contentStyleOverride,
   });
 
   @override
@@ -27,10 +29,9 @@ class HonooCard extends StatelessWidget {
     final media = MediaQuery.of(context);
     final String? currentUserId =
         viewerUserId ?? SupabaseProvider.client.auth.currentUser?.id;
-    final contentStyle = ChestContentStyle.forHonoo(
-      honoo,
-      viewerUserId: currentUserId,
-    );
+    final contentStyle =
+        contentStyleOverride ??
+        ChestContentStyle.forHonoo(honoo, viewerUserId: currentUserId);
     final Color cardBg = contentStyle.backgroundColor;
     final bool isReceivedReply = identical(
       contentStyle,

--- a/lib/UI/unified_thread_view.dart
+++ b/lib/UI/unified_thread_view.dart
@@ -342,8 +342,26 @@ class _UnifiedThreadViewState extends State<UnifiedThreadView>
     return replyIndex > 0 ? _entries[replyIndex - 1] : null;
   }
 
-  Widget _entryCard(ConversationEntry entry, {String? keyName}) {
+  bool _isOwnedByCurrentUser(ConversationEntry entry) {
+    final currentUserId =
+        widget.currentUserId ?? SupabaseProvider.client.auth.currentUser?.id;
+    return currentUserId != null && entry.ownerId == currentUserId;
+  }
+
+  Widget _entryCard(
+    ConversationEntry entry, {
+    String? keyName,
+    bool showAsOwnedContent = false,
+  }) {
     final GlobalKey repaintKey = GlobalKey();
+    final style = showAsOwnedContent
+        ? ChestContentStyle.own
+        : ChestContentStyle.forEntry(
+            entry,
+            viewerUserId:
+                widget.currentUserId ??
+                SupabaseProvider.client.auth.currentUser?.id,
+          );
     final Widget card;
     switch (entry.kind) {
       case ConversationEntryKind.honoo:
@@ -352,6 +370,7 @@ class _UnifiedThreadViewState extends State<UnifiedThreadView>
           child: HonooCard(
             honoo: entry.honoo!,
             viewerUserId: widget.currentUserId,
+            contentStyleOverride: showAsOwnedContent ? style : null,
             onDownloadTap: () => _downloadFromBoundary(
               repaintKey: repaintKey,
               baseName: 'honoo',
@@ -369,6 +388,9 @@ class _UnifiedThreadViewState extends State<UnifiedThreadView>
             isReply: entry.hinoo!.type == HinooType.answer,
             authorId: entry.ownerId,
             viewerUserId: widget.currentUserId,
+            gapColor: showAsOwnedContent
+                ? ChestContentStyle.own.backgroundColor
+                : HonooColor.background,
             onDownloadTap: () => _downloadFromBoundary(
               repaintKey: repaintKey,
               baseName: 'hinoo',
@@ -389,11 +411,6 @@ class _UnifiedThreadViewState extends State<UnifiedThreadView>
         );
         break;
     }
-    final style = ChestContentStyle.forEntry(
-      entry,
-      viewerUserId:
-          widget.currentUserId ?? SupabaseProvider.client.auth.currentUser?.id,
-    );
     return ColoredBox(
       key: keyName == null ? null : Key(keyName),
       color: style.backgroundColor,
@@ -476,6 +493,7 @@ class _UnifiedThreadViewState extends State<UnifiedThreadView>
                 child: _entryCard(
                   answeredEntry,
                   keyName: 'reply_reveal_parent',
+                  showAsOwnedContent: _isOwnedByCurrentUser(answeredEntry),
                 ),
               );
               return AnimatedBuilder(

--- a/test/widgets/unified_thread_reveal_test.dart
+++ b/test/widgets/unified_thread_reveal_test.dart
@@ -46,6 +46,7 @@ void main() {
     required String createdAt,
     HinooType type = HinooType.personal,
     String? replyTo,
+    bool fromMoon = false,
   }) => ConversationEntry.hinoo(
     HinooDraft(
       pages: [HinooSlide(backgroundImage: null, text: text, isTextWhite: true)],
@@ -56,6 +57,7 @@ void main() {
     id: id,
     ownerId: owner,
     createdAt: DateTime.parse(createdAt),
+    isFromMoonSaved: fromMoon,
   );
 
   Finder borderWithColor(Color color) => find.byWidgetPredicate((widget) {
@@ -407,7 +409,7 @@ void main() {
   });
 
   testWidgets(
-    'il bounce mostra lo sfondo bianco del padre Luna e quello blu della risposta propria',
+    'una risposta ricevuta mostra in blu il proprio Honoo salvato dalla Luna',
     (tester) async {
       tester.view.devicePixelRatio = 1;
       tester.view.physicalSize = const Size(600, 900);
@@ -426,8 +428,8 @@ void main() {
       final reply = ConversationEntry.honoo(
         honoo(
           id: 'reply-1',
-          text: 'La mia risposta',
-          owner: 'test_user',
+          text: 'Risposta ricevuta',
+          owner: 'other_user',
           createdAt: '2026-07-20T11:00:00Z',
           type: HonooType.answer,
           replyTo: 'moon-root-1',
@@ -456,9 +458,62 @@ void main() {
         tester
             .widget<ColoredBox>(find.byKey(const Key('reply_reveal_parent')))
             .color,
-        HonooColor.tertiary,
+        HonooColor.background,
       );
       expect(borderWithColor(HonooColor.secondary), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'una risposta ricevuta mostra in blu il proprio Hinoo salvato dalla Luna',
+    (tester) async {
+      tester.view.devicePixelRatio = 1;
+      tester.view.physicalSize = const Size(600, 900);
+      addTearDown(tester.view.resetDevicePixelRatio);
+      addTearDown(tester.view.resetPhysicalSize);
+
+      final root = hinoo(
+        id: 'saved-hinoo-root',
+        text: 'Hinoo salvato dalla Luna',
+        owner: 'test_user',
+        createdAt: '2026-07-20T10:00:00Z',
+        fromMoon: true,
+      );
+      final reply = ConversationEntry.honoo(
+        honoo(
+          id: 'reply-to-hinoo',
+          text: 'Risposta ricevuta',
+          owner: 'other_user',
+          createdAt: '2026-07-20T11:00:00Z',
+          type: HonooType.answer,
+          replyTo: 'saved-hinoo-root',
+        ),
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: UnifiedThreadView(
+              conversationId: 'conversation-1',
+              maxWidth: 600,
+              maxHeight: 700,
+              isActive: true,
+              currentUserId: 'test_user',
+              conversationLoader: (_) async => [root, reply],
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 600));
+
+      expect(find.byKey(const Key('reply_reveal_parent')), findsOneWidget);
+      expect(
+        tester
+            .widget<ColoredBox>(find.byKey(const Key('reply_reveal_parent')))
+            .color,
+        HonooColor.background,
+      );
     },
   );
 


### PR DESCRIPTION
## Sintesi
- mostra in blu nello Scrigno il contenuto padre appartenente all'utente quando viene rivelata una risposta ricevuta
- mantiene bianco lo stesso contenuto quando viene visualizzato direttamente sulla Luna
- applica la regola sia agli Honoo sia agli Hinoo

## Verifica
- flutter test --no-pub test/widgets/unified_thread_reveal_test.dart test/widgets/conversation_border_test.dart
- flutter analyze --no-pub lib/UI/honoo_card.dart lib/UI/unified_thread_view.dart test/widgets/unified_thread_reveal_test.dart
- git diff --check