### PR TITLE
Mantiene in alto il testo salvato dei campanelli

### DIFF
--- a/lib/Widgets/campanello_card.dart
+++ b/lib/Widgets/campanello_card.dart
@@ -29,7 +29,7 @@ class CampanelloCard extends StatelessWidget {
       fontWeight: FontWeight.w400,
     );
 
-    final Widget text = Padding(
+    final Widget introText = Padding(
       padding: EdgeInsets.symmetric(
         horizontal: HinooTypography.horizontalPadding,
         vertical: verticalPadding,
@@ -39,9 +39,23 @@ class CampanelloCard extends StatelessWidget {
 
     if (data.isIntro) {
       return Center(
-        child: SizedBox(width: width, height: height, child: text),
+        child: SizedBox(width: width, height: height, child: introText),
       );
     }
+
+    final Widget savedText = Padding(
+      padding: EdgeInsets.fromLTRB(
+        HinooTypography.horizontalPadding,
+        HinooTypography.editorTextTopPadding(width),
+        HinooTypography.horizontalPadding,
+        HinooTypography.editorTextBottomPadding,
+      ),
+      child: Align(
+        key: const ValueKey('campanello-saved-text-position'),
+        alignment: Alignment.topCenter,
+        child: _buildText(textStyle),
+      ),
+    );
 
     return Center(
       child: ClipRRect(
@@ -52,11 +66,8 @@ class CampanelloCard extends StatelessWidget {
           child: Stack(
             fit: StackFit.expand,
             children: [
-              Image(
-                image: data.campanello!.backgroundImage,
-                fit: BoxFit.cover,
-              ),
-              text,
+              Image(image: data.campanello!.backgroundImage, fit: BoxFit.cover),
+              savedText,
             ],
           ),
         ),

--- a/test/widgets/campanelli_renderers_test.dart
+++ b/test/widgets/campanelli_renderers_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:honoo/Entities/campanelli_view_data.dart';
+import 'package:honoo/UI/hinoo_typography.dart';
 import 'package:honoo/Widgets/campanello_card.dart';
 import 'package:honoo/Widgets/casa_section.dart';
 
@@ -13,8 +14,9 @@ void main() {
     bgOffsetY: 0,
   );
 
-  testWidgets('campanello introduttivo conserva il collegamento clicca qui',
-      (tester) async {
+  testWidgets('campanello introduttivo conserva il collegamento clicca qui', (
+    tester,
+  ) async {
     var requested = false;
 
     await tester.pumpWidget(
@@ -60,17 +62,28 @@ void main() {
     );
 
     expect(find.text('Un campanello'), findsOneWidget);
+    final savedTextPosition = tester.widget<Align>(
+      find.byKey(const ValueKey('campanello-saved-text-position')),
+    );
+    expect(savedTextPosition.alignment, Alignment.topCenter);
+    final background = find.byWidgetPredicate(
+      (widget) => widget is Image && widget.image == campanello.backgroundImage,
+    );
+    expect(background, findsOneWidget);
     expect(
-      find.byWidgetPredicate(
-        (widget) =>
-            widget is Image && widget.image == campanello.backgroundImage,
-      ),
-      findsOneWidget,
+      tester
+              .getRect(
+                find.byKey(const ValueKey('campanello-saved-text-position')),
+              )
+              .top -
+          tester.getRect(background).top,
+      closeTo(HinooTypography.editorTextTopPadding(320), 0.01),
     );
   });
 
-  testWidgets('casa chiusa conserva messaggio e azione scrigno',
-      (tester) async {
+  testWidgets('casa chiusa conserva messaggio e azione scrigno', (
+    tester,
+  ) async {
     var opened = false;
 
     await tester.pumpWidget(
@@ -106,8 +119,9 @@ void main() {
     expect(opened, isTrue);
   });
 
-  testWidgets('casa aperta mostra lo sfondo senza messaggio di chiusura',
-      (tester) async {
+  testWidgets('casa aperta mostra lo sfondo senza messaggio di chiusura', (
+    tester,
+  ) async {
     await tester.pumpWidget(
       const MaterialApp(
         home: Scaffold(


### PR DESCRIPTION
## Cosa cambia
- ancora in alto il testo dei campanelli salvati invece di ricentrarlo verticalmente
- usa lo stesso margine superiore dell'editor Hinoo
- conserva il centraggio della scheda introduttiva con il link clicca qui

## Verifiche
- flutter test test/widgets/campanelli_renderers_test.dart
- flutter analyze lib/Widgets/campanello_card.dart test/widgets/campanelli_renderers_test.dart