### PR TITLE
Fix reply notifications and Campanello editing

### DIFF
--- a/lib/IsolaDelleStorie/Pages/campanelli_page.dart
+++ b/lib/IsolaDelleStorie/Pages/campanelli_page.dart
@@ -54,8 +54,9 @@ class CampanelliPage extends StatefulWidget {
 class _CampanelliPageState extends State<CampanelliPage> {
   final CampanelliDataRepository _campanelliRepository =
       CampanelliDataRepository();
-  late final CampanelliController _campanelliController =
-      CampanelliController(repository: _campanelliRepository);
+  late final CampanelliController _campanelliController = CampanelliController(
+    repository: _campanelliRepository,
+  );
   // Animations: centralize durations/curves to avoid magic numbers
   static const Duration _kAnimFast = Duration(milliseconds: 220);
   static const Duration _kAnimMed = Duration(milliseconds: 240);
@@ -79,7 +80,7 @@ class _CampanelliPageState extends State<CampanelliPage> {
       _campanelliController.state.hasPendingOrAcceptedInvite;
   DateTime? _lastKnockToastAt;
   late final StreamSubscription<CampanelliRealtimeEvent>
-      _realtimeEventsSubscription;
+  _realtimeEventsSubscription;
   List<PendingKnock> get _pendingKnocks =>
       _campanelliController.state.pendingKnocks;
   Set<String> get _pendingKnockTags => _campanelliController.pendingKnockTags;
@@ -120,8 +121,9 @@ class _CampanelliPageState extends State<CampanelliPage> {
   void initState() {
     super.initState();
     _scheduleCarouselArrowsHide();
-    _realtimeEventsSubscription =
-        _campanelliController.realtimeEvents.listen(_handleRealtimeEvent);
+    _realtimeEventsSubscription = _campanelliController.realtimeEvents.listen(
+      _handleRealtimeEvent,
+    );
     _loadUserEntries();
     _subscribeVisitorAccessChannel();
   }
@@ -157,13 +159,15 @@ class _CampanelliPageState extends State<CampanelliPage> {
     final double delta = axis == Axis.vertical
         ? event.scrollDelta.dy
         : (event.scrollDelta.dy.abs() > 0
-            ? event.scrollDelta.dy
-            : event.scrollDelta.dx);
+              ? event.scrollDelta.dy
+              : event.scrollDelta.dx);
     if (delta.abs() < 0.5) {
       return;
     }
-    final double target = (position.pixels + delta)
-        .clamp(position.minScrollExtent, position.maxScrollExtent);
+    final double target = (position.pixels + delta).clamp(
+      position.minScrollExtent,
+      position.maxScrollExtent,
+    );
     if ((target - position.pixels).abs() > 0.5) {
       controller.jumpTo(target);
     }
@@ -189,7 +193,8 @@ class _CampanelliPageState extends State<CampanelliPage> {
       HapticFeedback.lightImpact();
     } catch (error, stackTrace) {
       debugPrint(
-          '[Campanelli] haptic failed: ${AppFailure.from(error, stackTrace)}');
+        '[Campanelli] haptic failed: ${AppFailure.from(error, stackTrace)}',
+      );
     }
     if (_isCampanelloUnlocked(campanello.id)) {
       await _showEnterDialog(campanello.id);
@@ -250,15 +255,19 @@ class _CampanelliPageState extends State<CampanelliPage> {
         );
         _hideBusyOverlay();
         if (mounted) {
-          showHonooToast(context,
-              message: 'Bussata inviata. Attendi risposta.');
+          showHonooToast(
+            context,
+            message: 'Bussata inviata. Attendi risposta.',
+          );
         }
       } catch (e) {
         debugPrint('house_access insert error: $e');
         _hideBusyOverlay();
         if (mounted) {
-          showHonooToast(context,
-              message: 'Invio non riuscito. Ritenta tra poco.');
+          showHonooToast(
+            context,
+            message: 'Invio non riuscito. Ritenta tra poco.',
+          );
         }
       }
     } finally {
@@ -289,11 +298,16 @@ class _CampanelliPageState extends State<CampanelliPage> {
     final position = _pageController.position;
     final double bump = position.viewportDimension * 0.5;
     final double start = position.pixels;
-    final double target = (start + bump)
-        .clamp(position.minScrollExtent, position.maxScrollExtent);
+    final double target = (start + bump).clamp(
+      position.minScrollExtent,
+      position.maxScrollExtent,
+    );
 
-    await _pageController.animateTo(target,
-        duration: _kAnimFast, curve: _kCurve);
+    await _pageController.animateTo(
+      target,
+      duration: _kAnimFast,
+      curve: _kCurve,
+    );
     await _pageController.animateTo(start, duration: _kAnimMed, curve: _kCurve);
   }
 
@@ -353,9 +367,7 @@ class _CampanelliPageState extends State<CampanelliPage> {
     return showDialog<Set<CasaShareMode>>(
       context: context,
       barrierDismissible: true,
-      builder: (_) => CasaMultiShareDialog(
-        onConfirm: (modes) async {},
-      ),
+      builder: (_) => CasaMultiShareDialog(onConfirm: (modes) async {}),
     );
   }
 
@@ -394,17 +406,13 @@ class _CampanelliPageState extends State<CampanelliPage> {
       case CasaShareMode.honoo:
         Navigator.push(
           context,
-          MaterialPageRoute(
-            builder: (_) => SharedHonooPage(ownerId: ownerId),
-          ),
+          MaterialPageRoute(builder: (_) => SharedHonooPage(ownerId: ownerId)),
         );
         return;
       case CasaShareMode.hinoo:
         Navigator.push(
           context,
-          MaterialPageRoute(
-            builder: (_) => SharedHinooPage(ownerId: ownerId),
-          ),
+          MaterialPageRoute(builder: (_) => SharedHinooPage(ownerId: ownerId)),
         );
         return;
       case CasaShareMode.conversations:
@@ -459,11 +467,8 @@ class _CampanelliPageState extends State<CampanelliPage> {
 
   List<_CampanelloEntry> _buildCampanelli() {
     final userId = SupabaseProvider.client.auth.currentUser?.id;
-    if (!_hasOwnHouse || userId == null) {
-      return [
-        ..._buildBaseCampanelli(),
-        ..._userEntries,
-      ];
+    if (userId == null) {
+      return [..._buildBaseCampanelli(), ..._userEntries];
     }
 
     final ownEntries = _userEntries
@@ -472,11 +477,7 @@ class _CampanelliPageState extends State<CampanelliPage> {
     final otherEntries = _userEntries
         .where((entry) => entry.campanello.ownerId != userId)
         .toList(growable: false);
-    return [
-      ...ownEntries,
-      ..._buildBaseCampanelli(),
-      ...otherEntries,
-    ];
+    return [...ownEntries, ..._buildBaseCampanelli(), ...otherEntries];
   }
 
   HinooDraft _campanelloDraftFor(_CampanelloEntry entry) {
@@ -495,7 +496,10 @@ class _CampanelliPageState extends State<CampanelliPage> {
     );
   }
 
-  Future<void> _editCampanello(_CampanelloEntry entry) async {
+  Future<void> _editCampanello(
+    _CampanelloEntry entry,
+    CampanelloEditMode editMode,
+  ) async {
     final String? campanelloId = entry.campanello.campanelloHinooId;
     if (campanelloId == null || campanelloId.isEmpty) return;
     final bool? updated = await Navigator.of(context).push<bool>(
@@ -504,6 +508,7 @@ class _CampanelliPageState extends State<CampanelliPage> {
           isCampanello: true,
           initialDraft: _campanelloDraftFor(entry),
           editingCampanelloId: campanelloId,
+          campanelloEditMode: editMode,
         ),
       ),
     );
@@ -562,8 +567,10 @@ class _CampanelliPageState extends State<CampanelliPage> {
           if (invite == true && mounted) {
             final inviteResult = await _campanelliController.sendAdminInvite();
             if (mounted) {
-              showHonooToast(context,
-                  message: _adminInviteMessage(inviteResult));
+              showHonooToast(
+                context,
+                message: _adminInviteMessage(inviteResult),
+              );
             }
           }
         default:
@@ -666,40 +673,42 @@ class _CampanelliPageState extends State<CampanelliPage> {
         return;
       }
 
-      final entries = loadState.entries.map((entry) {
-        final casaId = 'casa_${entry.hinooId}';
-        return _CampanelloEntry(
-          campanello: CampanelloData.fromBackend(
-            row: {
-              'id': 'campanello_${entry.hinooId}',
-              'campanello_hinoo_id': entry.hinooId,
-              'owner_id': entry.ownerId,
-            },
-            backgroundImage: _campanelloBackgroundProvider(
-              entry.campanelloBackgroundUrl,
-            ),
-            text: entry.text,
-            linkedHouseId: casaId,
-          ),
-          casa: CasaData.fromBackend(
-            row: {'id': casaId, 'bg_transform': entry.bgTransform},
-            backgroundImage: _houseBackgroundProvider(
-              entry.houseImageUrl,
-              entry.campanelloBackgroundUrl,
-            ),
-            bgScale: entry.bgScale,
-            bgOffsetX: entry.bgOffsetX,
-            bgOffsetY: entry.bgOffsetY,
-          ),
-          campanelloBackgroundUrl: entry.campanelloBackgroundUrl,
-          houseImageUrl: entry.houseImageUrl,
-          campanelloIsTextWhite: entry.campanelloIsTextWhite,
-          campanelloBgScale: entry.bgScale,
-          campanelloBgOffsetX: entry.bgOffsetX,
-          campanelloBgOffsetY: entry.bgOffsetY,
-          campanelloBgTransform: entry.campanelloBgTransform,
-        );
-      }).toList(growable: false);
+      final entries = loadState.entries
+          .map((entry) {
+            final casaId = 'casa_${entry.hinooId}';
+            return _CampanelloEntry(
+              campanello: CampanelloData.fromBackend(
+                row: {
+                  'id': 'campanello_${entry.hinooId}',
+                  'campanello_hinoo_id': entry.hinooId,
+                  'owner_id': entry.ownerId,
+                },
+                backgroundImage: _campanelloBackgroundProvider(
+                  entry.campanelloBackgroundUrl,
+                ),
+                text: entry.text,
+                linkedHouseId: casaId,
+              ),
+              casa: CasaData.fromBackend(
+                row: {'id': casaId, 'bg_transform': entry.bgTransform},
+                backgroundImage: _houseBackgroundProvider(
+                  entry.houseImageUrl,
+                  entry.campanelloBackgroundUrl,
+                ),
+                bgScale: entry.bgScale,
+                bgOffsetX: entry.bgOffsetX,
+                bgOffsetY: entry.bgOffsetY,
+              ),
+              campanelloBackgroundUrl: entry.campanelloBackgroundUrl,
+              houseImageUrl: entry.houseImageUrl,
+              campanelloIsTextWhite: entry.campanelloIsTextWhite,
+              campanelloBgScale: entry.bgScale,
+              campanelloBgOffsetX: entry.bgOffsetX,
+              campanelloBgOffsetY: entry.bgOffsetY,
+              campanelloBgTransform: entry.campanelloBgTransform,
+            );
+          })
+          .toList(growable: false);
 
       if (mounted) {
         setState(() {
@@ -711,8 +720,9 @@ class _CampanelliPageState extends State<CampanelliPage> {
                 .map((entry) => entry.campanello.id),
           );
         });
-        final bool hasOwnEntry =
-            entries.any((entry) => entry.campanello.ownerId == user.id);
+        final bool hasOwnEntry = entries.any(
+          (entry) => entry.campanello.ownerId == user.id,
+        );
         if (hasOwnEntry) {
           WidgetsBinding.instance.addPostFrameCallback((_) {
             if (!mounted || !_campanelloPageController.hasClients) return;
@@ -730,7 +740,8 @@ class _CampanelliPageState extends State<CampanelliPage> {
         if (mounted) setState(() {});
       } catch (error, stackTrace) {
         debugPrint(
-            '[Campanelli] invite state failed: ${AppFailure.from(error, stackTrace)}');
+          '[Campanelli] invite state failed: ${AppFailure.from(error, stackTrace)}',
+        );
       }
       _subscribeOwnerAccessChannel();
       await _campanelliController.startPendingKnockRefresh(
@@ -741,7 +752,8 @@ class _CampanelliPageState extends State<CampanelliPage> {
       );
     } catch (error, stackTrace) {
       debugPrint(
-          '[Campanelli] user entries failed: ${AppFailure.from(error, stackTrace)}');
+        '[Campanelli] user entries failed: ${AppFailure.from(error, stackTrace)}',
+      );
       if (mounted) {
         setState(() {
           _userEntries = const [];
@@ -765,7 +777,8 @@ class _CampanelliPageState extends State<CampanelliPage> {
       );
     } catch (error, stackTrace) {
       debugPrint(
-          '[Campanelli] owner realtime failed: ${AppFailure.from(error, stackTrace)}');
+        '[Campanelli] owner realtime failed: ${AppFailure.from(error, stackTrace)}',
+      );
       // In test or when Realtime not available, safely ignore
     }
   }
@@ -774,12 +787,11 @@ class _CampanelliPageState extends State<CampanelliPage> {
     try {
       final user = SupabaseProvider.client.auth.currentUser;
       if (user == null) return;
-      _campanelliController.startVisitorRealtime(
-        userId: user.id,
-      );
+      _campanelliController.startVisitorRealtime(userId: user.id);
     } catch (error, stackTrace) {
       debugPrint(
-          '[Campanelli] visitor realtime failed: ${AppFailure.from(error, stackTrace)}');
+        '[Campanelli] visitor realtime failed: ${AppFailure.from(error, stackTrace)}',
+      );
       // In test or when Realtime not available, safely ignore
     }
   }
@@ -793,10 +805,7 @@ class _CampanelliPageState extends State<CampanelliPage> {
         if (_lastKnockToastAt == null ||
             now.difference(_lastKnockToastAt!) > const Duration(seconds: 3)) {
           _lastKnockToastAt = now;
-          showHonooToast(
-            context,
-            message: 'Qualcuno ha bussato alla tua casa',
-          );
+          showHonooToast(context, message: 'Qualcuno ha bussato alla tua casa');
         }
       case CampanelliPendingKnockRemoved():
         setState(() {});
@@ -806,7 +815,8 @@ class _CampanelliPageState extends State<CampanelliPage> {
           HapticFeedback.lightImpact();
         } catch (error, stackTrace) {
           debugPrint(
-              '[Campanelli] haptic failed: ${AppFailure.from(error, stackTrace)}');
+            '[Campanelli] haptic failed: ${AppFailure.from(error, stackTrace)}',
+          );
         }
         await _goToCampanelloByTag(targetTag);
         await _hintCampanelloBounce();
@@ -848,16 +858,25 @@ class _CampanelliPageState extends State<CampanelliPage> {
     final position = _campanelloPageController.position;
     final double bump = (position.viewportDimension * 0.08).clamp(6.0, 60.0);
     final double start = position.pixels;
-    final double target = (start + bump)
-        .clamp(position.minScrollExtent, position.maxScrollExtent);
+    final double target = (start + bump).clamp(
+      position.minScrollExtent,
+      position.maxScrollExtent,
+    );
     try {
-      await _campanelloPageController.animateTo(target,
-          duration: _kBounceIn, curve: _kCurve);
-      await _campanelloPageController.animateTo(start,
-          duration: _kBounceOut, curve: _kCurve);
+      await _campanelloPageController.animateTo(
+        target,
+        duration: _kBounceIn,
+        curve: _kCurve,
+      );
+      await _campanelloPageController.animateTo(
+        start,
+        duration: _kBounceOut,
+        curve: _kCurve,
+      );
     } catch (error, stackTrace) {
       debugPrint(
-          '[Campanelli] bounce animation failed: ${AppFailure.from(error, stackTrace)}');
+        '[Campanelli] bounce animation failed: ${AppFailure.from(error, stackTrace)}',
+      );
     }
   }
 
@@ -921,12 +940,15 @@ class _CampanelliPageState extends State<CampanelliPage> {
 
     if (draft != null) {
       try {
-        final HinooDraft personalDraft =
-            draft.copyWith(type: HinooType.personal, recipientTag: null);
+        final HinooDraft personalDraft = draft.copyWith(
+          type: HinooType.personal,
+          recipientTag: null,
+        );
         await HinooController().saveToChest(personalDraft);
       } catch (error, stackTrace) {
         debugPrint(
-            '[Campanelli] save hinoo failed: ${AppFailure.from(error, stackTrace)}');
+          '[Campanelli] save hinoo failed: ${AppFailure.from(error, stackTrace)}',
+        );
       }
     }
 
@@ -935,7 +957,8 @@ class _CampanelliPageState extends State<CampanelliPage> {
         await HonooController().saveToChest(honoo);
       } catch (error, stackTrace) {
         debugPrint(
-            '[Campanelli] save honoo failed: ${AppFailure.from(error, stackTrace)}');
+          '[Campanelli] save honoo failed: ${AppFailure.from(error, stackTrace)}',
+        );
       }
     }
 
@@ -947,7 +970,8 @@ class _CampanelliPageState extends State<CampanelliPage> {
       HapticFeedback.lightImpact();
     } catch (error, stackTrace) {
       debugPrint(
-          '[Campanelli] haptic failed: ${AppFailure.from(error, stackTrace)}');
+        '[Campanelli] haptic failed: ${AppFailure.from(error, stackTrace)}',
+      );
     }
   }
 
@@ -972,13 +996,12 @@ class _CampanelliPageState extends State<CampanelliPage> {
     }
 
     if (knock.hinooId != null && knock.hinooId!.isNotEmpty) {
-      final draft =
-          await _campanelliController.fetchPendingHinoo(knock.hinooId!);
+      final draft = await _campanelliController.fetchPendingHinoo(
+        knock.hinooId!,
+      );
       if (draft == null || !mounted) return;
       final bool? approved = await Navigator.of(context).push<bool>(
-        MaterialPageRoute(
-          builder: (_) => PendingHinooPage(draft: draft),
-        ),
+        MaterialPageRoute(builder: (_) => PendingHinooPage(draft: draft)),
       );
 
       if (approved == true && mounted) {
@@ -988,13 +1011,12 @@ class _CampanelliPageState extends State<CampanelliPage> {
     }
 
     if (knock.honooId != null && knock.honooId!.isNotEmpty) {
-      final honoo =
-          await _campanelliController.fetchPendingHonoo(knock.honooId!);
+      final honoo = await _campanelliController.fetchPendingHonoo(
+        knock.honooId!,
+      );
       if (honoo == null || !mounted) return;
       final bool? approved = await Navigator.of(context).push<bool>(
-        MaterialPageRoute(
-          builder: (_) => PendingHonooPage(honoo: honoo),
-        ),
+        MaterialPageRoute(builder: (_) => PendingHonooPage(honoo: honoo)),
       );
 
       if (approved == true && mounted) {
@@ -1045,16 +1067,19 @@ class _CampanelliPageState extends State<CampanelliPage> {
         builder: (context, constraints) {
           final double maxWidth = constraints.maxWidth;
           final double maxHeight = constraints.maxHeight;
-          final ResponsiveLayoutMode layoutMode =
-              ResponsiveLayout.modeForWidth(maxWidth);
-          final double footerIconSize =
-              ResponsiveLayout.footerIconSizeForMode(layoutMode);
-          final double footerGap =
-              ResponsiveLayout.footerGapForMode(layoutMode);
+          final ResponsiveLayoutMode layoutMode = ResponsiveLayout.modeForWidth(
+            maxWidth,
+          );
+          final double footerIconSize = ResponsiveLayout.footerIconSizeForMode(
+            layoutMode,
+          );
+          final double footerGap = ResponsiveLayout.footerGapForMode(
+            layoutMode,
+          );
           final bool isMobile = layoutMode == ResponsiveLayoutMode.mobile;
           final double footerBottomPadding =
               ResponsiveLayout.footerBottomPaddingForMode(layoutMode) +
-                  (isMobile ? 0 : 12);
+              (isMobile ? 0 : 12);
           final double safeBottom = MediaQuery.of(context).viewPadding.bottom;
           final double footerSpacing = footerBottomPadding + safeBottom;
           final double footerBottomSpacing = footerSpacing / 2;
@@ -1072,20 +1097,27 @@ class _CampanelliPageState extends State<CampanelliPage> {
           final List<_CampanelloEntry> campanelli = _buildCampanelli();
           final List<CampanelloPageData> campanelloPages =
               _buildCampanelloPages(campanelli);
-          final int safeCampanelloIndex =
-              _campanelloIndex.clamp(0, campanelloPages.length - 1);
-          final int houseCampanelloIndex =
-              safeCampanelloIndex == 0 ? 1 : safeCampanelloIndex;
-          final int casaIndex =
-              (houseCampanelloIndex - 1).clamp(0, campanelli.length - 1);
+          final int safeCampanelloIndex = _campanelloIndex.clamp(
+            0,
+            campanelloPages.length - 1,
+          );
+          final int houseCampanelloIndex = safeCampanelloIndex == 0
+              ? 1
+              : safeCampanelloIndex;
+          final int casaIndex = (houseCampanelloIndex - 1).clamp(
+            0,
+            campanelli.length - 1,
+          );
           final bool showCampanello = safeCampanelloIndex > 0;
           final bool showFooter = _verticalPageIndex == 0;
-          final CampanelloData? activeCampanello =
-              showCampanello ? campanelli[casaIndex].campanello : null;
+          final CampanelloData? activeCampanello = showCampanello
+              ? campanelli[casaIndex].campanello
+              : null;
           final user = SupabaseProvider.client.auth.currentUser;
           final String? activeCampanelloId =
               activeCampanello?.campanelloHinooId;
-          final bool hasPendingKnock = activeCampanelloId != null &&
+          final bool hasPendingKnock =
+              activeCampanelloId != null &&
               _pendingKnockTags.contains(activeCampanelloId);
           final bool hasAnyPendingKnock = _pendingKnockTags.isNotEmpty;
           final int pendingKnockCount = _pendingKnocks.length;
@@ -1095,27 +1127,39 @@ class _CampanelliPageState extends State<CampanelliPage> {
           final VoidCallback? scrignoTap = activeCampanello == null
               ? null
               : () => _handleScrigno(activeCampanello);
-          final bool isOwnCampanello = activeCampanello != null &&
+          final bool isOwnCampanello =
+              activeCampanello != null &&
               user != null &&
               activeCampanello.ownerId == user.id;
-          final ScrollPhysics pagePhysics =
-              const PageScrollPhysics().applyTo(const BouncingScrollPhysics());
+          final ScrollPhysics pagePhysics = const PageScrollPhysics().applyTo(
+            const BouncingScrollPhysics(),
+          );
           const int verticalPages = 2;
-          final int maxCampanelloIndex =
-              math.max(0, campanelloPages.length - 1);
+          final int maxCampanelloIndex = math.max(
+            0,
+            campanelloPages.length - 1,
+          );
           const int maxVerticalIndex = verticalPages - 1;
 
           return FocusableActionDetector(
             autofocus: true,
             shortcuts: {
-              LogicalKeySet(LogicalKeyboardKey.arrowLeft):
-                  const _ArrowIntent(Axis.horizontal, -1),
-              LogicalKeySet(LogicalKeyboardKey.arrowRight):
-                  const _ArrowIntent(Axis.horizontal, 1),
-              LogicalKeySet(LogicalKeyboardKey.arrowUp):
-                  const _ArrowIntent(Axis.vertical, -1),
-              LogicalKeySet(LogicalKeyboardKey.arrowDown):
-                  const _ArrowIntent(Axis.vertical, 1),
+              LogicalKeySet(LogicalKeyboardKey.arrowLeft): const _ArrowIntent(
+                Axis.horizontal,
+                -1,
+              ),
+              LogicalKeySet(LogicalKeyboardKey.arrowRight): const _ArrowIntent(
+                Axis.horizontal,
+                1,
+              ),
+              LogicalKeySet(LogicalKeyboardKey.arrowUp): const _ArrowIntent(
+                Axis.vertical,
+                -1,
+              ),
+              LogicalKeySet(LogicalKeyboardKey.arrowDown): const _ArrowIntent(
+                Axis.vertical,
+                1,
+              ),
             },
             actions: {
               _ArrowIntent: CallbackAction<_ArrowIntent>(
@@ -1173,8 +1217,9 @@ class _CampanelliPageState extends State<CampanelliPage> {
                         onPageChanged: (index) {
                           _revealCarouselArrows();
                           if (index == 1) {
-                            _lastHouseCampanelloIndex =
-                                _campanelloIndex == 0 ? 1 : _campanelloIndex;
+                            _lastHouseCampanelloIndex = _campanelloIndex == 0
+                                ? 1
+                                : _campanelloIndex;
                           }
                           if (index == 0) {
                             final int target = _campanelloIndex == 0
@@ -1216,13 +1261,13 @@ class _CampanelliPageState extends State<CampanelliPage> {
                                     child: ScrollConfiguration(
                                       behavior: ScrollConfiguration.of(context)
                                           .copyWith(
-                                        dragDevices: {
-                                          PointerDeviceKind.touch,
-                                          PointerDeviceKind.mouse,
-                                          PointerDeviceKind.stylus,
-                                          PointerDeviceKind.trackpad,
-                                        },
-                                      ),
+                                            dragDevices: {
+                                              PointerDeviceKind.touch,
+                                              PointerDeviceKind.mouse,
+                                              PointerDeviceKind.stylus,
+                                              PointerDeviceKind.trackpad,
+                                            },
+                                          ),
                                       child: () {
                                         final pvViewport = SizedBox(
                                           width: canvasSize.width,
@@ -1246,13 +1291,12 @@ class _CampanelliPageState extends State<CampanelliPage> {
                                             itemBuilder: (context, pageIndex) {
                                               final _CampanelloEntry? entry =
                                                   pageIndex > 0 &&
-                                                          pageIndex <=
-                                                              campanelli.length
-                                                      ? campanelli[
-                                                          pageIndex - 1]
-                                                      : null;
-                                              final bool isOwnEntry = entry !=
-                                                      null &&
+                                                      pageIndex <=
+                                                          campanelli.length
+                                                  ? campanelli[pageIndex - 1]
+                                                  : null;
+                                              final bool isOwnEntry =
+                                                  entry != null &&
                                                   user != null &&
                                                   entry.campanello.ownerId ==
                                                       user.id;
@@ -1263,9 +1307,18 @@ class _CampanelliPageState extends State<CampanelliPage> {
                                                 height: canvasSize.height,
                                                 onRequestTap:
                                                     _handleInviteRequestTap,
-                                                onEditTap: isOwnEntry
-                                                    ? () =>
-                                                        _editCampanello(entry)
+                                                onEditImageTap: isOwnEntry
+                                                    ? () => _editCampanello(
+                                                        entry,
+                                                        CampanelloEditMode
+                                                            .image,
+                                                      )
+                                                    : null,
+                                                onEditTextTap: isOwnEntry
+                                                    ? () => _editCampanello(
+                                                        entry,
+                                                        CampanelloEditMode.text,
+                                                      )
                                                     : null,
                                               );
                                             },
@@ -1323,9 +1376,8 @@ class _CampanelliPageState extends State<CampanelliPage> {
                                       width: casaWidth,
                                       height: casaHeight,
                                       onEditTap: isOwnCampanello
-                                          ? () => _editCasa(
-                                                campanelli[casaIndex],
-                                              )
+                                          ? () =>
+                                                _editCasa(campanelli[casaIndex])
                                           : null,
                                     ),
                                   ),
@@ -1345,9 +1397,7 @@ class _CampanelliPageState extends State<CampanelliPage> {
                                     width: casaWidth,
                                     height: casaHeight,
                                     onEditTap: isOwnCampanello
-                                        ? () => _editCasa(
-                                              campanelli[casaIndex],
-                                            )
+                                        ? () => _editCasa(campanelli[casaIndex])
                                         : null,
                                   ),
                                 ),

--- a/lib/Pages/new_hinoo_page.dart
+++ b/lib/Pages/new_hinoo_page.dart
@@ -26,6 +26,9 @@ import '../Entities/reply_navigation_result.dart';
 import 'casa_builder_page.dart';
 import '../Widgets/conversation_notification_prompt.dart';
 import '../Widgets/repeated_reply_prompt.dart';
+import '../Widgets/text_box_download_button.dart';
+
+enum CampanelloEditMode { image, text }
 
 class NewHinooPage extends StatefulWidget {
   const NewHinooPage({
@@ -41,6 +44,7 @@ class NewHinooPage extends StatefulWidget {
     this.targetContentName = 'hinoo',
     this.initialDraft,
     this.editingCampanelloId,
+    this.campanelloEditMode,
   });
 
   final bool isReply;
@@ -54,6 +58,7 @@ class NewHinooPage extends StatefulWidget {
   final String targetContentName;
   final HinooDraft? initialDraft;
   final String? editingCampanelloId;
+  final CampanelloEditMode? campanelloEditMode;
 
   @override
   State<NewHinooPage> createState() => _NewHinooPageState();
@@ -73,6 +78,7 @@ class _NewHinooPageState extends State<NewHinooPage>
   int _currentTextLength = 0;
   bool _bgUploadInProgress = false;
   bool _hasBackground = false;
+  bool _campanelloEditStarted = false;
 
   bool get _isWriteStep => _builderStep == 'writeText';
   bool get _hasMinTextForDownload => _currentTextLength >= 1;
@@ -115,6 +121,12 @@ class _NewHinooPageState extends State<NewHinooPage>
       final draft = dyn?.exportDraft?.call();
       if (!mounted) return;
       setState(() => _applyDraftToLocalState(draft));
+      final editMode = widget.campanelloEditMode;
+      if (editMode == CampanelloEditMode.image) {
+        _beginCampanelloImageEdit();
+      } else if (editMode == CampanelloEditMode.text) {
+        _beginCampanelloTextEdit();
+      }
     });
   }
 
@@ -556,6 +568,19 @@ class _NewHinooPageState extends State<NewHinooPage>
     builder?.replaceBackgroundPublic?.call();
   }
 
+  void _beginCampanelloImageEdit() {
+    if (!mounted) return;
+    setState(() => _campanelloEditStarted = true);
+    _replaceEditorImage();
+  }
+
+  void _beginCampanelloTextEdit() {
+    if (!mounted) return;
+    setState(() => _campanelloEditStarted = true);
+    final dynamic builder = _builderKey.currentState;
+    builder?.editTextPublic?.call();
+  }
+
   void _saveEditorImage() {
     final dynamic builder = _builderKey.currentState;
     builder?.confirmBackgroundPublic?.call();
@@ -667,6 +692,45 @@ class _NewHinooPageState extends State<NewHinooPage>
   }
 
   Widget _buildEditorControls() {
+    final bool editingExistingCampanello =
+        widget.isCampanello &&
+        (widget.editingCampanelloId?.isNotEmpty ?? false);
+    if (editingExistingCampanello) {
+      const double actionSize = 30;
+      return SizedBox(
+        key: const Key('campanello-editor-controls'),
+        height: 40,
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            TextBoxDownloadButton(
+              key: const Key('campanello-edit-image'),
+              onPressed: _beginCampanelloImageEdit,
+              tooltip: 'Modifica immagine',
+              size: actionSize,
+              asset: 'assets/icons/sostituisci immagine.svg',
+            ),
+            if (_campanelloEditStarted)
+              TextBoxDownloadButton(
+                key: const Key('campanello-save-changes'),
+                onPressed: _submitHinoo,
+                tooltip: 'Conferma e salva',
+                size: actionSize,
+                asset: 'assets/icons/ok.svg',
+              )
+            else
+              const SizedBox(width: actionSize, height: actionSize),
+            TextBoxDownloadButton(
+              key: const Key('campanello-edit-text'),
+              onPressed: _beginCampanelloTextEdit,
+              tooltip: 'Modifica testo',
+              size: actionSize,
+              asset: 'assets/icons/modifica testo.svg',
+            ),
+          ],
+        ),
+      );
+    }
     return SizedBox(
       key: const Key('hinoo-editor-controls'),
       height: 40,
@@ -870,7 +934,11 @@ class _NewHinooPageState extends State<NewHinooPage>
                             );
                           },
                         ),
-                        if (_isWriteStep && _currentTextLength > 0)
+                        if (_isWriteStep &&
+                            _currentTextLength > 0 &&
+                            !(widget.isCampanello &&
+                                (widget.editingCampanelloId?.isNotEmpty ??
+                                    false)))
                           ResponsiveFooterAction(
                             asset: "assets/icons/ok.svg",
                             semanticsLabel:

--- a/lib/UI/hinoo_builder.dart
+++ b/lib/UI/hinoo_builder.dart
@@ -433,6 +433,11 @@ class _HinooBuilderState extends State<HinooBuilder> {
       _downloadHinoo(baseName: baseName);
   Future<void> replaceBackgroundPublic() => _pickAndUploadBackground();
   void confirmBackgroundPublic() => _confirmBgAndLock();
+  void editTextPublic() {
+    setState(() => _step = _WizardStep.writeText);
+    _textFocus.requestFocus();
+    _notifyChanged();
+  }
 
   String _prepareFileBaseName(String? raw) {
     const String fallback = 'hinoo';

--- a/lib/Widgets/campanello_card.dart
+++ b/lib/Widgets/campanello_card.dart
@@ -14,6 +14,8 @@ class CampanelloCard extends StatelessWidget {
     required this.height,
     this.onRequestTap,
     this.onEditTap,
+    this.onEditImageTap,
+    this.onEditTextTap,
   });
 
   final CampanelloPageData data;
@@ -21,6 +23,8 @@ class CampanelloCard extends StatelessWidget {
   final double height;
   final VoidCallback? onRequestTap;
   final VoidCallback? onEditTap;
+  final VoidCallback? onEditImageTap;
+  final VoidCallback? onEditTextTap;
 
   @override
   Widget build(BuildContext context) {
@@ -68,15 +72,26 @@ class CampanelloCard extends StatelessWidget {
         children: [
           Image(image: data.campanello!.backgroundImage, fit: BoxFit.cover),
           savedText,
-          if (onEditTap != null)
+          if (onEditTap != null || onEditImageTap != null)
+            Positioned(
+              top: 6,
+              left: 6,
+              child: TextBoxDownloadButton(
+                key: const ValueKey('edit-own-campanello-image'),
+                onPressed: onEditImageTap ?? onEditTap!,
+                tooltip: 'Modifica immagine',
+                asset: 'assets/icons/sostituisci immagine.svg',
+              ),
+            ),
+          if (onEditTextTap != null || onEditTap != null)
             Positioned(
               top: 6,
               right: 6,
               child: TextBoxDownloadButton(
-                key: const ValueKey('edit-own-campanello'),
-                onPressed: onEditTap!,
-                tooltip: 'Modifica campanello',
-                asset: 'assets/icons/sostituisci immagine.svg',
+                key: const ValueKey('edit-own-campanello-text'),
+                onPressed: onEditTextTap ?? onEditTap!,
+                tooltip: 'Modifica testo',
+                asset: 'assets/icons/modifica testo.svg',
               ),
             ),
         ],

--- a/lib/Widgets/global_reply_notification_listener.dart
+++ b/lib/Widgets/global_reply_notification_listener.dart
@@ -58,11 +58,15 @@ class _GlobalReplyNotificationListenerState
   final Set<String> _deliveredEventKeys = <String>{};
   final Map<String, ReplyNotificationEvent> _pendingEvents =
       <String, ReplyNotificationEvent>{};
+  final Map<String, ReplyNotificationEvent> _shownEventsByConversation =
+      <String, ReplyNotificationEvent>{};
+  bool _multipleNotificationShown = false;
 
   @override
   void initState() {
     super.initState();
     WidgetsBinding.instance.addObserver(this);
+    ReplyNotificationSignal.revision.addListener(_reconcileSeenNotifications);
     if (widget.enabled) _start();
   }
 
@@ -218,11 +222,13 @@ class _GlobalReplyNotificationListenerState
     );
   }
 
-  void _flushPendingEvents() {
+  Future<void> _flushPendingEvents() async {
     _notificationTimer = null;
     if (!mounted || _pendingEvents.isEmpty) return;
-    final events = _pendingEvents.values.toList(growable: false);
+    final queuedEvents = _pendingEvents.values.toList(growable: false);
     _pendingEvents.clear();
+    final events = await _onlyUnseenEvents(queuedEvents);
+    if (!mounted || events.isEmpty) return;
     final event = events.last;
     final replyCount = events.length;
     final conversationIds = events.map((item) => item.conversationId).toSet();
@@ -240,13 +246,71 @@ class _GlobalReplyNotificationListenerState
       onTap: open,
       replyCount: replyCount,
     );
+    _multipleNotificationShown =
+        _multipleNotificationShown || hasMultipleConversations;
+    for (final item in events) {
+      _shownEventsByConversation[item.conversationId] = item;
+    }
 
     final context = widget.navigatorKey.currentContext;
-    if (context != null) {
+    if (context != null && context.mounted) {
       unawaited(
         _showReplyDialog(context, replyCount: replyCount, onOpen: open),
       );
     }
+  }
+
+  Future<List<ReplyNotificationEvent>> _onlyUnseenEvents(
+    List<ReplyNotificationEvent> events,
+  ) async {
+    if (events.isEmpty) return const [];
+    final result = <ReplyNotificationEvent>[];
+    final states = <String, ReplySeenState>{};
+    for (final event in events) {
+      final createdAt = event.createdAt;
+      if (createdAt == null) {
+        result.add(event);
+        continue;
+      }
+      final state = states[event.recipientId] ??= await RepliesSeenTracker.load(
+        userId: event.recipientId,
+      );
+      if (!state.isSeen(
+        conversationId: event.conversationId,
+        createdAt: createdAt,
+      )) {
+        result.add(event);
+      }
+    }
+    return result;
+  }
+
+  void _reconcileSeenNotifications() {
+    unawaited(_closeNotificationsAlreadySeen());
+  }
+
+  Future<void> _closeNotificationsAlreadySeen() async {
+    if (_shownEventsByConversation.isEmpty && _pendingEvents.isEmpty) return;
+    final events = <ReplyNotificationEvent>{
+      ..._shownEventsByConversation.values,
+      ..._pendingEvents.values,
+    }.toList(growable: false);
+    final unseen = await _onlyUnseenEvents(events);
+    if (!mounted) return;
+    final unseenConversations = unseen.map((e) => e.conversationId).toSet();
+    final shownConversations = _shownEventsByConversation.keys.toList();
+    for (final conversationId in shownConversations) {
+      if (unseenConversations.contains(conversationId)) continue;
+      _systemNotification.closeConversation(conversationId);
+      _shownEventsByConversation.remove(conversationId);
+    }
+    if (_multipleNotificationShown && _shownEventsByConversation.isEmpty) {
+      _systemNotification.closeConversation('multiple-conversations');
+      _multipleNotificationShown = false;
+    }
+    _pendingEvents.removeWhere(
+      (_, event) => !unseenConversations.contains(event.conversationId),
+    );
   }
 
   Future<void> _showReplyDialog(
@@ -400,6 +464,8 @@ class _GlobalReplyNotificationListenerState
     _notificationTimer?.cancel();
     _notificationTimer = null;
     _pendingEvents.clear();
+    _shownEventsByConversation.clear();
+    _multipleNotificationShown = false;
     _replyEventSubscription?.cancel();
     _replyEventSubscription = null;
     _authSubscription?.cancel();
@@ -411,6 +477,9 @@ class _GlobalReplyNotificationListenerState
   @override
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
+    ReplyNotificationSignal.revision.removeListener(
+      _reconcileSeenNotifications,
+    );
     _stop();
     super.dispose();
   }

--- a/test/pages/new_hinoo_page_test.dart
+++ b/test/pages/new_hinoo_page_test.dart
@@ -4,9 +4,58 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:honoo/Pages/new_hinoo_page.dart';
 import 'package:honoo/UI/hinoo_builder.dart';
 import 'package:honoo/Utility/honoo_colors.dart';
+import 'package:honoo/Entities/hinoo.dart';
 import 'package:sizer/sizer.dart';
 
 void main() {
+  testWidgets(
+    'il campanello mostra salva al centro solo dopo aver avviato una modifica',
+    (tester) async {
+      await tester.pumpWidget(
+        Sizer(
+          builder: (context, orientation, deviceType) {
+            return const MaterialApp(
+              home: NewHinooPage(
+                isCampanello: true,
+                editingCampanelloId: 'campanello-1',
+                initialDraft: HinooDraft(
+                  pages: [
+                    HinooSlide(
+                      backgroundImage: null,
+                      text: 'Il mio campanello',
+                      isTextWhite: true,
+                    ),
+                  ],
+                ),
+              ),
+            );
+          },
+        ),
+      );
+      await tester.pump();
+
+      expect(find.byKey(const Key('campanello-edit-image')), findsOneWidget);
+      expect(find.byKey(const Key('campanello-edit-text')), findsOneWidget);
+      expect(find.byKey(const Key('campanello-save-changes')), findsNothing);
+
+      await tester.tap(find.byKey(const Key('campanello-edit-text')));
+      await tester.pump();
+
+      expect(find.byKey(const Key('campanello-save-changes')), findsOneWidget);
+      final imageX = tester
+          .getCenter(find.byKey(const Key('campanello-edit-image')))
+          .dx;
+      final saveX = tester
+          .getCenter(find.byKey(const Key('campanello-save-changes')))
+          .dx;
+      final textX = tester
+          .getCenter(find.byKey(const Key('campanello-edit-text')))
+          .dx;
+      expect(imageX, lessThan(saveX));
+      expect(saveX, lessThan(textX));
+    },
+  );
+
   testWidgets('il footer hinoo non mostra Scrivi honoo', (tester) async {
     await tester.pumpWidget(
       Sizer(

--- a/test/widgets/campanelli_renderers_test.dart
+++ b/test/widgets/campanelli_renderers_test.dart
@@ -84,7 +84,8 @@ void main() {
   testWidgets('il campanello proprietario espone il comando modifica', (
     tester,
   ) async {
-    var edited = false;
+    var editedImage = false;
+    var editedText = false;
     const campanello = CampanelloData(
       id: 'campanello-1',
       campanelloHinooId: 'hinoo-1',
@@ -101,14 +102,17 @@ void main() {
             data: CampanelloPageData.campanello(campanello),
             width: 320,
             height: 500,
-            onEditTap: () => edited = true,
+            onEditImageTap: () => editedImage = true,
+            onEditTextTap: () => editedText = true,
           ),
         ),
       ),
     );
 
-    await tester.tap(find.byKey(const ValueKey('edit-own-campanello')));
-    expect(edited, isTrue);
+    await tester.tap(find.byKey(const ValueKey('edit-own-campanello-image')));
+    await tester.tap(find.byKey(const ValueKey('edit-own-campanello-text')));
+    expect(editedImage, isTrue);
+    expect(editedText, isTrue);
   });
 
   testWidgets('casa chiusa conserva messaggio e azione scrigno', (

--- a/test/widgets/global_reply_notification_listener_test.dart
+++ b/test/widgets/global_reply_notification_listener_test.dart
@@ -175,6 +175,91 @@ void main() {
     );
   });
 
+  testWidgets('una risposta già visualizzata non genera una nuova notifica', (
+    tester,
+  ) async {
+    final navigatorKey = GlobalKey<NavigatorState>();
+    final notification = _FakeReplySystemNotification();
+    final createdAt = DateTime.utc(2026, 8, 3, 10);
+    await RepliesSeenTracker.markAt(
+      createdAt,
+      userId: 'test_user',
+      conversationId: 'conversation-seen',
+    );
+
+    await tester.pumpWidget(
+      GlobalReplyNotificationListener(
+        navigatorKey: navigatorKey,
+        systemNotification: notification,
+        replyEventStream: events.stream,
+        child: MaterialApp(
+          navigatorKey: navigatorKey,
+          home: const Scaffold(body: Text('Luna')),
+        ),
+      ),
+    );
+
+    events.add(
+      ReplyNotificationEvent(
+        kind: ReplyNotificationKind.honoo,
+        conversationId: 'conversation-seen',
+        senderId: 'other_user',
+        recipientId: 'test_user',
+        replyId: 'reply-seen',
+        createdAt: createdAt,
+      ),
+    );
+    await tester.pump(const Duration(milliseconds: 200));
+    await tester.pump();
+
+    expect(notification.showCount, 0);
+    expect(find.text('Hai ricevuto una nuova risposta'), findsNothing);
+  });
+
+  testWidgets('visualizzare una risposta chiude la sua notifica attiva', (
+    tester,
+  ) async {
+    final navigatorKey = GlobalKey<NavigatorState>();
+    final notification = _FakeReplySystemNotification();
+    final createdAt = DateTime.utc(2026, 8, 3, 11);
+
+    await tester.pumpWidget(
+      GlobalReplyNotificationListener(
+        navigatorKey: navigatorKey,
+        systemNotification: notification,
+        replyEventStream: events.stream,
+        child: MaterialApp(
+          navigatorKey: navigatorKey,
+          home: const Scaffold(body: Text('Luna')),
+        ),
+      ),
+    );
+
+    events.add(
+      ReplyNotificationEvent(
+        kind: ReplyNotificationKind.honoo,
+        conversationId: 'conversation-now-seen',
+        senderId: 'other_user',
+        recipientId: 'test_user',
+        replyId: 'reply-now-seen',
+        createdAt: createdAt,
+      ),
+    );
+    await tester.pump(const Duration(milliseconds: 200));
+    expect(notification.showCount, 1);
+
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(
+      'last_seen_reply_by_conversation_v1_test_user',
+      '{"conversation-now-seen":"${createdAt.toIso8601String()}"}',
+    );
+    ReplyNotificationSignal.notifyChanged();
+    await tester.pump();
+
+    expect(notification.closedConversations, contains('conversation-now-seen'));
+    await tester.pumpWidget(const SizedBox.shrink());
+  });
+
   testWidgets(
     'un grande burst produce una sola notifica e un solo aggiornamento UI',
     (tester) async {


### PR DESCRIPTION
## Cosa cambia

- non mostra notifiche per risposte già visualizzate e chiude quelle attive quando la conversazione viene letta
- porta il Campanello dell’utente in cima alla lista e lo riconosce correttamente come proprio
- separa i comandi di modifica immagine e testo, mantenendo lo stile circolare attuale
- mostra il comando centrale di conferma/salvataggio solo dopo l’avvio di una modifica

## Perché

Lo stato locale delle risposte visualizzate non veniva verificato al momento della consegna realtime e il Campanello personale dipendeva da uno stato della casa che poteva risultare obsoleto. Inoltre l’editor esponeva un solo comando generico, senza il flusso immagine/salva/testo richiesto.

## Verifica

- `flutter test --no-pub test/widgets/global_reply_notification_listener_test.dart`
- `flutter test --no-pub test/pages/new_hinoo_page_test.dart test/widgets/campanelli_renderers_test.dart test/pages/campanelli_page_layout_test.dart test/utility/replies_seen_tracker_test.dart`
- `flutter analyze --no-pub`
- `git diff --check`
