### PR TITLE
Fix chest conversations and responsive toolbar

### DIFF
--- a/lib/Services/chest_repository.dart
+++ b/lib/Services/chest_repository.dart
@@ -34,8 +34,8 @@ class ChestRepository {
           .select(
             'id,pages,type,reply_to,recipient_tag,created_at,is_from_moon_saved,user_id,conversation_id',
           )
-          .eq('user_id', userId)
           .in_('type', ['personal', 'answer'])
+          .or('user_id.eq.$userId,and(type.eq.answer,recipient_tag.eq.$userId)')
           .order('created_at', ascending: false);
       return _asList(rows);
     } on PostgrestException catch (error) {
@@ -48,8 +48,8 @@ class ChestRepository {
           .select(
             'id,pages,type,reply_to,recipient_tag,created_at,user_id,conversation_id',
           )
-          .eq('user_id', userId)
           .in_('type', ['personal', 'answer'])
+          .or('user_id.eq.$userId,and(type.eq.answer,recipient_tag.eq.$userId)')
           .order('created_at', ascending: false);
       return _asList(rows);
     }

--- a/lib/Services/honoo_service.dart
+++ b/lib/Services/honoo_service.dart
@@ -21,46 +21,58 @@ class HonooService {
 
   /// Honoo pubblici (Luna)
   static Future<List<Honoo>> fetchPublicHonoo() async {
-    final response = await _reliability.read(() async => await _client
-        .from('honoo')
-        .select('*')
-        .eq('destination', 'moon')
-        .order('created_at', ascending: false));
+    final response = await _reliability.read(
+      () async => await _client
+          .from('honoo')
+          .select('*')
+          .eq('destination', 'moon')
+          .order('created_at', ascending: false),
+    );
     return (response as List).map((e) => Honoo.fromMap(e)).toList();
   }
 
   /// Honoo dell’utente per una certa destination (es. 'chest')
   static Future<List<Honoo>> fetchUserHonoo(
-      String userId, String destination) async {
-    final response = await _reliability.read(() async => await _client
-        .from('honoo')
-        .select('*')
-        .eq('destination', destination)
-        .eq('user_id', userId)
-        .order('created_at', ascending: false));
+    String userId,
+    String destination,
+  ) async {
+    final response = await _reliability.read(
+      () async => await _client
+          .from('honoo')
+          .select('*')
+          .eq('destination', destination)
+          .eq('user_id', userId)
+          .order('created_at', ascending: false),
+    );
     return (response as List).map((e) => Honoo.fromMap(e)).toList();
   }
 
-  /// Radici personali e risposte scritte dall'utente che devono comparire
-  /// come un solo accesso alla relativa conversazione nello Scrigno.
+  /// Radici personali e risposte inviate o ricevute che devono comparire
+  /// come un solo accesso persistente alla conversazione nello Scrigno.
   static Future<List<Honoo>> fetchUserChestHonoo(String userId) async {
-    final response = await _reliability.read(() async => await _client
-        .from('honoo')
-        .select('*')
-        .eq('user_id', userId)
-        .in_('destination', ['chest', 'reply']).order('created_at',
-            ascending: false));
+    final response = await _reliability.read(
+      () async => await _client
+          .from('honoo')
+          .select('*')
+          .in_('destination', ['chest', 'reply'])
+          .or(
+            'user_id.eq.$userId,and(destination.eq.reply,recipient_tag.eq.$userId)',
+          )
+          .order('created_at', ascending: false),
+    );
     return (response as List).map((e) => Honoo.fromMap(e)).toList();
   }
 
   /// Tutte le reply indirizzate a recipientTag (se usi i tag poetici)
   static Future<List<Honoo>> fetchRepliesForUser(String recipientTag) async {
-    final response = await _reliability.read(() async => await _client
-        .from('honoo')
-        .select('*')
-        .eq('destination', 'reply')
-        .eq('recipient_tag', recipientTag)
-        .order('created_at', ascending: false));
+    final response = await _reliability.read(
+      () async => await _client
+          .from('honoo')
+          .select('*')
+          .eq('destination', 'reply')
+          .eq('recipient_tag', recipientTag)
+          .order('created_at', ascending: false),
+    );
     return (response as List).map((e) => Honoo.fromMap(e)).toList();
   }
 
@@ -75,11 +87,13 @@ class HonooService {
   static Future<String> publishHonooAndReturnId(Honoo honoo) async {
     _validateConversationLink(honoo);
     Map<String, dynamic>? row;
-    row = await _reliability.write(() async => await _client
-        .from('honoo')
-        .insert(honoo.toInsertMap())
-        .select('id')
-        .maybeSingle());
+    row = await _reliability.write(
+      () async => await _client
+          .from('honoo')
+          .insert(honoo.toInsertMap())
+          .select('id')
+          .maybeSingle(),
+    );
     final id = row?['id']?.toString() ?? '';
     if (id.isEmpty) {
       throw Exception('publishHonoo: id mancante');
@@ -103,9 +117,12 @@ class HonooService {
     required String id,
     required String destination,
   }) async {
-    await _reliability.write(() async => await _client.from('honoo').update({
-          'destination': destination,
-        }).eq('id', id));
+    await _reliability.write(
+      () async => await _client
+          .from('honoo')
+          .update({'destination': destination})
+          .eq('id', id),
+    );
   }
 
   /// Duplica un honoo salvandolo nello scrigno dell'utente corrente.

--- a/lib/Widgets/chest_footer.dart
+++ b/lib/Widgets/chest_footer.dart
@@ -70,12 +70,10 @@ class ChestFooter extends StatelessWidget {
     );
 
     final selectedEntry = selectedConversationEntry;
-    if (_canReplyTo(selectedEntry)) {
+    if (_canReplyTo(selectedEntry) &&
+        !actions.any((action) => action.tooltip == 'Rispondi')) {
       actions.add(
-        _replyAction(
-          () => onReplyToConversationEntry(selectedEntry!),
-          color: Colors.white,
-        ),
+        _replyAction(() => onReplyToConversationEntry(selectedEntry!)),
       );
     }
 
@@ -102,17 +100,6 @@ class ChestFooter extends StatelessWidget {
         !isOnMoon &&
         selectedEntryToPublish == null) {
       actions.add(_moonAction(() => onSendHonooToMoon(honoo)));
-    } else if (hasReplies &&
-        !isFromMoonSaved &&
-        selectedConversationEntry == null) {
-      actions.add(
-        _action(
-          asset: 'assets/icons/reply.svg',
-          label: 'Reply',
-          tooltip: 'Vedi risposte',
-          onPressed: () {},
-        ),
-      );
     } else if (isFromMoonSaved) {
       actions.add(_replyAction(() => onReplyToHonoo(honoo)));
     }

--- a/lib/Widgets/responsive_footer_bar.dart
+++ b/lib/Widgets/responsive_footer_bar.dart
@@ -67,11 +67,18 @@ class ResponsiveFooterBar extends StatelessWidget {
             0,
             (sum, action) => sum + action.size,
           );
+          final double iconScale =
+              availableWidth.isFinite &&
+                  totalIconWidth > availableWidth &&
+                  totalIconWidth > 0
+              ? availableWidth / totalIconWidth
+              : 1;
+          final double fittedIconWidth = totalIconWidth * iconScale;
           final int gapCount = math.max(0, actions.length - 1);
           double gap = effectiveDesiredGap;
 
           if (availableWidth.isFinite && gapCount > 0) {
-            final double maxGap = (availableWidth - totalIconWidth) / gapCount;
+            final double maxGap = (availableWidth - fittedIconWidth) / gapCount;
             if (lockGapWhenPossible && maxGap >= effectiveDesiredGap) {
               gap = effectiveDesiredGap;
             } else if (maxGap <= effectiveMinGap) {
@@ -95,7 +102,10 @@ class ResponsiveFooterBar extends StatelessWidget {
                     : MainAxisSize.min,
                 children: [
                   for (int index = 0; index < actions.length; index++) ...[
-                    _FooterIconButton(action: actions[index]),
+                    _FooterIconButton(
+                      action: actions[index],
+                      size: actions[index].size * iconScale,
+                    ),
                     if (!expandToAvailableWidth && index < actions.length - 1)
                       SizedBox(width: gap),
                   ],
@@ -116,31 +126,33 @@ class ResponsiveFooterBar extends StatelessWidget {
 }
 
 class _FooterIconButton extends StatelessWidget {
-  const _FooterIconButton({required this.action});
+  const _FooterIconButton({required this.action, required this.size});
 
   final ResponsiveFooterAction action;
+  final double size;
 
   @override
   Widget build(BuildContext context) {
-    final Widget iconWidget =
-        action.icon ??
-        SvgPicture.asset(
-          action.asset,
-          semanticsLabel: action.semanticsLabel,
-          colorFilter: action.colorFilter,
-          width: action.size,
-          height: action.size,
-        );
+    final Widget iconWidget = action.icon == null
+        ? SvgPicture.asset(
+            action.asset,
+            semanticsLabel: action.semanticsLabel,
+            colorFilter: action.colorFilter,
+            width: size,
+            height: size,
+          )
+        : SizedBox.square(
+            dimension: size,
+            child: FittedBox(child: action.icon),
+          );
 
     return IconButton(
-      constraints: BoxConstraints.tightFor(
-        width: action.size,
-        height: action.size,
-      ),
+      visualDensity: VisualDensity.compact,
+      constraints: BoxConstraints.tightFor(width: size, height: size),
       padding: EdgeInsets.zero,
       icon: iconWidget,
-      iconSize: action.size,
-      splashRadius: action.splashRadius ?? action.size * 0.5,
+      iconSize: size,
+      splashRadius: math.min(action.splashRadius ?? size * 0.5, size * 0.5),
       tooltip: action.tooltip,
       onPressed: action.onPressed,
     );

--- a/test/services/chest_repository_test.dart
+++ b/test/services/chest_repository_test.dart
@@ -21,33 +21,39 @@ void main() {
 
   test('fetchHinooRows mantiene filtri e ordinamento dello Scrigno', () async {
     final rows = <Map<String, dynamic>>[
-      {'id': 'h-1', 'pages': <dynamic>[]}
+      {'id': 'h-1', 'pages': <dynamic>[]},
     ];
     hinoo.queueResponse(rows);
 
     final result = await repository.fetchHinooRows('user-1');
 
     expect(result, rows);
-    verify(() => hinoo.eq('user_id', 'user-1')).called(1);
     verify(() => hinoo.in_('type', ['personal', 'answer'])).called(1);
+    verify(
+      () => hinoo.or(
+        'user_id.eq.user-1,and(type.eq.answer,recipient_tag.eq.user-1)',
+      ),
+    ).called(1);
     verify(() => hinoo.order('created_at', ascending: false)).called(1);
   });
 
-  test('fetchHinooMoonFingerprints restituisce i fingerprint pubblicati',
-      () async {
-    hinoo.queueResponse([
-      {'fingerprint': 'fp-1'},
-      {'fingerprint': null},
-      {'fingerprint': 'fp-2'},
-    ]);
+  test(
+    'fetchHinooMoonFingerprints restituisce i fingerprint pubblicati',
+    () async {
+      hinoo.queueResponse([
+        {'fingerprint': 'fp-1'},
+        {'fingerprint': null},
+        {'fingerprint': 'fp-2'},
+      ]);
 
-    final result = await repository.fetchHinooMoonFingerprints('user-1');
+      final result = await repository.fetchHinooMoonFingerprints('user-1');
 
-    expect(result, {'fp-1', 'fp-2'});
-    verify(() => hinoo.select('fingerprint')).called(1);
-    verify(() => hinoo.eq('user_id', 'user-1')).called(1);
-    verify(() => hinoo.eq('type', 'moon')).called(1);
-  });
+      expect(result, {'fp-1', 'fp-2'});
+      verify(() => hinoo.select('fingerprint')).called(1);
+      verify(() => hinoo.eq('user_id', 'user-1')).called(1);
+      verify(() => hinoo.eq('type', 'moon')).called(1);
+    },
+  );
 
   test('deleteHinoo elimina esclusivamente la riga indicata', () async {
     hinoo.queueResponse(<String, dynamic>{});

--- a/test/services/honoo_service_test.dart
+++ b/test/services/honoo_service_test.dart
@@ -51,8 +51,11 @@ void main() {
     when(() => chain.insert(any())).thenAnswer((_) => chain);
     when(() => chain.delete()).thenAnswer((_) => chain);
     when(() => chain.eq(any(), any())).thenAnswer((_) => chain);
-    when(() => chain.order(any(), ascending: any(named: 'ascending')))
-        .thenAnswer((_) => chain);
+    when(() => chain.in_(any(), any())).thenAnswer((_) => chain);
+    when(() => chain.or(any())).thenAnswer((_) => chain);
+    when(
+      () => chain.order(any(), ascending: any(named: 'ascending')),
+    ).thenAnswer((_) => chain);
   });
 
   tearDown(() {
@@ -60,41 +63,43 @@ void main() {
     resetMocktailState();
   });
 
-  test('fetchPublicHonoo: filtra destination=moon e ordina per created_at desc',
-      () async {
-    final rows = [
-      {
-        'id': 2,
-        'text': '“b”',
-        'image_url': '',
-        'created_at': '2024-01-02T00:00:00Z',
-        'updated_at': '2024-01-02T00:00:00Z',
-        'user_id': 'u2',
-        'type': 'personal',
-      },
-      {
-        'id': 1,
-        'text': '“a”',
-        'image_url': '',
-        'created_at': '2024-01-01T00:00:00Z',
-        'updated_at': '2024-01-01T00:00:00Z',
-        'user_id': 'u1',
-        'type': 'personal',
-      },
-    ];
-    chain.queueResponse(rows);
+  test(
+    'fetchPublicHonoo: filtra destination=moon e ordina per created_at desc',
+    () async {
+      final rows = [
+        {
+          'id': 2,
+          'text': '“b”',
+          'image_url': '',
+          'created_at': '2024-01-02T00:00:00Z',
+          'updated_at': '2024-01-02T00:00:00Z',
+          'user_id': 'u2',
+          'type': 'personal',
+        },
+        {
+          'id': 1,
+          'text': '“a”',
+          'image_url': '',
+          'created_at': '2024-01-01T00:00:00Z',
+          'updated_at': '2024-01-01T00:00:00Z',
+          'user_id': 'u1',
+          'type': 'personal',
+        },
+      ];
+      chain.queueResponse(rows);
 
-    final list = await HonooService.fetchPublicHonoo();
+      final list = await HonooService.fetchPublicHonoo();
 
-    expect(list, isA<List<Honoo>>());
-    expect(list.length, 2);
-    expect(list.first.dbId, '2');
+      expect(list, isA<List<Honoo>>());
+      expect(list.length, 2);
+      expect(list.first.dbId, '2');
 
-    verify(() => client.from('honoo')).called(1);
-    verify(() => chain.select('*')).called(1);
-    verify(() => chain.eq('destination', 'moon')).called(1);
-    verify(() => chain.order('created_at', ascending: false)).called(1);
-  });
+      verify(() => client.from('honoo')).called(1);
+      verify(() => chain.select('*')).called(1);
+      verify(() => chain.eq('destination', 'moon')).called(1);
+      verify(() => chain.order('created_at', ascending: false)).called(1);
+    },
+  );
 
   test('deleteHonooById: chiama delete().eq("id", id) e completa', () async {
     chain.queueResponse(<String, dynamic>{});
@@ -105,6 +110,23 @@ void main() {
     verify(() => chain.delete()).called(1);
     verify(() => chain.eq('id', '123')).called(1);
   });
+
+  test(
+    'fetchUserChestHonoo include risposte ricevute oltre ai contenuti propri',
+    () async {
+      chain.queueResponse(<Map<String, dynamic>>[]);
+
+      await HonooService.fetchUserChestHonoo('user-1');
+
+      verify(() => chain.in_('destination', ['chest', 'reply'])).called(1);
+      verify(
+        () => chain.or(
+          'user_id.eq.user-1,and(destination.eq.reply,recipient_tag.eq.user-1)',
+        ),
+      ).called(1);
+      verify(() => chain.order('created_at', ascending: false)).called(1);
+    },
+  );
 
   test('publishHonoo: reply inserisce reply_to e recipient_tag', () async {
     chain.queueResponse(<String, dynamic>{});
@@ -123,8 +145,9 @@ void main() {
 
     await HonooService.publishHonoo(honoo);
 
-    final captured = verify(() => chain.insert(captureAny())).captured.single
-        as Map<String, dynamic>;
+    final captured =
+        verify(() => chain.insert(captureAny())).captured.single
+            as Map<String, dynamic>;
     expect(captured['destination'], 'reply');
     expect(captured['reply_to'], 'root-1');
     expect(captured['recipient_tag'], 'recipient-1');
@@ -142,10 +165,7 @@ void main() {
       HonooType.personal,
     )..isFromMoonSaved = true;
 
-    await expectLater(
-      HonooService.duplicateToMoon(honoo),
-      throwsArgumentError,
-    );
+    await expectLater(HonooService.duplicateToMoon(honoo), throwsArgumentError);
     verifyNever(() => client.from('honoo'));
   });
 }

--- a/test/widgets/chest_footer_test.dart
+++ b/test/widgets/chest_footer_test.dart
@@ -63,29 +63,38 @@ void main() {
     ConversationEntry? selectedConversationEntry,
     ValueChanged<ConversationEntry>? onReplyToConversationEntry,
     ValueChanged<ConversationEntry>? onSendConversationEntryToMoon,
+    Color foregroundColor = HonooColor.onBackground,
+    double width = 800,
+    double iconSize = 40,
   }) async {
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
-          body: ChestFooter(
-            item: item,
-            selectedConversationEntry: selectedConversationEntry,
-            currentUserId: 'current-user',
-            iconSize: 40,
-            gap: 24,
-            bottomPadding: 10,
-            onHome: () {},
-            onInfo: () {},
-            onSendHonooToMoon: onSendHonooToMoon ?? (_) {},
-            onReplyToHonoo: (_) {},
-            onDeleteHonoo: onDeleteHonoo ?? (_) {},
-            onSendHinooToMoon: onSendHinooToMoon ?? (_) {},
-            onReplyToHinoo: (_) {},
-            onDeleteHinoo: onDeleteHinoo ?? (_) {},
-            onReplyToConversationEntry:
-                onReplyToConversationEntry ?? (ConversationEntry _) {},
-            onSendConversationEntryToMoon:
-                onSendConversationEntryToMoon ?? (ConversationEntry _) {},
+          body: Align(
+            child: SizedBox(
+              width: width,
+              child: ChestFooter(
+                item: item,
+                selectedConversationEntry: selectedConversationEntry,
+                currentUserId: 'current-user',
+                iconSize: iconSize,
+                gap: 24,
+                bottomPadding: 10,
+                foregroundColor: foregroundColor,
+                onHome: () {},
+                onInfo: () {},
+                onSendHonooToMoon: onSendHonooToMoon ?? (_) {},
+                onReplyToHonoo: (_) {},
+                onDeleteHonoo: onDeleteHonoo ?? (_) {},
+                onSendHinooToMoon: onSendHinooToMoon ?? (_) {},
+                onReplyToHinoo: (_) {},
+                onDeleteHinoo: onDeleteHinoo ?? (_) {},
+                onReplyToConversationEntry:
+                    onReplyToConversationEntry ?? (ConversationEntry _) {},
+                onSendConversationEntryToMoon:
+                    onSendConversationEntryToMoon ?? (ConversationEntry _) {},
+              ),
+            ),
           ),
         ),
       ),
@@ -130,18 +139,17 @@ void main() {
     );
   });
 
-  testWidgets('anche Vedi risposte resta bianca', (tester) async {
+  testWidgets('non aggiunge una finta seconda azione per vedere le risposte', (
+    tester,
+  ) async {
     await pumpFooter(
       tester,
       item: honooItem(HonooType.personal, hasReplies: true),
     );
 
-    final icons = tester
-        .widgetList<SvgPicture>(find.byType(SvgPicture))
-        .toList();
-    expect(find.byTooltip('Vedi risposte'), findsOneWidget);
-    expect(icons, hasLength(4));
-    expect(icons.every((icon) => icon.colorFilter != null), isTrue);
+    expect(find.byTooltip('Vedi risposte'), findsNothing);
+    expect(find.byTooltip('Rispondi'), findsNothing);
+    expect(find.byType(IconButton), findsNWidgets(3));
   });
 
   testWidgets('Honoo personale mostra Luna e Cancella e inoltra le azioni', (
@@ -287,6 +295,71 @@ void main() {
       expect(find.byTooltip('Rispondi'), findsOneWidget);
     },
   );
+
+  testWidgets('non duplica Rispondi tra contenuto e selezione', (tester) async {
+    final item = honooItem(
+      HonooType.personal,
+      isFromMoonSaved: true,
+      conversationId: 'conversation-1',
+    );
+    item.honoo!.dbId = 'root-1';
+
+    await pumpFooter(
+      tester,
+      item: item,
+      selectedConversationEntry: ConversationEntry.honoo(item.honoo!),
+    );
+
+    expect(find.byTooltip('Rispondi'), findsOneWidget);
+  });
+
+  testWidgets('Rispondi usa il contrasto corrente anche sullo sfondo bianco', (
+    tester,
+  ) async {
+    final item = honooItem(
+      HonooType.personal,
+      isFromMoonSaved: true,
+      conversationId: 'conversation-1',
+    );
+
+    await pumpFooter(
+      tester,
+      item: item,
+      foregroundColor: HonooColor.onTertiary,
+    );
+
+    final replyIcon = tester.widget<SvgPicture>(
+      find.descendant(
+        of: find.byTooltip('Rispondi'),
+        matching: find.byType(SvgPicture),
+      ),
+    );
+    expect(
+      replyIcon.colorFilter,
+      const ColorFilter.mode(HonooColor.onTertiary, BlendMode.srcIn),
+    );
+  });
+
+  testWidgets('tutte le azioni restano visibili su una toolbar stretta', (
+    tester,
+  ) async {
+    final item = honooItem(
+      HonooType.personal,
+      conversationId: 'conversation-1',
+    );
+    item.honoo!.dbId = 'root-1';
+
+    await pumpFooter(
+      tester,
+      item: item,
+      selectedConversationEntry: ConversationEntry.honoo(item.honoo!),
+      width: 200,
+      iconSize: 60,
+    );
+
+    expect(find.byType(IconButton), findsNWidgets(5));
+    expect(tester.takeException(), isNull);
+  });
 
   testWidgets('Hinoo già sulla Luna non mostra una seconda azione Luna', (
     tester,


### PR DESCRIPTION
## Cosa cambia
- mantiene nello scrigno anche le conversazioni lette, ordinate insieme agli altri contenuti
- conserva il blu per le proprie risposte e il rosso per quelle ricevute
- elimina le azioni Rispondi duplicate e corregge il contrasto delle icone
- adatta dimensioni e spaziatura della toolbar agli schermi telefonici stretti

## Verifiche
- flutter analyze --no-pub
- 51 test mirati su repository, controller, ordinamento, conversazioni e toolbar