### PR TITLE
Modifica campanello e casa dal carosello

### DIFF
--- a/lib/Controller/campanelli_controller.dart
+++ b/lib/Controller/campanelli_controller.dart
@@ -159,6 +159,8 @@ class CampanelliController extends ChangeNotifier {
           bgScale: slide.bgScale,
           bgOffsetX: slide.bgOffsetX,
           bgOffsetY: slide.bgOffsetY,
+          campanelloIsTextWhite: slide.isTextWhite,
+          campanelloBgTransform: slide.bgTransform,
         ));
       }
       _publish(CampanelliLoadState(

--- a/lib/Entities/campanelli_entry.dart
+++ b/lib/Entities/campanelli_entry.dart
@@ -12,6 +12,8 @@ class CampanelliEntry {
     required this.bgScale,
     required this.bgOffsetX,
     required this.bgOffsetY,
+    required this.campanelloIsTextWhite,
+    required this.campanelloBgTransform,
   });
 
   final String hinooId;
@@ -23,4 +25,6 @@ class CampanelliEntry {
   final double bgScale;
   final double bgOffsetX;
   final double bgOffsetY;
+  final bool campanelloIsTextWhite;
+  final List<double>? campanelloBgTransform;
 }

--- a/lib/IsolaDelleStorie/Pages/campanelli_page.dart
+++ b/lib/IsolaDelleStorie/Pages/campanelli_page.dart
@@ -35,6 +35,7 @@ import 'package:honoo/Widgets/busy_overlay.dart';
 import 'package:honoo/Services/campanelli_repository.dart';
 
 import '../../Pages/home_page.dart';
+import '../../Pages/casa_builder_page.dart';
 import '../../Pages/shared_conversations_page.dart';
 import '../../Pages/shared_hinoo_page.dart';
 import '../../Pages/shared_honoo_page.dart';
@@ -457,10 +458,72 @@ class _CampanelliPageState extends State<CampanelliPage> {
   }
 
   List<_CampanelloEntry> _buildCampanelli() {
+    final userId = SupabaseProvider.client.auth.currentUser?.id;
+    if (!_hasOwnHouse || userId == null) {
+      return [
+        ..._buildBaseCampanelli(),
+        ..._userEntries,
+      ];
+    }
+
+    final ownEntries = _userEntries
+        .where((entry) => entry.campanello.ownerId == userId)
+        .toList(growable: false);
+    final otherEntries = _userEntries
+        .where((entry) => entry.campanello.ownerId != userId)
+        .toList(growable: false);
     return [
+      ...ownEntries,
       ..._buildBaseCampanelli(),
-      ..._userEntries,
+      ...otherEntries,
     ];
+  }
+
+  HinooDraft _campanelloDraftFor(_CampanelloEntry entry) {
+    return HinooDraft(
+      pages: [
+        HinooSlide(
+          backgroundImage: entry.campanelloBackgroundUrl,
+          text: entry.campanello.text,
+          isTextWhite: entry.campanelloIsTextWhite,
+          bgScale: entry.campanelloBgScale,
+          bgOffsetX: entry.campanelloBgOffsetX,
+          bgOffsetY: entry.campanelloBgOffsetY,
+          bgTransform: entry.campanelloBgTransform,
+        ),
+      ],
+    );
+  }
+
+  Future<void> _editCampanello(_CampanelloEntry entry) async {
+    final String? campanelloId = entry.campanello.campanelloHinooId;
+    if (campanelloId == null || campanelloId.isEmpty) return;
+    final bool? updated = await Navigator.of(context).push<bool>(
+      MaterialPageRoute(
+        builder: (_) => NewHinooPage(
+          isCampanello: true,
+          initialDraft: _campanelloDraftFor(entry),
+          editingCampanelloId: campanelloId,
+        ),
+      ),
+    );
+    if (updated == true && mounted) await _loadUserEntries();
+  }
+
+  Future<void> _editCasa(_CampanelloEntry entry) async {
+    final String? campanelloId = entry.campanello.campanelloHinooId;
+    if (campanelloId == null || campanelloId.isEmpty) return;
+    final bool? updated = await Navigator.of(context).push<bool>(
+      MaterialPageRoute(
+        builder: (_) => CasaBuilderPage(
+          campanello: _campanelloDraftFor(entry),
+          editingCampanelloId: campanelloId,
+          initialHouseImageUrl: entry.houseImageUrl,
+          initialTransform: entry.casa.bgTransform,
+        ),
+      ),
+    );
+    if (updated == true && mounted) await _loadUserEntries();
   }
 
   Future<void> _handleInviteRequestTap() async {
@@ -628,6 +691,13 @@ class _CampanelliPageState extends State<CampanelliPage> {
             bgOffsetX: entry.bgOffsetX,
             bgOffsetY: entry.bgOffsetY,
           ),
+          campanelloBackgroundUrl: entry.campanelloBackgroundUrl,
+          houseImageUrl: entry.houseImageUrl,
+          campanelloIsTextWhite: entry.campanelloIsTextWhite,
+          campanelloBgScale: entry.bgScale,
+          campanelloBgOffsetX: entry.bgOffsetX,
+          campanelloBgOffsetY: entry.bgOffsetY,
+          campanelloBgTransform: entry.campanelloBgTransform,
         );
       }).toList(growable: false);
 
