### PR TITLE
Fix conversation background ownership

### DIFF
--- a/lib/UI/honoo_card.dart
+++ b/lib/UI/honoo_card.dart
@@ -73,7 +73,8 @@ class HonooCard extends StatelessWidget {
 
         const double cornerRadius = 5;
 
-        final Color gapColor = honoo.type == HonooType.moon
+        final Color gapColor =
+            contentStyleOverride == null && honoo.type == HonooType.moon
             ? HonooColor.tertiary
             : cardBg;
 

--- a/lib/Utility/chest_content_style.dart
+++ b/lib/Utility/chest_content_style.dart
@@ -85,18 +85,14 @@ class ChestContentStyle {
     ConversationEntry entry, {
     String? viewerUserId,
   }) {
-    final isFromMoon = switch (entry.kind) {
+    final isFromMoonSaved = switch (entry.kind) {
       ConversationEntryKind.honoo =>
-        entry.isFromMoonSaved ||
-            entry.honoo!.isFromMoonSaved ||
-            entry.honoo!.type == HonooType.moon,
+        entry.isFromMoonSaved || entry.honoo!.isFromMoonSaved,
       ConversationEntryKind.hinoo =>
-        entry.isFromMoonSaved ||
-            entry.hinoo!.isFromMoonSaved ||
-            entry.hinoo!.type == HinooType.moon,
+        entry.isFromMoonSaved || entry.hinoo!.isFromMoonSaved,
       ConversationEntryKind.deleted => false,
     };
-    if (isFromMoon) return receivedReply;
+    if (isFromMoonSaved) return receivedReply;
     final ownerId = entry.ownerId;
     if (viewerUserId != null && ownerId != null && ownerId != viewerUserId) {
       return receivedReply;

--- a/test/widgets/conversation_border_test.dart
+++ b/test/widgets/conversation_border_test.dart
@@ -68,7 +68,11 @@ void main() {
     isFromMoonSaved: fromMoon,
   );
 
-  Future<void> pumpHonoo(WidgetTester tester, Honoo value) async {
+  Future<void> pumpHonoo(
+    WidgetTester tester,
+    Honoo value, {
+    ChestContentStyle? contentStyleOverride,
+  }) async {
     tester.view.devicePixelRatio = 1;
     tester.view.physicalSize = const Size(800, 1000);
     addTearDown(tester.view.resetDevicePixelRatio);
@@ -79,7 +83,10 @@ void main() {
           body: SizedBox(
             width: 500,
             height: 750,
-            child: HonooCard(honoo: value),
+            child: HonooCard(
+              honoo: value,
+              contentStyleOverride: contentStyleOverride,
+            ),
           ),
         ),
       ),
@@ -201,6 +208,34 @@ void main() {
     );
   });
 
+  test('Honoo Luna proprio resta blu nella conversazione', () {
+    final value = honoo(type: HonooType.moon, owner: 'test_user');
+
+    expect(
+      ChestContentStyle.forConversationEntry(
+        ConversationEntry.honoo(value),
+        viewerUserId: 'test_user',
+      ),
+      same(ChestContentStyle.own),
+    );
+  });
+
+  testWidgets('Honoo Luna in conversazione usa il rosso anche nella fascia', (
+    tester,
+  ) async {
+    final value = honoo(type: HonooType.moon, owner: 'other_user');
+    await pumpHonoo(
+      tester,
+      value,
+      contentStyleOverride: ChestContentStyle.receivedReply,
+    );
+
+    final gap = tester.widget<ColoredBox>(
+      find.byKey(const Key('honoo-card-gap')),
+    );
+    expect(gap.color, HonooColor.secondary);
+  });
+
   test('Honoo personale altrui diventa rosso nella conversazione', () {
     final value = honoo(type: HonooType.personal, owner: 'other_user');
 
@@ -222,6 +257,38 @@ void main() {
         viewerUserId: 'test_user',
       ),
       same(ChestContentStyle.own),
+    );
+  });
+
+  test('Hinoo Luna proprio resta blu nella conversazione', () {
+    final draft = hinoo().copyWith(type: HinooType.moon);
+
+    expect(
+      ChestContentStyle.forConversationEntry(
+        ConversationEntry.hinoo(
+          draft,
+          createdAt: DateTime.parse('2026-07-18T10:00:00Z'),
+          ownerId: 'test_user',
+        ),
+        viewerUserId: 'test_user',
+      ),
+      same(ChestContentStyle.own),
+    );
+  });
+
+  test('Hinoo Luna altrui resta rosso nella conversazione', () {
+    final draft = hinoo().copyWith(type: HinooType.moon);
+
+    expect(
+      ChestContentStyle.forConversationEntry(
+        ConversationEntry.hinoo(
+          draft,
+          createdAt: DateTime.parse('2026-07-18T10:00:00Z'),
+          ownerId: 'other_user',
+        ),
+        viewerUserId: 'test_user',
+      ),
+      same(ChestContentStyle.receivedReply),
     );
   });
 


### PR DESCRIPTION
## What changed

- color direct Moon conversation roots by actual ownership
- keep saved-from-Moon copies red in conversations and white in the chest
- make the Honoo separator follow the conversation background override
- add regression coverage for Honoo/Hinoo ownership and separator colors

## Why

The conversation classifier treated every `moon` record as foreign, so a user's own published root appeared red. Honoo also forced the separator white inside red or blue conversation cards.

## Validation

- `flutter analyze --no-pub`
- `flutter test --no-pub test/widgets/conversation_border_test.dart test/widgets/unified_thread_reveal_test.dart test/widgets/unified_thread_notification_focus_test.dart test/services/conversation_service_test.dart`