### PR TITLE
Use branded loader across content flows

### DIFF
--- a/lib/Pages/admin_menu_page.dart
+++ b/lib/Pages/admin_menu_page.dart
@@ -320,7 +320,7 @@ class _AdminMenuPageState extends State<AdminMenuPage> {
       builder: (context, snapshot) {
         if (snapshot.connectionState != ConnectionState.done) {
           return const HonooScaffold(
-            body: Center(child: LoadingSpinner()),
+            body: Center(child: LoadingSpinner(color: Colors.white)),
           );
         }
 
@@ -393,10 +393,9 @@ class _AdminMenuPageState extends State<AdminMenuPage> {
                                           ? null
                                           : () => _reviewHouseRequest(inviteId, true),
                                       child: reviewing
-                                          ? const SizedBox(
-                                              width: 18,
-                                              height: 18,
-                                              child: CircularProgressIndicator(strokeWidth: 2),
+                                          ? const LoadingSpinner(
+                                              size: 18,
+                                              color: Colors.black,
                                             )
                                           : const Text('Approva'),
                                     ),
@@ -523,13 +522,9 @@ class _AdminMenuPageState extends State<AdminMenuPage> {
                             suffixIcon: _loadingEmails
                                 ? const Padding(
                                     padding: EdgeInsets.all(12),
-                                    child: SizedBox(
-                                      width: 16,
-                                      height: 16,
-                                      child: CircularProgressIndicator(
-                                        strokeWidth: 2,
-                                        color: Colors.white,
-                                      ),
+                                    child: LoadingSpinner(
+                                      size: 16,
+                                      color: Colors.white,
                                     ),
                                   )
                                 : null,
@@ -605,7 +600,9 @@ class _AdminMenuPageState extends State<AdminMenuPage> {
                     ),
                     const SizedBox(height: 12),
                     _loadingVisits
-                        ? const Center(child: LoadingSpinner())
+                        ? const Center(
+                            child: LoadingSpinner(color: Colors.white),
+                          )
                         : _VisitsSummary(visits: _visits),
                     const SizedBox(height: 24),
                     Text(
@@ -619,7 +616,9 @@ class _AdminMenuPageState extends State<AdminMenuPage> {
                     ),
                     const SizedBox(height: 12),
                     _loadingMoonCounts
-                        ? const Center(child: LoadingSpinner())
+                        ? const Center(
+                            child: LoadingSpinner(color: Colors.white),
+                          )
                         : _MoonCountsSummary(counts: _moonCounts),
                     const SizedBox(height: 24),
                     Text(
@@ -633,7 +632,9 @@ class _AdminMenuPageState extends State<AdminMenuPage> {
                     ),
                     const SizedBox(height: 12),
                     _loadingDailyCounts
-                        ? const Center(child: LoadingSpinner())
+                        ? const Center(
+                            child: LoadingSpinner(color: Colors.white),
+                          )
                         : _DailyCountsSummary(counts: _dailyCounts),
                   ],
                 ),

--- a/lib/Pages/admin_moon_search_page.dart
+++ b/lib/Pages/admin_moon_search_page.dart
@@ -186,7 +186,9 @@ class _AdminMoonSearchPageState extends State<AdminMoonSearchPage> {
       future: _adminCheck,
       builder: (context, snapshot) {
         if (snapshot.connectionState != ConnectionState.done) {
-          return const HonooScaffold(body: Center(child: LoadingSpinner()));
+          return const HonooScaffold(
+            body: Center(child: LoadingSpinner(color: Colors.white)),
+          );
         }
         final isAdmin = snapshot.data == true;
         if (!isAdmin) {
@@ -222,13 +224,9 @@ class _AdminMoonSearchPageState extends State<AdminMoonSearchPage> {
                     suffixIcon: _loading
                         ? const Padding(
                             padding: EdgeInsets.all(12),
-                            child: SizedBox(
-                              width: 16,
-                              height: 16,
-                              child: CircularProgressIndicator(
-                                strokeWidth: 2,
-                                color: Colors.white,
-                              ),
+                            child: LoadingSpinner(
+                              size: 16,
+                              color: Colors.white,
                             ),
                           )
                         : (_query.isEmpty
@@ -276,7 +274,7 @@ class _AdminMoonSearchPageState extends State<AdminMoonSearchPage> {
       );
     }
     if (_loading) {
-      return const Center(child: LoadingSpinner());
+      return const Center(child: LoadingSpinner(color: Colors.white));
     }
     if (_results.isEmpty) {
       return Center(

--- a/lib/Pages/conversation_page.dart
+++ b/lib/Pages/conversation_page.dart
@@ -98,7 +98,7 @@ class _ConversationPageState extends State<ConversationPage> {
             );
 
         final Widget carousel = _isLoading
-            ? const Center(child: LoadingSpinner())
+            ? const Center(child: LoadingSpinner(color: Colors.white))
             : (_thread.isEmpty
                   ? Center(
                       child: Text(

--- a/lib/Pages/reply_honoo_page.dart
+++ b/lib/Pages/reply_honoo_page.dart
@@ -205,7 +205,7 @@ class _ReplyHonooPageState extends State<ReplyHonooPage> {
             if (_isSending)
               const Padding(
                 padding: EdgeInsets.only(bottom: 16),
-                child: LoadingSpinner(),
+                child: LoadingSpinner(color: Colors.white),
               ),
           ],
         ),

--- a/lib/Pages/shared_conversations_page.dart
+++ b/lib/Pages/shared_conversations_page.dart
@@ -92,7 +92,7 @@ class _SharedConversationsPageState extends State<SharedConversationsPage> {
       ),
       bodyBuilder: (context, viewW, availableH, layoutMode) {
         final Widget threads = _isLoadingRoots
-            ? const Center(child: LoadingSpinner())
+            ? const Center(child: LoadingSpinner(color: Colors.white))
             : (_conversationIds.isEmpty
                   ? Center(
                       child: Text(

--- a/lib/Pages/shared_hinoo_page.dart
+++ b/lib/Pages/shared_hinoo_page.dart
@@ -125,7 +125,7 @@ class _SharedHinooPageState extends State<SharedHinooPage> {
       ),
       bodyBuilder: (context, viewW, availableH, layoutMode) {
         final Widget content = _isLoading
-            ? const Center(child: LoadingSpinner())
+            ? const Center(child: LoadingSpinner(color: Colors.white))
             : (_items.isEmpty
                   ? Center(
                       child: Text(
@@ -416,16 +416,7 @@ class _SharedHinooPageState extends State<SharedHinooPage> {
                                 mainAxisSize: MainAxisSize.min,
                                 children: [
                                   SizedBox(height: 8),
-                                  SizedBox(
-                                    width: 28,
-                                    height: 28,
-                                    child: CircularProgressIndicator(
-                                      strokeWidth: 2.5,
-                                      valueColor: AlwaysStoppedAnimation(
-                                        Colors.white,
-                                      ),
-                                    ),
-                                  ),
+                                  LoadingSpinner(size: 28, color: Colors.white),
                                   SizedBox(height: 16),
                                   Text(
                                     'Apro la conversazione...',

--- a/lib/Pages/shared_honoo_page.dart
+++ b/lib/Pages/shared_honoo_page.dart
@@ -110,7 +110,7 @@ class _SharedHonooPageState extends State<SharedHonooPage> {
           mode: layoutMode,
         );
         final Widget content = _isLoading
-            ? const Center(child: LoadingSpinner())
+            ? const Center(child: LoadingSpinner(color: Colors.white))
             : (_items.isEmpty
                   ? Center(
                       child: Text(

--- a/lib/UI/HinooBuilder/overlays/cambia_sfondo.dart
+++ b/lib/UI/HinooBuilder/overlays/cambia_sfondo.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:honoo/Utility/honoo_colors.dart';
+import 'package:honoo/Widgets/loading_spinner.dart';
 
 class CambiaSfondoOverlay extends StatelessWidget {
   const CambiaSfondoOverlay({
@@ -167,14 +168,7 @@ class CambiaSfondoOverlay extends StatelessWidget {
                     Row(
                       mainAxisAlignment: MainAxisAlignment.center,
                       children: [
-                        const SizedBox(
-                          width: 18,
-                          height: 18,
-                          child: CircularProgressIndicator(
-                            strokeWidth: 2,
-                            color: Colors.white,
-                          ),
-                        ),
+                        const LoadingSpinner(size: 18, color: Colors.white),
                         const SizedBox(width: 10),
                         Text(
                           'Caricamento immagine…',
@@ -267,14 +261,7 @@ class CambiaSfondoOverlay extends StatelessWidget {
               child: Row(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  const SizedBox(
-                    width: 18,
-                    height: 18,
-                    child: CircularProgressIndicator(
-                      strokeWidth: 2,
-                      color: Colors.white,
-                    ),
-                  ),
+                  const LoadingSpinner(size: 18, color: Colors.white),
                   const SizedBox(width: 10),
                   Text(
                     'Caricamento immagine…',

--- a/lib/UI/honoo_builder.dart
+++ b/lib/UI/honoo_builder.dart
@@ -15,6 +15,7 @@ import 'package:honoo/Services/supabase_provider.dart';
 import 'package:honoo/Utility/honoo_colors.dart';
 import 'package:honoo/Utility/typographic_substitutions_formatter.dart';
 import 'package:honoo/Widgets/honoo_dialogs.dart';
+import 'package:honoo/Widgets/loading_spinner.dart';
 import 'package:honoo/Widgets/gallery_save_dialog.dart';
 import 'package:honoo/Widgets/cover_transform_image.dart';
 import 'package:honoo/UI/HinooBuilder/services/download_saver.dart';
@@ -786,13 +787,9 @@ class HonooBuilderState extends State<HonooBuilder> {
               Expanded(
                 child: Center(
                   child: _isUploadingFinal
-                      ? SizedBox(
-                          width: resolvedConfirmIconSize * 0.72,
-                          height: resolvedConfirmIconSize * 0.72,
-                          child: const CircularProgressIndicator(
-                            strokeWidth: 3,
-                            color: HonooColor.onBackground,
-                          ),
+                      ? LoadingSpinner(
+                          size: resolvedConfirmIconSize * 0.72,
+                          color: HonooColor.onBackground,
                         )
                       : Tooltip(
                           message: 'Salva honoo',

--- a/lib/UI/honoo_thread_view.dart
+++ b/lib/UI/honoo_thread_view.dart
@@ -119,7 +119,7 @@ class _HonooThreadViewState extends State<HonooThreadView>
         if (state.isLoading) {
           child = const Center(
             key: ValueKey('thread_loading'),
-            child: LoadingSpinner(),
+            child: LoadingSpinner(color: Colors.white),
           );
         } else if (state.error != null) {
           child = Center(

--- a/lib/UI/unified_thread_view.dart
+++ b/lib/UI/unified_thread_view.dart
@@ -420,7 +420,9 @@ class _UnifiedThreadViewState extends State<UnifiedThreadView>
 
   @override
   Widget build(BuildContext context) {
-    if (_loading) return const Center(child: LoadingSpinner());
+    if (_loading) {
+      return const Center(child: LoadingSpinner(color: Colors.white));
+    }
     if (_entries.isEmpty) {
       return Center(
         child: Padding(

--- a/lib/Widgets/busy_overlay.dart
+++ b/lib/Widgets/busy_overlay.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:honoo/Widgets/honoo_dialogs.dart';
+import 'package:honoo/Widgets/loading_spinner.dart';
 
 class BusyOverlay extends StatelessWidget {
   const BusyOverlay({super.key, this.message = 'Attendi...'});
@@ -15,14 +16,7 @@ class BusyOverlay extends StatelessWidget {
           mainAxisSize: MainAxisSize.min,
           children: [
             const SizedBox(height: 8),
-            const SizedBox(
-              width: 28,
-              height: 28,
-              child: CircularProgressIndicator(
-                strokeWidth: 2.5,
-                valueColor: AlwaysStoppedAnimation(Colors.white),
-              ),
-            ),
+            const LoadingSpinner(size: 28, color: Colors.white),
             const SizedBox(height: 16),
             Text(
               message,

--- a/lib/Widgets/casa_share_dialogs.dart
+++ b/lib/Widgets/casa_share_dialogs.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../Entities/casa_share_mode.dart';
 import 'honoo_dialogs.dart';
+import 'loading_spinner.dart';
 
 class CasaMultiShareDialog extends StatefulWidget {
   const CasaMultiShareDialog({super.key, required this.onConfirm});
@@ -91,15 +92,7 @@ class _CasaMultiShareDialogState extends State<CasaMultiShareDialog> {
                   child: Row(
                     mainAxisSize: MainAxisSize.min,
                     children: [
-                      const SizedBox(
-                        width: 16,
-                        height: 16,
-                        child: CircularProgressIndicator(
-                          strokeWidth: 2,
-                          valueColor: AlwaysStoppedAnimation(Colors.black),
-                          backgroundColor: Colors.white,
-                        ),
-                      ),
+                      const LoadingSpinner(size: 16, color: Colors.black),
                       const SizedBox(width: 10),
                       Text(
                         'Salvo...',

--- a/lib/Widgets/loading_spinner.dart
+++ b/lib/Widgets/loading_spinner.dart
@@ -7,13 +7,15 @@ class LoadingSpinner extends StatefulWidget {
   const LoadingSpinner({
     super.key,
     this.size = 50.0,
-    this.color,
+    this.color = Colors.black,
     this.semanticsLabel,
     this.rotationDuration = const Duration(milliseconds: 900),
   });
 
   final double size;
-  final Color? color;
+
+  /// Nero sulle superfici chiare; passare bianco sui fondi scuri.
+  final Color color;
   final String? semanticsLabel;
   final Duration rotationDuration;
 
@@ -59,9 +61,7 @@ class _LoadingSpinnerState extends State<LoadingSpinner>
       width: widget.size,
       height: widget.size,
       semanticsLabel: semantics,
-      colorFilter: widget.color != null
-          ? ColorFilter.mode(widget.color!, BlendMode.srcIn)
-          : null,
+      colorFilter: ColorFilter.mode(widget.color, BlendMode.srcIn),
     );
 
     return SizedBox(

--- a/test/widgets/loading_spinner_test.dart
+++ b/test/widgets/loading_spinner_test.dart
@@ -1,0 +1,50 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:honoo/Widgets/loading_spinner.dart';
+
+void main() {
+  testWidgets('usa load.svg in nero per impostazione predefinita', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(home: Scaffold(body: LoadingSpinner(size: 32))),
+    );
+
+    final spinner = tester.widget<LoadingSpinner>(find.byType(LoadingSpinner));
+    final svg = tester.widget<SvgPicture>(find.byType(SvgPicture));
+
+    expect(spinner.color, Colors.black);
+    expect(svg.width, 32);
+    expect(svg.height, 32);
+    expect(svg.colorFilter, isNotNull);
+  });
+
+  test('i loader dell app non usano indicatori Material predefiniti', () {
+    final dartFiles = Directory('lib')
+        .listSync(recursive: true)
+        .whereType<File>()
+        .where((file) => file.path.endsWith('.dart'));
+
+    for (final file in dartFiles) {
+      final source = file.readAsStringSync();
+      expect(
+        source,
+        isNot(contains('CircularProgressIndicator')),
+        reason: '${file.path} deve usare LoadingSpinner con load.svg',
+      );
+      expect(
+        source,
+        isNot(contains('LinearProgressIndicator')),
+        reason: '${file.path} deve usare LoadingSpinner con load.svg',
+      );
+      expect(
+        source,
+        isNot(contains('CupertinoActivityIndicator')),
+        reason: '${file.path} deve usare LoadingSpinner con load.svg',
+      );
+    }
+  });
+}


### PR DESCRIPTION
## Sintesi
- sostituisce tutti gli indicatori di caricamento Material con il loader condiviso basato su assets/icons/load.svg
- usa il loader nero sulle superfici bianche e bianco sui fondi scuri blu/rossi
- imposta il nero come colore predefinito di LoadingSpinner
- aggiunge una regressione che impedisce di reintrodurre indicatori Material/Cupertino predefiniti

## Verifiche
- flutter test test/widgets/loading_spinner_test.dart
- flutter analyze