@@ -641,6 +711,18 @@ class _CampanelliPageState extends State<CampanelliPage> {
                 .map((entry) => entry.campanello.id),
           );
         });
+        final bool hasOwnEntry =
+            entries.any((entry) => entry.campanello.ownerId == user.id);
+        if (hasOwnEntry) {
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            if (!mounted || !_campanelloPageController.hasClients) return;
+            _campanelloPageController.jumpToPage(1);
+            setState(() {
+              _campanelloIndex = 1;
+              _lastHouseCampanelloIndex = 1;
+            });
+          });
+        }
       }
       // Verifica inviti pendenti/accettati per nascondere CTA se già invitato
       try {
@@ -1162,6 +1244,18 @@ class _CampanelliPageState extends State<CampanelliPage> {
                                               });
                                             },
                                             itemBuilder: (context, pageIndex) {
+                                              final _CampanelloEntry? entry =
+                                                  pageIndex > 0 &&
+                                                          pageIndex <=
+                                                              campanelli.length
+                                                      ? campanelli[
+                                                          pageIndex - 1]
+                                                      : null;
+                                              final bool isOwnEntry = entry !=
+                                                      null &&
+                                                  user != null &&
+                                                  entry.campanello.ownerId ==
+                                                      user.id;
                                               return CampanelloCard(
                                                 data:
                                                     campanelloPages[pageIndex],
@@ -1169,6 +1263,10 @@ class _CampanelliPageState extends State<CampanelliPage> {
                                                 height: canvasSize.height,
                                                 onRequestTap:
                                                     _handleInviteRequestTap,
+                                                onEditTap: isOwnEntry
+                                                    ? () =>
+                                                        _editCampanello(entry)
+                                                    : null,
                                               );
                                             },
                                           ),
@@ -1224,6 +1322,11 @@ class _CampanelliPageState extends State<CampanelliPage> {
                                       footerBottomSpacing: footerBottomSpacing,
                                       width: casaWidth,
                                       height: casaHeight,
+                                      onEditTap: isOwnCampanello
+                                          ? () => _editCasa(
+                                                campanelli[casaIndex],
+                                              )
+                                          : null,
                                     ),
                                   ),
                                 )
@@ -1241,6 +1344,11 @@ class _CampanelliPageState extends State<CampanelliPage> {
                                     footerBottomSpacing: footerBottomSpacing,
                                     width: casaWidth,
                                     height: casaHeight,
+                                    onEditTap: isOwnCampanello
+                                        ? () => _editCasa(
+                                              campanelli[casaIndex],
+                                            )
+                                        : null,
                                   ),
                                 ),
                         ],
