### PR TITLE
Allow replies to owned chest content

### DIFF
--- a/lib/Widgets/chest_footer.dart
+++ b/lib/Widgets/chest_footer.dart
@@ -138,8 +138,7 @@ class ChestFooter extends StatelessWidget {
       entry != null &&
       entry.kind != ConversationEntryKind.deleted &&
       entry.id != null &&
-      entry.id!.isNotEmpty &&
-      (entry.ownerId != currentUserId || entry.isFromMoonSaved);
+      entry.id!.isNotEmpty;
 
   void _addHinooActions(
     List<ResponsiveFooterAction> actions,

--- a/test/widgets/chest_footer_test.dart
+++ b/test/widgets/chest_footer_test.dart
@@ -217,7 +217,7 @@ void main() {
   });
 
   testWidgets(
-    'la selezione di un proprio Honoo non mostra Rispondi',
+    'la selezione del padre della conversazione mostra una sola azione Luna',
     (tester) async {
       final item = honooItem(
         HonooType.personal,
@@ -235,7 +235,7 @@ void main() {
       );
 
       expect(find.byTooltip('Spedisci sulla Luna'), findsOneWidget);
-      expect(find.byTooltip('Rispondi'), findsNothing);
+      expect(find.byTooltip('Rispondi'), findsOneWidget);
       await tester.tap(find.byTooltip('Spedisci sulla Luna'));
       expect(publishedEntry, same(selectedEntry));
     },
@@ -357,8 +357,7 @@ void main() {
       iconSize: 60,
     );
 
-    expect(find.byType(IconButton), findsNWidgets(4));
-    expect(find.byTooltip('Rispondi'), findsNothing);
+    expect(find.byType(IconButton), findsNWidgets(5));
     expect(tester.takeException(), isNull);
   });
 


### PR DESCRIPTION
## Cosa cambia
- mantiene Rispondi anche sui propri Honoo e Hinoo nello scrigno
- consente quindi di rispondere a sé stessi
- ripristina il test della toolbar anche su schermi stretti

## Verifiche
- 20 test mirati superati
- flutter analyze mirato senza problemi