### PR TITLE
Corregge i colori dei contenuti nelle conversazioni

### DIFF
--- a/lib/Utility/chest_content_style.dart
+++ b/lib/Utility/chest_content_style.dart
@@ -77,8 +77,10 @@ class ChestContentStyle {
     }
   }
 
-  /// Nella conversazione un contenuto proveniente dalla Luna identifica
-  /// sempre il contenuto dell'altro autore, anche per i salvataggi storici.
+  /// Nella conversazione ogni contenuto dell'altro autore è rosso.
+  ///
+  /// Un contenuto salvato dalla Luna resta attribuito all'autore originale
+  /// anche quando la copia nello Scrigno è posseduta dall'utente corrente.
   static ChestContentStyle forConversationEntry(
     ConversationEntry entry, {
     String? viewerUserId,
@@ -95,6 +97,10 @@ class ChestContentStyle {
       ConversationEntryKind.deleted => false,
     };
     if (isFromMoon) return receivedReply;
+    final ownerId = entry.ownerId;
+    if (viewerUserId != null && ownerId != null && ownerId != viewerUserId) {
+      return receivedReply;
+    }
     return forEntry(entry, viewerUserId: viewerUserId);
   }
 

--- a/test/widgets/conversation_border_test.dart
+++ b/test/widgets/conversation_border_test.dart
@@ -201,6 +201,30 @@ void main() {
     );
   });
 
+  test('Honoo personale altrui diventa rosso nella conversazione', () {
+    final value = honoo(type: HonooType.personal, owner: 'other_user');
+
+    expect(
+      ChestContentStyle.forConversationEntry(
+        ConversationEntry.honoo(value),
+        viewerUserId: 'test_user',
+      ),
+      same(ChestContentStyle.receivedReply),
+    );
+  });
+
+  test('Honoo personale proprio resta blu nella conversazione', () {
+    final value = honoo(type: HonooType.personal, owner: 'test_user');
+
+    expect(
+      ChestContentStyle.forConversationEntry(
+        ConversationEntry.honoo(value),
+        viewerUserId: 'test_user',
+      ),
+      same(ChestContentStyle.own),
+    );
+  });
+
   testWidgets('Hinoo di risposta proprio non ha cornice', (tester) async {
     final draft = hinoo(fromMoon: true);
     await pumpHinoo(tester, draft: draft, isReply: true, authorId: 'test_user');


### PR DESCRIPTION
## Cosa cambia

- mantiene bianco lo sfondo dei contenuti salvati dalla Luna e non ancora in conversazione
- mantiene blu i contenuti propri, anche quando fanno parte di una conversazione
- assegna lo sfondo rosso a qualsiasi contenuto altrui visualizzato in una conversazione, non solo alle risposte esplicite o ai contenuti marcati come provenienti dalla Luna

## Causa

La selezione dello stile in conversazione controllava la provenienza dalla Luna e il tipo risposta, ma non confrontava in modo generale l'autore del contenuto con l'utente corrente. Un contenuto personale di un altro autore poteva quindi essere mostrato in blu.

## Verifica

- `flutter test test/widgets/conversation_border_test.dart`
- `flutter analyze lib/Utility/chest_content_style.dart test/widgets/conversation_border_test.dart`
- `git diff --check`