### PR TITLE
Mantiene stabile l’editor Honoo con la tastiera mobile

### DIFF
--- a/lib/Pages/new_honoo_page.dart
+++ b/lib/Pages/new_honoo_page.dart
@@ -381,6 +381,14 @@ class _NewHonooPageState extends State<NewHonooPage> {
     if (mounted) setState(() {});
   }
 
+  Widget _withoutKeyboardInsets(BuildContext context, Widget child) {
+    final MediaQueryData mediaQuery = MediaQuery.of(context);
+    return MediaQuery(
+      data: mediaQuery.copyWith(viewInsets: EdgeInsets.zero),
+      child: child,
+    );
+  }
+
   Future<String?> _resolveFinalImageUrl(String raw) async {
     final s = raw.trim();
     if (s.isEmpty) return null;
@@ -425,6 +433,7 @@ class _NewHonooPageState extends State<NewHonooPage> {
       resizeToAvoidBottomInset: false,
       backgroundColor: HonooColor.background,
       body: SafeArea(
+        maintainBottomViewPadding: true,
         child: LayoutBuilder(
           builder: (context, viewport) {
             final double viewW = viewport.maxWidth;
@@ -493,7 +502,7 @@ class _NewHonooPageState extends State<NewHonooPage> {
             final double footerTop =
                 editorGroupTop + editorGroupHeight + footerTopSpacing;
 
-            return Stack(
+            final Widget content = Stack(
               clipBehavior: Clip.none,
               children: [
                 // ===== HEADER + HONOO (full height) =====
@@ -646,6 +655,7 @@ class _NewHonooPageState extends State<NewHonooPage> {
                 ),
               ],
             );
+            return _withoutKeyboardInsets(context, content);
           },
         ),
       ),

--- a/test/pages/new_honoo_page_test.dart
+++ b/test/pages/new_honoo_page_test.dart
@@ -109,8 +109,8 @@ void main() {
       'Salva sul dispositivo',
     ]) {
       final actionRect = tester.getRect(find.byTooltip(tooltip));
-      expect(actionRect.left, greaterThanOrEqualTo(imageRect.left));
-      expect(actionRect.right, lessThanOrEqualTo(imageRect.right));
+      expect(actionRect.left, greaterThanOrEqualTo(imageRect.left - 0.5));
+      expect(actionRect.right, lessThanOrEqualTo(imageRect.right + 0.5));
     }
   });
 
@@ -133,5 +133,49 @@ void main() {
     expect(find.byTooltip('Apri il tuo Cuore'), findsOneWidget);
     expect(find.byTooltip('Invia'), findsNothing);
     expect(find.byTooltip('Salva sul dispositivo'), findsOneWidget);
+  });
+
+  testWidgets('la tastiera mobile non ridimensiona l’editor honoo', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(390, 844);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    addTearDown(tester.view.resetViewInsets);
+
+    await tester.pumpWidget(
+      Sizer(
+        builder: (context, orientation, deviceType) {
+          return const MaterialApp(home: NewHonooPage());
+        },
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final builder = find.byType(HonooBuilder);
+    tester
+        .state<HonooBuilderState>(builder)
+        .setImageBytesForTesting(
+          base64Decode(
+            'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=',
+          ),
+        );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('honoo-edit-text')));
+    await tester.pump();
+    final Size sizeBeforeKeyboard = tester.getSize(builder);
+
+    tester.view.viewInsets = const FakeViewPadding(bottom: 320);
+    await tester.pump();
+
+    expect(tester.getSize(builder), sizeBeforeKeyboard);
+    expect(
+      MediaQuery.viewInsetsOf(
+        tester.element(find.byType(TextField).first),
+      ).bottom,
+      0,
+    );
   });
 }


### PR DESCRIPTION
## Cosa cambia
- impedisce agli inset della tastiera mobile di ridimensionare la tela Honoo
- mantiene stabile la Safe Area inferiore mentre si modifica il testo
- lascia che la tastiera si sovrapponga alla parte inferiore, senza cambiare il flusso OK, anteprima e salvataggio
- aggiunge un test mobile che verifica dimensioni invariate con tastiera aperta

## Verifiche
- flutter test test/pages/new_honoo_page_test.dart
- flutter analyze lib/Pages/new_honoo_page.dart test/pages/new_honoo_page_test.dart