### PR TITLE
Refine chest reply and landing layout

### DIFF
--- a/lib/Pages/placeholder_page.dart
+++ b/lib/Pages/placeholder_page.dart
@@ -50,9 +50,9 @@ class _PlaceholderPageState extends State<PlaceholderPage> {
   static const double _honooBottomSpacing = 15;
   static const double _libriTopSpacing = 5;
   static const double _libriBottomSpacing = 30;
-  static const double _regiaAgentiTopSpacing = _podcastTopSpacing;
-  static const double _regiaAgentiBottomSpacing = _podcastBottomSpacing;
-  static const double _regiaAgentiIconSizeReduction = 3;
+  static const double _regiaAgentiTopSpacing = 18 * 1.3;
+  static const double _regiaAgentiBottomSpacing = 0;
+  static const double _regiaAgentiIconSizeReduction = 8;
   static const Color _linkIconColor = Color.fromRGBO(183, 183, 206, 1);
 
   List<Widget> _iconBlockWithSpacing(
@@ -195,7 +195,7 @@ class _PlaceholderPageState extends State<PlaceholderPage> {
     const String esplorazioniLine = 'esplorazioni lunari';
     const String festeLine = 'feste';
     const String viaggiLine = "viaggi sull'Isola delle Storie";
-    const String podcastLine = 'podcast e dirette';
+    const String podcastLine = 'Podcast e dirette';
     const String libriLine = 'libri';
     const String regiaAgentiLine = 'Regia degli Agenti';
     const String venceslaoLine = 'Venceslao Cembalo';

--- a/lib/Widgets/chest_footer.dart
+++ b/lib/Widgets/chest_footer.dart
@@ -138,7 +138,8 @@ class ChestFooter extends StatelessWidget {
       entry != null &&
       entry.kind != ConversationEntryKind.deleted &&
       entry.id != null &&
-      entry.id!.isNotEmpty;
+      entry.id!.isNotEmpty &&
+      (entry.ownerId != currentUserId || entry.isFromMoonSaved);
 
   void _addHinooActions(
     List<ResponsiveFooterAction> actions,

--- a/test/pages/regia_agenti_page_test.dart
+++ b/test/pages/regia_agenti_page_test.dart
@@ -31,7 +31,7 @@ void main() {
     );
     expect(aiIcon, findsOneWidget);
     final svg = tester.widget<SvgPicture>(aiIcon);
-    expect(svg.height, 57);
+    expect(svg.height, 52);
     expect(
       svg.colorFilter,
       const ColorFilter.mode(Color.fromRGBO(183, 183, 206, 1), BlendMode.srcIn),
@@ -40,13 +40,11 @@ void main() {
       tester
           .getSize(find.byKey(const Key('regia_agenti_icon_top_spacing')))
           .height,
-      5,
+      closeTo(23.4, 0.001),
     );
     expect(
-      tester
-          .getSize(find.byKey(const Key('regia_agenti_icon_bottom_spacing')))
-          .height,
-      30,
+      find.byKey(const Key('regia_agenti_icon_bottom_spacing')),
+      findsNothing,
     );
 
     final visibleTexts = tester
@@ -56,7 +54,7 @@ void main() {
         .toList();
     final viaggiIndex = visibleTexts.indexOf("viaggi sull'Isola delle Storie");
     final regiaIndex = visibleTexts.indexOf('Regia degli Agenti');
-    final podcastIndex = visibleTexts.indexOf('podcast e dirette');
+    final podcastIndex = visibleTexts.indexOf('Podcast e dirette');
     expect(regiaIndex, viaggiIndex + 1);
     expect(regiaIndex, lessThan(podcastIndex));
 

--- a/test/widgets/chest_footer_test.dart
+++ b/test/widgets/chest_footer_test.dart
@@ -217,7 +217,7 @@ void main() {
   });
 
   testWidgets(
-    'la selezione del padre della conversazione mostra una sola azione Luna',
+    'la selezione di un proprio Honoo non mostra Rispondi',
     (tester) async {
       final item = honooItem(
         HonooType.personal,
@@ -235,7 +235,7 @@ void main() {
       );
 
       expect(find.byTooltip('Spedisci sulla Luna'), findsOneWidget);
-      expect(find.byTooltip('Rispondi'), findsOneWidget);
+      expect(find.byTooltip('Rispondi'), findsNothing);
       await tester.tap(find.byTooltip('Spedisci sulla Luna'));
       expect(publishedEntry, same(selectedEntry));
     },
@@ -357,7 +357,8 @@ void main() {
       iconSize: 60,
     );
 
-    expect(find.byType(IconButton), findsNWidgets(5));
+    expect(find.byType(IconButton), findsNWidgets(4));
+    expect(find.byTooltip('Rispondi'), findsNothing);
     expect(tester.takeException(), isNull);
   });
 


### PR DESCRIPTION
## Cosa cambia
- nasconde Rispondi sui propri Honoo/Hinoo creati nello scrigno
- mantiene Rispondi sui contenuti ricevuti o salvati dalla Luna
- dispone Regia degli Agenti, icona e Podcast e dirette con la spaziatura richiesta
- riduce l’icona Regia degli Agenti di altri 5 punti

## Verifiche
- 20 test mirati superati
- flutter analyze mirato senza problemi