@@ -1248,7 +1356,7 @@ class _CampanelliPageState extends State<CampanelliPage> {
                     ),
                   ),
                 ),
-                if (campanelloPages.length > 1)
+                if (_verticalPageIndex == 0 && campanelloPages.length > 1)
                   Positioned(
                     top: 0,
                     bottom: 0,
@@ -1332,9 +1440,23 @@ class _ArrowIntent extends Intent {
 class _CampanelloEntry {
   final CampanelloData campanello;
   final CasaData casa;
+  final String? campanelloBackgroundUrl;
+  final String? houseImageUrl;
+  final bool campanelloIsTextWhite;
+  final double campanelloBgScale;
+  final double campanelloBgOffsetX;
+  final double campanelloBgOffsetY;
+  final List<double>? campanelloBgTransform;
 
   const _CampanelloEntry({
     required this.campanello,
     required this.casa,
+    this.campanelloBackgroundUrl,
+    this.houseImageUrl,
+    this.campanelloIsTextWhite = true,
+    this.campanelloBgScale = 1,
+    this.campanelloBgOffsetX = 0,
+    this.campanelloBgOffsetY = 0,
+    this.campanelloBgTransform,
   });
 }

--- a/lib/Pages/casa_builder_page.dart
+++ b/lib/Pages/casa_builder_page.dart
@@ -21,9 +21,18 @@ import 'package:image_picker/image_picker.dart';
 import 'home_page.dart';
 
 class CasaBuilderPage extends StatefulWidget {
-  const CasaBuilderPage({super.key, required this.campanello});
+  const CasaBuilderPage({
+    super.key,
+    required this.campanello,
+    this.editingCampanelloId,
+    this.initialHouseImageUrl,
+    this.initialTransform,
+  });
 
   final HinooDraft campanello;
+  final String? editingCampanelloId;
+  final String? initialHouseImageUrl;
+  final List<double>? initialTransform;
 
   @override
   State<CasaBuilderPage> createState() => _CasaBuilderPageState();
@@ -36,6 +45,7 @@ class _CasaBuilderPageState extends State<CasaBuilderPage> {
   ImageProvider? _imageProvider;
   bool _isSaving = false;
   bool _isUploadingImage = false;
+  bool _hasPickedImage = false;
   double _imageScale = 1.0;
   static const double _imageMinScale = 1.0;
   static const double _imageMaxScale = 5.0;
@@ -44,6 +54,15 @@ class _CasaBuilderPageState extends State<CasaBuilderPage> {
   @override
   void initState() {
     super.initState();
+    final String? initialUrl = widget.initialHouseImageUrl;
+    if (initialUrl != null && initialUrl.isNotEmpty) {
+      _imageProvider = NetworkImage(initialUrl);
+    }
+    final List<double>? initialTransform = widget.initialTransform;
+    if (initialTransform != null && initialTransform.length == 16) {
+      _imageController.value = Matrix4.fromList(initialTransform);
+      _imageScale = _extractScaleFromMatrix(_imageController.value);
+    }
     _imageController.addListener(_handleImageTransform);
   }
 
@@ -112,6 +131,7 @@ class _CasaBuilderPageState extends State<CasaBuilderPage> {
       setState(() {
         _imageProvider = MemoryImage(bytes);
         _imageScale = _imageMinScale;
+        _hasPickedImage = true;
       });
       _resetImageTransform();
     } catch (e) {
@@ -165,29 +185,48 @@ class _CasaBuilderPageState extends State<CasaBuilderPage> {
         throw Exception('Utente non autenticato.');
       }
 
-      setState(() => _isUploadingImage = true);
-      final Uint8List? pngBytes = await _captureCasaImage();
-      if (pngBytes == null || pngBytes.isEmpty) {
-        throw Exception('Impossibile generare l\'immagine della casa.');
+      String imageUrl = widget.initialHouseImageUrl ?? '';
+      if (_hasPickedImage || imageUrl.isEmpty) {
+        setState(() => _isUploadingImage = true);
+        final Uint8List? pngBytes = await _captureCasaImage();
+        if (pngBytes == null || pngBytes.isEmpty) {
+          throw Exception('Impossibile generare l\'immagine della casa.');
+        }
+        imageUrl = await HinooStorageUploader.uploadBackground(
+          bytes: pngBytes,
+          ext: 'png',
+          userId: user.id,
+          // Il PNG della casa comprende l'intero canvas e sui collegamenti più
+          // lenti può richiedere più dei 15 secondi usati dagli upload normali.
+          writeTimeout: const Duration(minutes: 1),
+        );
+        setState(() => _isUploadingImage = false);
       }
-      final imageUrl = await HinooStorageUploader.uploadBackground(
-        bytes: pngBytes,
-        ext: 'png',
-        userId: user.id,
-        // Il PNG della casa comprende l'intero canvas e sui collegamenti più
-        // lenti può richiedere più dei 15 secondi usati dagli upload normali.
-        writeTimeout: const Duration(minutes: 1),
-      );
-      setState(() => _isUploadingImage = false);
 
-      await _inviteService.createHouseWithCampanello(
-        campanello: widget.campanello,
-        houseImageUrl: imageUrl,
-        bgTransform: _imageController.value.storage.toList(),
-      );
+      final String? editingId = widget.editingCampanelloId;
+      if (editingId != null && editingId.isNotEmpty) {
+        await _inviteService.updateHouse(
+          campanelloHinooId: editingId,
+          houseImageUrl: imageUrl,
+          bgTransform: _imageController.value.storage.toList(),
+        );
+      } else {
+        await _inviteService.createHouseWithCampanello(
+          campanello: widget.campanello,
+          houseImageUrl: imageUrl,
+          bgTransform: _imageController.value.storage.toList(),
+        );
+      }
 
       if (!mounted) return;
-      showHonooToast(context, message: 'Casa creata.');
+      showHonooToast(
+        context,
+        message: editingId == null ? 'Casa creata.' : 'Casa aggiornata.',
+      );
+      if (editingId != null) {
+        Navigator.of(context).pop(true);
+        return;
+      }
       Navigator.of(context).pushAndRemoveUntil(
         MaterialPageRoute(builder: (_) => const HomePage()),
         (route) => false,

--- a/lib/Pages/new_hinoo_page.dart
+++ b/lib/Pages/new_hinoo_page.dart
@@ -4,6 +4,7 @@ import 'dart:typed_data';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:honoo/Services/supabase_provider.dart';
+import 'package:honoo/Services/house_invite_service.dart';
 
 import 'package:honoo/Utility/honoo_colors.dart';
 import 'package:honoo/Widgets/honoo_dialogs.dart';
@@ -38,6 +39,8 @@ class NewHinooPage extends StatefulWidget {
     this.conversationId,
     this.returnToPreviousOnAnswer = false,
     this.targetContentName = 'hinoo',
+    this.initialDraft,
+    this.editingCampanelloId,
   });
 
   final bool isReply;
@@ -49,6 +52,8 @@ class NewHinooPage extends StatefulWidget {
   final String? conversationId;
   final bool returnToPreviousOnAnswer;
   final String targetContentName;
+  final HinooDraft? initialDraft;
+  final String? editingCampanelloId;
 
   @override
   State<NewHinooPage> createState() => _NewHinooPageState();
@@ -326,6 +331,17 @@ class _NewHinooPageState extends State<NewHinooPage>
       }
 
       if (widget.isCampanello) {
+        final String? editingId = widget.editingCampanelloId;
+        if (editingId != null && editingId.isNotEmpty) {
+          await HouseInviteService().updateCampanello(
+            campanelloHinooId: editingId,
+            campanello: hinooDraft,
+          );
+          if (!mounted) return;
+          showHonooToast(context, message: 'Campanello aggiornato.');
+          Navigator.of(context).pop(true);
+          return;
+        }
         if (!mounted) return;
         Navigator.of(context).pushReplacement(
           MaterialPageRoute(
@@ -765,6 +781,7 @@ class _NewHinooPageState extends State<NewHinooPage>
                                             'per la pagina\n'
                                             'del tuo campanello'
                                       : null,
+                                  initialDraft: widget.initialDraft,
                                 ),
                               ),
                             ),

--- a/lib/Services/house_invite_service.dart
+++ b/lib/Services/house_invite_service.dart
@@ -92,4 +92,28 @@ class HouseInviteService {
     if (id.isEmpty) throw StateError('ID campanello mancante.');
     return id;
   }
+
+  Future<void> updateCampanello({
+    required String campanelloHinooId,
+    required HinooDraft campanello,
+  }) async {
+    await _client
+        .from('hinoo')
+        .update({
+          'pages': campanello.pages.map((page) => page.toJson()).toList(),
+          'updated_at': DateTime.now().toIso8601String(),
+        })
+        .eq('id', campanelloHinooId);
+  }
+
+  Future<void> updateHouse({
+    required String campanelloHinooId,
+    required String houseImageUrl,
+    required List<double> bgTransform,
+  }) async {
+    await _client
+        .from('case')
+        .update({'house_image_url': houseImageUrl, 'bg_transform': bgTransform})
+        .eq('campanello_hinoo_id', campanelloHinooId);
+  }
 }

--- a/lib/UI/hinoo_builder.dart
+++ b/lib/UI/hinoo_builder.dart
@@ -32,6 +32,7 @@ import 'package:honoo/Widgets/text_box_download_button.dart';
 import 'package:honoo/UI/HinooBuilder/dialogs/name_hinoo_dialog.dart';
 import 'package:honoo/UI/hinoo_export_spec.dart';
 import 'package:honoo/UI/hinoo_typography.dart';
+import 'package:honoo/Entities/hinoo.dart';
 
 // Import coerenti con la struttura HinooBuilder
 
@@ -48,12 +49,14 @@ class HinooBuilder extends StatefulWidget {
     this.onPngExported, // PNG generato (anteprima)
     this.hintText,
     this.backgroundPromptText,
+    this.initialDraft,
   });
 
   final ValueChanged<dynamic>? onHinooChanged;
   final ValueChanged<Uint8List>? onPngExported;
   final String? hintText;
   final String? backgroundPromptText;
+  final HinooDraft? initialDraft;
 
   @override
   State<HinooBuilder> createState() => _HinooBuilderState();
@@ -102,7 +105,24 @@ class _HinooBuilderState extends State<HinooBuilder> {
   @override
   void initState() {
     super.initState();
-    if (_pages.isEmpty) {
+    final HinooDraft? initialDraft = widget.initialDraft;
+    if (initialDraft != null && initialDraft.pages.isNotEmpty) {
+      _pages.addAll(
+        initialDraft.pages.map(
+          (slide) => {
+            'text': slide.text,
+            'bgUrl': slide.backgroundImage,
+            'textColor': (slide.isTextWhite ? Colors.white : Colors.black)
+                .toARGB32(),
+            if (slide.bgTransform != null)
+              'bgTransform': List<double>.from(slide.bgTransform!),
+          },
+        ),
+      );
+      _applySlideState(_pages.first);
+      _step = _WizardStep.writeText;
+      _bgMinInteractiveScale = _bgScale;
+    } else if (_pages.isEmpty) {
       _pages.add(_createEmptySlide());
     }
     _textController.addListener(
@@ -537,7 +557,11 @@ class _HinooBuilderState extends State<HinooBuilder> {
           builder: (_) {
             final ImageProvider background = _localBgPreviewBytes != null
                 ? MemoryImage(_localBgPreviewBytes!)
-                : const AssetImage('assets/images/hinoo_default_1080x1920.png');
+                : (_bgPublicUrl != null && _bgPublicUrl!.isNotEmpty
+                      ? NetworkImage(_bgPublicUrl!)
+                      : const AssetImage(
+                          'assets/images/hinoo_default_1080x1920.png',
+                        ));
             final bool interactive =
                 (_step == _WizardStep.changeBg &&
                 _bgChosen &&

--- a/lib/UI/hinoo_viewer.dart
+++ b/lib/UI/hinoo_viewer.dart
@@ -304,12 +304,11 @@ class HinooSlideView extends StatelessWidget {
     const double horizontalPadding = HinooTypography.horizontalPadding;
     final double textTopPadding = HinooTypography.editorTextTopPadding(width);
     const double textBottomPadding = HinooTypography.editorTextBottomPadding;
-    final double actionVerticalPadding = HinooTypography.verticalPadding(width);
     final TextStyle effectiveStyle = HinooTypography.displayTextStyle(
       color: textColor,
     );
     final double halfGap = gap / 2;
-    const double actionInset = 8;
+    const double actionInset = 6;
     final Widget? downloadOverlay = onDownloadTap == null
         ? null
         : TextBoxDownloadButton(onPressed: onDownloadTap!, tooltip: 'download');
@@ -364,8 +363,8 @@ class HinooSlideView extends StatelessWidget {
           ),
           if (downloadOverlay != null)
             Positioned(
-              top: halfGap + actionVerticalPadding + actionInset,
-              right: horizontalPadding + actionInset,
+              top: halfGap + actionInset,
+              right: actionInset,
               child: downloadOverlay,
             ),
           if (halfGap > 0.05)

--- a/lib/UI/honoo_card.dart
+++ b/lib/UI/honoo_card.dart
@@ -97,7 +97,6 @@ class HonooCard extends StatelessWidget {
                   height: textHeight,
                   child: Container(
                     key: const Key('honoo-card-text-panel'),
-                    padding: const EdgeInsets.all(8),
                     decoration: BoxDecoration(
                       color: textPanelColor,
                       border: isReceivedReply
@@ -116,24 +115,27 @@ class HonooCard extends StatelessWidget {
                     ),
                     child: Stack(
                       children: [
-                        Center(
-                          child: Text(
-                            honoo.text,
-                            textAlign: TextAlign.center,
-                            style: GoogleFonts.arvo(
-                              color: textColor,
-                              fontSize: 18,
-                              height: 1.4,
-                              fontWeight: FontWeight.w400,
+                        Padding(
+                          padding: const EdgeInsets.all(8),
+                          child: Center(
+                            child: Text(
+                              honoo.text,
+                              textAlign: TextAlign.center,
+                              style: GoogleFonts.arvo(
+                                color: textColor,
+                                fontSize: 18,
+                                height: 1.4,
+                                fontWeight: FontWeight.w400,
+                              ),
+                              maxLines: 5,
+                              overflow: TextOverflow.visible,
                             ),
-                            maxLines: 5,
-                            overflow: TextOverflow.visible,
                           ),
                         ),
                         if (onDownloadTap != null)
                           Positioned(
-                            top: 0,
-                            right: 0,
+                            top: 6,
+                            right: 6,
                             child: TextBoxDownloadButton(
                               onPressed: onDownloadTap!,
                               tooltip: 'download',

--- a/lib/Widgets/campanello_card.dart
+++ b/lib/Widgets/campanello_card.dart
@@ -4,6 +4,7 @@ import 'package:google_fonts/google_fonts.dart';
 import '../Entities/campanelli_view_data.dart';
 import '../UI/hinoo_typography.dart';
 import '../Utility/honoo_colors.dart';
+import 'text_box_download_button.dart';
 
 class CampanelloCard extends StatelessWidget {
   const CampanelloCard({
@@ -12,12 +13,14 @@ class CampanelloCard extends StatelessWidget {
     required this.width,
     required this.height,
     this.onRequestTap,
+    this.onEditTap,
   });
 
   final CampanelloPageData data;
   final double width;
   final double height;
   final VoidCallback? onRequestTap;
+  final VoidCallback? onEditTap;
 
   @override
   Widget build(BuildContext context) {
@@ -65,6 +68,17 @@ class CampanelloCard extends StatelessWidget {
         children: [
           Image(image: data.campanello!.backgroundImage, fit: BoxFit.cover),
           savedText,
+          if (onEditTap != null)
+            Positioned(
+              top: 6,
+              right: 6,
+              child: TextBoxDownloadButton(
+                key: const ValueKey('edit-own-campanello'),
+                onPressed: onEditTap!,
+                tooltip: 'Modifica campanello',
+                asset: 'assets/icons/sostituisci immagine.svg',
+              ),
+            ),
         ],
       ),
     );

--- a/lib/Widgets/casa_section.dart
+++ b/lib/Widgets/casa_section.dart
@@ -3,6 +3,7 @@ import 'package:google_fonts/google_fonts.dart';
 
 import '../Entities/campanelli_view_data.dart';
 import '../Utility/honoo_colors.dart';
+import 'text_box_download_button.dart';
 
 class CasaSection extends StatelessWidget {
   const CasaSection({
@@ -16,6 +17,7 @@ class CasaSection extends StatelessWidget {
     required this.footerBottomSpacing,
     required this.width,
     required this.height,
+    this.onEditTap,
   });
 
   final CasaData casa;
@@ -27,6 +29,7 @@ class CasaSection extends StatelessWidget {
   final double footerBottomSpacing;
   final double width;
   final double height;
+  final VoidCallback? onEditTap;
 
   @override
   Widget build(BuildContext context) {
@@ -76,6 +79,17 @@ class CasaSection extends StatelessWidget {
                   color: HonooColor.onBackground,
                   fontWeight: FontWeight.w400,
                 ),
+              ),
+            ),
+          if (onEditTap != null)
+            Positioned(
+              top: 6,
+              right: 6,
+              child: TextBoxDownloadButton(
+                key: const ValueKey('edit-own-casa'),
+                onPressed: onEditTap!,
+                tooltip: 'Modifica casa',
+                asset: 'assets/icons/sostituisci immagine.svg',
               ),
             ),
           Positioned(

--- a/lib/Widgets/text_box_download_button.dart
+++ b/lib/Widgets/text_box_download_button.dart
@@ -7,11 +7,13 @@ class TextBoxDownloadButton extends StatelessWidget {
     required this.onPressed,
     this.tooltip = 'download',
     this.size = 30,
+    this.asset = 'assets/icons/download.svg',
   });
 
   final VoidCallback onPressed;
   final String tooltip;
   final double size;
+  final String asset;
 
   static final ValueNotifier<bool> _hiddenForCapture = ValueNotifier<bool>(
     false,
@@ -63,7 +65,7 @@ class TextBoxDownloadButton extends StatelessWidget {
                 ),
                 child: Center(
                   child: SvgPicture.asset(
-                    'assets/icons/download.svg',
+                    asset,
                     width: size * 0.6,
                     height: size * 0.6,
                     colorFilter: const ColorFilter.mode(

--- a/test/pages/campanelli_page_layout_test.dart
+++ b/test/pages/campanelli_page_layout_test.dart
@@ -80,6 +80,7 @@ void main() {
     await tester.pumpAndSettle();
 
     final CasaSection casa = tester.widget(find.byType(CasaSection));
+    expect(find.byType(DesktopCarouselArrows), findsNothing);
     expect(casa.width, closeTo(506.25, 0.01));
     expect(casa.height, 900);
     expect(tester.takeException(), isNull);

--- a/test/services/house_invite_service_test.dart
+++ b/test/services/house_invite_service_test.dart
@@ -143,4 +143,53 @@ void main() {
       throwsArgumentError,
     );
   });
+
+  test('updateCampanello aggiorna le pagine del campanello esistente', () async {
+    when(() => client.from('hinoo')).thenAnswer((_) => chain);
+    when(() => chain.update(any())).thenAnswer((_) => chain);
+    chain.queueResponse(null);
+    const draft = HinooDraft(
+      pages: [
+        HinooSlide(
+          backgroundImage: 'https://example.com/bell.png',
+          text: 'Campanello modificato',
+          isTextWhite: false,
+        ),
+      ],
+    );
+
+    await service.updateCampanello(
+      campanelloHinooId: 'hinoo-1',
+      campanello: draft,
+    );
+
+    verify(() => client.from('hinoo')).called(1);
+    verify(() => chain.update(any(
+          that: containsPair(
+            'pages',
+            draft.pages.map((page) => page.toJson()).toList(),
+          ),
+        ))).called(1);
+    verify(() => chain.eq('id', 'hinoo-1')).called(1);
+  });
+
+  test('updateHouse aggiorna immagine e trasformazione della propria casa',
+      () async {
+    when(() => client.from('case')).thenAnswer((_) => chain);
+    when(() => chain.update(any())).thenAnswer((_) => chain);
+    chain.queueResponse(null);
+
+    await service.updateHouse(
+      campanelloHinooId: 'hinoo-1',
+      houseImageUrl: 'https://example.com/house.png',
+      bgTransform: const [1, 0, 0, 1],
+    );
+
+    verify(() => client.from('case')).called(1);
+    verify(() => chain.update({
+          'house_image_url': 'https://example.com/house.png',
+          'bg_transform': [1, 0, 0, 1],
+        })).called(1);
+    verify(() => chain.eq('campanello_hinoo_id', 'hinoo-1')).called(1);
+  });
 }

--- a/test/widgets/campanelli_renderers_test.dart
+++ b/test/widgets/campanelli_renderers_test.dart
@@ -81,6 +81,36 @@ void main() {
     );
   });
 
+  testWidgets('il campanello proprietario espone il comando modifica', (
+    tester,
+  ) async {
+    var edited = false;
+    const campanello = CampanelloData(
+      id: 'campanello-1',
+      campanelloHinooId: 'hinoo-1',
+      ownerId: 'owner-1',
+      backgroundImage: AssetImage('assets/campanello1.png'),
+      text: 'Un campanello',
+      linkedHouseId: 'casa-1',
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: CampanelloCard(
+            data: CampanelloPageData.campanello(campanello),
+            width: 320,
+            height: 500,
+            onEditTap: () => edited = true,
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byKey(const ValueKey('edit-own-campanello')));
+    expect(edited, isTrue);
+  });
+
   testWidgets('casa chiusa conserva messaggio e azione scrigno', (
     tester,
   ) async {
@@ -146,5 +176,31 @@ void main() {
       ),
       findsOneWidget,
     );
+  });
+
+  testWidgets('la casa proprietaria espone il comando modifica', (
+    tester,
+  ) async {
+    var edited = false;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: CasaSection(
+            casa: casa,
+            isUnlocked: true,
+            scrignoAsset: 'assets/images/casa_palombaro_con_scrigno.png',
+            footerIconSize: 40,
+            scrignoSize: 80,
+            footerBottomSpacing: 10,
+            width: 320,
+            height: 500,
+            onEditTap: () => edited = true,
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byKey(const ValueKey('edit-own-casa')));
+    expect(edited, isTrue);
   });
 }


### PR DESCRIPTION
## Cosa cambia
- mostra le frecce solo nel carosello orizzontale dei campanelli e le fa svanire dopo pochi secondi
- porta il campanello personale in prima posizione per chi possiede una casa
- aggiunge l’azione di modifica al proprio campanello e alla propria casa, riaprendo gli editor con i dati esistenti
- riallinea più in alto le icone di modifica e download mantenendo distanze uniformi dai bordi
- conserva il flusso attuale di esempi e richiesta all’admin per chi non possiede una casa

## Verifiche
- flutter analyze
- flutter test test/pages/campanelli_page_layout_test.dart test/widgets/campanelli_renderers_test.dart test/services/house_invite_service_test.dart test/pages/new_hinoo_page_test.dart test/widgets/honoo_card_layout_test.dart