### PR TITLE
Use native GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -98,17 +98,20 @@ jobs:
         if: ${{ !inputs.apply_migrations }}
         run: echo "Database migration explicitly disabled for this release."
 
-  build-and-deploy:
-    name: Build and deploy web
+  build-pages:
+    name: Build GitHub Pages artifact
     needs: [validate-release, migrate-production]
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
     steps:
       - uses: actions/checkout@v6
         with:
           ref: ${{ needs.validate-release.outputs.release_sha }}
           fetch-depth: 0
+
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v5
 
       - name: Setup Flutter 3.44.6
         uses: subosito/flutter-action@v2
@@ -139,9 +142,22 @@ jobs:
       - name: Add CNAME for custom domain
         run: echo honoo.it > build/web/CNAME
 
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@v4
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: build/web
-          commit_message: Deploy web build for ${{ needs.validate-release.outputs.release_sha }}
+          path: build/web
+
+  deploy-pages:
+    name: Deploy GitHub Pages
+    needs: build-pages
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy GitHub Pages artifact
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ Essentials for developing and maintaining **honoo** with the current architectur
 | Targets         | Web (primary), Android/iOS/Desktop supported via Flutter scaffolding    |
 | Backend         | Supabase (PostgreSQL + Auth + Storage)                                  |
 | Design Language | Typography via Google Fonts (Lora), extensive SVG assets               |
-| Git Branches    | `main` (source), `gh-pages` (built site), feature branches as needed    |
+| Git Branches    | `main` (source), feature branches as needed                             |
 
 ---
 
@@ -122,10 +122,10 @@ Golden tests rely on `test/test_config.dart` (fixes DPI). If fonts cause 400s, p
   - Workflow: `.github/workflows/deploy-gh-pages.yml`.
   - Trigger: manual dispatch only, with `DEPLOY` confirmation and a commit reachable from `main`.
   - Optional database migration gate runs before the web build; publishing starts only after it succeeds.
-  - Steps: validate release → optional Supabase migrations → Flutter web release build → add `CNAME` (`honoo.it`) → deploy via `peaceiris/actions-gh-pages`.
-  - Environment: `production`, with required reviewers recommended.
+  - Steps: validate release → optional Supabase migrations → Flutter web release build → upload native Pages artifact → deploy via `actions/deploy-pages`.
+  - Environments: `production` for migrations and `github-pages` for the native Pages deployment; required reviewers are recommended.
   - Secrets needed for every release: `PROD_SUPABASE_URL`, `PROD_SUPABASE_ANON_KEY`. Migration releases also need `SUPABASE_ACCESS_TOKEN`, `PROD_SUPABASE_PROJECT_REF`, `PROD_SUPABASE_DB_PASSWORD`.
-* For manual builds, `build/web` mirrors what peanut produced previously. Keep the base href at `/` because `gh-pages` has a `CNAME`.
+* For manual builds, `build/web` mirrors the artifact uploaded to GitHub Pages. Keep the base href at `/` and include the `CNAME` for `honoo.it`.
 * Ensure DNS for `honoo.it` points the apex to GitHub Pages IPs.
 
 ---
@@ -137,7 +137,7 @@ Golden tests rely on `test/test_config.dart` (fixes DPI). If fonts cause 400s, p
   - Jobs: analysis + staging read-only suite, optional CRUD (manual).
 * **Deploy to Pages (`deploy-gh-pages.yml`)**
   - Manual only; validates the selected `main` commit and gates build/deploy on optional production migrations.
-  - Produces the `gh-pages` build.
+  - Publishes `build/web` through the native GitHub Pages artifact and deployment actions; it does not write a `gh-pages` branch.
 * **Live Supabase E2E (`live-supabase-e2e.yml`)**
   - Scheduled daily and manually dispatchable against staging.
   - Always checks conversation CRUD, RLS and Realtime; the browser UI flow is opt-in on manual runs.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,6 +124,7 @@ Golden tests rely on `test/test_config.dart` (fixes DPI). If fonts cause 400s, p
   - Optional database migration gate runs before the web build; publishing starts only after it succeeds.
   - Steps: validate release → optional Supabase migrations → Flutter web release build → upload native Pages artifact → deploy via `actions/deploy-pages`.
   - Environments: `production` for migrations and `github-pages` for the native Pages deployment; required reviewers are recommended.
+  - Repository setting: **Settings → Pages → Build and deployment → Source** must be set to **GitHub Actions** once after migration from branch publishing.
   - Secrets needed for every release: `PROD_SUPABASE_URL`, `PROD_SUPABASE_ANON_KEY`. Migration releases also need `SUPABASE_ACCESS_TOKEN`, `PROD_SUPABASE_PROJECT_REF`, `PROD_SUPABASE_DB_PASSWORD`.
 * For manual builds, `build/web` mirrors the artifact uploaded to GitHub Pages. Keep the base href at `/` and include the `CNAME` for `honoo.it`.
 * Ensure DNS for `honoo.it` points the apex to GitHub Pages IPs.


### PR DESCRIPTION
## Cosa cambia

- sostituisce il push automatico sul branch `gh-pages` con il deployment nativo di GitHub Pages
- configura Pages con `actions/configure-pages@v5`
- carica `build/web` con `actions/upload-pages-artifact@v4`
- pubblica l'artifact con `actions/deploy-pages@v4` e permessi OIDC minimi
- espone l'URL del deployment tramite l'ambiente `github-pages`
- aggiorna la guida del repository per descrivere il nuovo flusso

## Perché

Il deploy manuale usa così lo stesso meccanismo “pages build and deployment” gestito da GitHub, senza scrivere direttamente sul branch `gh-pages`.

## Verifica

- parsing YAML riuscito
- `git diff --check` riuscito
- versioni e struttura confrontate con la documentazione ufficiale GitHub Pages

Non sono stati eseguiti test Flutter perché non è cambiato codice applicativo.