### PR TITLE
Add scoped house knock sharing

### DIFF
--- a/lib/Controller/campanelli_controller.dart
+++ b/lib/Controller/campanelli_controller.dart
@@ -217,23 +217,18 @@ class CampanelliController extends ChangeNotifier {
 
   Future<void> approvePendingKnock({
     required String knockId,
-    required String ownerId,
-    required String campanelloHinooId,
     required List<String> shareModes,
-    DateTime? approvedAt,
   }) async {
-    final timestamp = approvedAt ?? DateTime.now();
-    await _repository.saveShareModes(
-      ownerId: ownerId,
-      campanelloHinooId: campanelloHinooId,
-      modes: shareModes,
-      updatedAt: timestamp,
-    );
-    await _repository.grantHouseAccess(
+    await _repository.approveHouseKnock(
       knockId: knockId,
-      grantedAt: timestamp,
+      shareModes: shareModes,
     );
     removePendingKnock(knockId);
+  }
+
+  Future<Set<String>> loadGrantedHouseTags(String visitorId) async {
+    final tags = await _repository.fetchGrantedHouseTags(visitorId);
+    return Set<String>.unmodifiable(tags);
   }
 
   Future<void> sendHouseKnock({

--- a/lib/Entities/casa_share_mode.dart
+++ b/lib/Entities/casa_share_mode.dart
@@ -1,38 +1,38 @@
 enum CasaShareMode {
-  honoo,
-  hinoo,
-  conversations;
+  home,
+  moon,
+  all;
 
   String get label {
     switch (this) {
-      case CasaShareMode.honoo:
-        return 'I miei honoo';
-      case CasaShareMode.hinoo:
-        return 'I miei hinoo';
-      case CasaShareMode.conversations:
-        return 'Le mie conversazioni';
+      case CasaShareMode.home:
+        return 'honoo e hinoo di casa';
+      case CasaShareMode.moon:
+        return 'honoo e hinoo dalla luna';
+      case CasaShareMode.all:
+        return 'tutto';
     }
   }
 
   String get dbValue {
     switch (this) {
-      case CasaShareMode.honoo:
-        return 'honoo';
-      case CasaShareMode.hinoo:
-        return 'hinoo';
-      case CasaShareMode.conversations:
-        return 'conversations';
+      case CasaShareMode.home:
+        return 'home';
+      case CasaShareMode.moon:
+        return 'moon';
+      case CasaShareMode.all:
+        return 'all';
     }
   }
 
   static CasaShareMode? fromDb(String? value) {
     switch (value) {
-      case 'honoo':
-        return CasaShareMode.honoo;
-      case 'hinoo':
-        return CasaShareMode.hinoo;
-      case 'conversations':
-        return CasaShareMode.conversations;
+      case 'home':
+        return CasaShareMode.home;
+      case 'moon':
+        return CasaShareMode.moon;
+      case 'all':
+        return CasaShareMode.all;
       default:
         return null;
     }

--- a/lib/IsolaDelleStorie/Pages/campanelli_page.dart
+++ b/lib/IsolaDelleStorie/Pages/campanelli_page.dart
@@ -10,7 +10,6 @@ import 'package:honoo/Entities/casa_share_mode.dart';
 import 'package:honoo/Entities/casa_request_result.dart';
 import 'package:honoo/Entities/campanelli_realtime_event.dart';
 import 'package:honoo/Entities/campanelli_view_data.dart';
-import 'package:honoo/Entities/knock_message_choice.dart';
 import 'package:honoo/Entities/pending_knock.dart';
 import 'package:honoo/Services/supabase_provider.dart';
 import 'package:honoo/Services/app_failure.dart';
@@ -24,8 +23,6 @@ import 'package:honoo/Widgets/honoo_dialogs.dart';
 import 'package:honoo/Widgets/campanelli_footer.dart';
 import 'package:honoo/Widgets/campanello_card.dart';
 import 'package:honoo/Widgets/casa_section.dart';
-import 'package:honoo/Widgets/casa_share_dialogs.dart';
-import 'package:honoo/Widgets/knock_message_dialog.dart';
 import 'package:honoo/Widgets/house_invite_dialogs.dart';
 import 'package:honoo/Widgets/pending_knocks_dialog.dart';
 import 'package:honoo/Entities/honoo.dart';
@@ -36,11 +33,10 @@ import 'package:honoo/Services/campanelli_repository.dart';
 
 import '../../Pages/home_page.dart';
 import '../../Pages/casa_builder_page.dart';
-import '../../Pages/shared_conversations_page.dart';
-import '../../Pages/shared_hinoo_page.dart';
-import '../../Pages/shared_honoo_page.dart';
+import '../../Pages/casa_share_selection_page.dart';
+import '../../Pages/chest_page.dart';
+import '../../Pages/shared_house_chest_page.dart';
 import '../../Pages/new_hinoo_page.dart';
-import '../../Pages/new_honoo_page.dart';
 import 'pending_hinoo_page.dart';
 import 'pending_honoo_page.dart';
 
@@ -74,10 +70,11 @@ class _CampanelliPageState extends State<CampanelliPage> {
   bool _showCarouselArrows = true;
   Timer? _carouselHintTimer;
   bool _isKnocking = false;
+  bool _isShowingKnockRequest = false;
+  final Set<String> _shownKnockRequestIds = <String>{};
   bool get _hasOwnHouse => _campanelliController.state.hasOwnHouse;
   bool get _hasPendingOrAcceptedInvite =>
       _campanelliController.state.hasPendingOrAcceptedInvite;
-  DateTime? _lastKnockToastAt;
   late final StreamSubscription<CampanelliRealtimeEvent>
       _realtimeEventsSubscription;
   List<PendingKnock> get _pendingKnocks =>
@@ -196,39 +193,6 @@ class _CampanelliPageState extends State<CampanelliPage> {
       return;
     }
 
-    final KnockMessageChoice? choice = await _showKnockMessageDialog();
-    if (choice == null || !mounted) return;
-
-    String? hinooId;
-    String? honooId;
-    if (choice == KnockMessageChoice.hinoo) {
-      final String? result = await Navigator.of(context).push<String>(
-        MaterialPageRoute(
-          builder: (_) => NewHinooPage(
-            forcedType: HinooType.answer,
-            recipientTag: campanello.ownerId,
-            returnSavedId: true,
-          ),
-        ),
-      );
-      if (!mounted) return;
-      if (result == null || result.isEmpty) return;
-      hinooId = result;
-    } else if (choice == KnockMessageChoice.honoo) {
-      final String? result = await Navigator.of(context).push<String>(
-        MaterialPageRoute(
-          builder: (_) => NewHonooPage(
-            forcedType: HonooType.answer,
-            recipientTag: campanello.ownerId,
-            returnSavedId: true,
-          ),
-        ),
-      );
-      if (!mounted) return;
-      if (result == null || result.isEmpty) return;
-      honooId = result;
-    }
-
     setState(() => _isKnocking = true);
     try {
       _showBusyOverlay('Invio la bussata...');
@@ -245,8 +209,6 @@ class _CampanelliPageState extends State<CampanelliPage> {
         await _campanelliController.sendHouseKnock(
           targetHouseTag: targetTag,
           visitorId: user.id,
-          hinooId: hinooId,
-          honooId: honooId,
         );
         _hideBusyOverlay();
         if (mounted) {
@@ -297,125 +259,36 @@ class _CampanelliPageState extends State<CampanelliPage> {
     await _pageController.animateTo(start, duration: _kAnimMed, curve: _kCurve);
   }
 
-  String _shareKeyFor(CampanelloData campanello) {
-    return campanello.campanelloHinooId ?? campanello.id;
-  }
-
   Future<void> _handleScrigno(CampanelloData campanello) async {
     if (!_isCampanelloUnlocked(campanello.id)) {
       showHonooToast(context, message: 'Casa chiusa.');
       return;
     }
 
-    final String shareKey = _shareKeyFor(campanello);
-    Set<CasaShareMode>? modes =
-        _campanelliController.state.shareModesByCampanello[shareKey];
     final user = SupabaseProvider.client.auth.currentUser;
     final bool isOwner = user != null && campanello.ownerId == user.id;
-
-    if ((modes == null || modes.isEmpty) && isOwner) {
-      final selected = await showDialog<Set<CasaShareMode>>(
-        context: context,
-        barrierDismissible: true,
-        builder: (_) => CasaMultiShareDialog(
-          onConfirm: (picked) => _saveShareModes(campanello, picked),
-        ),
-      );
-      if (selected == null || selected.isEmpty || !mounted) return;
-      modes = selected;
-    }
-
-    if (!mounted) return;
-    if (modes == null || modes.isEmpty) {
-      showHonooToast(
-        context,
-        message: 'Il padrone di casa non ha ancora scelto cosa condividere.',
+    if (isOwner) {
+      await Navigator.of(context).push<void>(
+        MaterialPageRoute(builder: (_) => const ChestPage()),
       );
       return;
     }
-
-    if (modes.length == 1) {
-      _openSharedContent(modes.first, campanello);
-      return;
-    }
-
-    final CasaShareMode? choice = await showDialog<CasaShareMode>(
-      context: context,
-      barrierDismissible: true,
-      builder: (_) => VisitorShareChoiceDialog(modes: modes!),
-    );
-    if (choice != null) {
-      _openSharedContent(choice, campanello);
-    }
-  }
-
-  Future<Set<CasaShareMode>?> _showOwnerMultiShareDialog() {
-    return showDialog<Set<CasaShareMode>>(
-      context: context,
-      barrierDismissible: true,
-      builder: (_) => CasaMultiShareDialog(
-        onConfirm: (modes) async {},
+    final ownerId = campanello.ownerId;
+    if (ownerId == null || ownerId.isEmpty) return;
+    await Navigator.of(context).push<void>(
+      MaterialPageRoute(
+        builder: (_) => SharedHouseChestPage(ownerId: ownerId),
       ),
     );
   }
 
-  Future<void> _saveShareModes(
-    CampanelloData campanello,
-    Set<CasaShareMode> modes,
-  ) async {
-    final user = SupabaseProvider.client.auth.currentUser;
-    if (user == null || campanello.campanelloHinooId == null) {
-      return;
-    }
-
-    final List<String> values = modes.map((m) => m.dbValue).toList();
-    await _campanelliController.saveShareModes(
-      ownerId: user.id,
-      campanelloHinooId: campanello.campanelloHinooId!,
-      modes: values,
+  Future<Set<CasaShareMode>?> _showOwnerMultiShareDialog() {
+    return Navigator.of(context).push<Set<CasaShareMode>>(
+      MaterialPageRoute(
+        fullscreenDialog: true,
+        builder: (_) => const CasaShareSelectionPage(),
+      ),
     );
-
-    if (!mounted) return;
-  }
-
-  void _openSharedContent(CasaShareMode mode, CampanelloData campanello) {
-    final ownerId = campanello.ownerId;
-    if (ownerId == null || ownerId.isEmpty) {
-      showHonooMessageDialog(
-        context,
-        title: 'Questa è una casa di esempio',
-        message: 'Il contenuto condiviso non è ancora disponibile.',
-        duration: const Duration(milliseconds: 1600),
-      );
-      return;
-    }
-
-    switch (mode) {
-      case CasaShareMode.honoo:
-        Navigator.push(
-          context,
-          MaterialPageRoute(
-            builder: (_) => SharedHonooPage(ownerId: ownerId),
-          ),
-        );
-        return;
-      case CasaShareMode.hinoo:
-        Navigator.push(
-          context,
-          MaterialPageRoute(
-            builder: (_) => SharedHinooPage(ownerId: ownerId),
-          ),
-        );
-        return;
-      case CasaShareMode.conversations:
-        Navigator.push(
-          context,
-          MaterialPageRoute(
-            builder: (_) => SharedConversationsPage(ownerId: ownerId),
-          ),
-        );
-        return;
-    }
   }
 
   List<_CampanelloEntry> _buildBaseCampanelli() {
@@ -700,6 +573,8 @@ class _CampanelliPageState extends State<CampanelliPage> {
           campanelloBgTransform: entry.campanelloBgTransform,
         );
       }).toList(growable: false);
+      final grantedHouseTags =
+          await _campanelliController.loadGrantedHouseTags(user.id);
 
       if (mounted) {
         setState(() {
@@ -707,7 +582,10 @@ class _CampanelliPageState extends State<CampanelliPage> {
           _ownedHinooIds = List<String>.from(ownedHinooIds);
           _unlockedCampanelli.addAll(
             entries
-                .where((entry) => entry.campanello.ownerId == user.id)
+                .where((entry) =>
+                    entry.campanello.ownerId == user.id ||
+                    grantedHouseTags
+                        .contains(entry.campanello.campanelloHinooId))
                 .map((entry) => entry.campanello.id),
           );
         });
@@ -736,7 +614,13 @@ class _CampanelliPageState extends State<CampanelliPage> {
       await _campanelliController.startPendingKnockRefresh(
         ownedHinooIds: ownedHinooIds,
         onChanged: () {
-          if (mounted) setState(() {});
+          if (!mounted) return;
+          setState(() {});
+          if (_pendingKnocks.isNotEmpty) {
+            final sorted = List<PendingKnock>.from(_pendingKnocks)
+              ..sort((a, b) => b.createdAt.compareTo(a.createdAt));
+            unawaited(_showKnockRequestOnce(sorted.first));
+          }
         },
       );
     } catch (error, stackTrace) {
@@ -787,17 +671,9 @@ class _CampanelliPageState extends State<CampanelliPage> {
   Future<void> _handleRealtimeEvent(CampanelliRealtimeEvent event) async {
     if (!mounted) return;
     switch (event) {
-      case CampanelliPendingKnockReceived():
+      case CampanelliPendingKnockReceived(:final knock):
         setState(() {});
-        final now = DateTime.now();
-        if (_lastKnockToastAt == null ||
-            now.difference(_lastKnockToastAt!) > const Duration(seconds: 3)) {
-          _lastKnockToastAt = now;
-          showHonooToast(
-            context,
-            message: 'Qualcuno ha bussato alla tua casa',
-          );
-        }
+        await _showKnockRequestOnce(knock);
       case CampanelliPendingKnockRemoved():
         setState(() {});
       case CampanelliAccessGranted(:final targetTag):
@@ -813,7 +689,29 @@ class _CampanelliPageState extends State<CampanelliPage> {
         final entry = _entryForTag(targetTag);
         if (entry != null && mounted) {
           setState(() => _unlockedCampanelli.add(entry.campanello.id));
+          final ownerId = entry.campanello.ownerId;
+          if (ownerId != null && ownerId.isNotEmpty) {
+            await Navigator.of(context).push<void>(
+              MaterialPageRoute(
+                builder: (_) => SharedHouseChestPage(ownerId: ownerId),
+              ),
+            );
+          }
         }
+    }
+  }
+
+  Future<void> _showKnockRequestOnce(PendingKnock knock) async {
+    if (!mounted ||
+        _isShowingKnockRequest ||
+        !_shownKnockRequestIds.add(knock.id)) {
+      return;
+    }
+    _isShowingKnockRequest = true;
+    try {
+      await _openPendingKnock(knock);
+    } finally {
+      _isShowingKnockRequest = false;
     }
   }
 
@@ -891,18 +789,16 @@ class _CampanelliPageState extends State<CampanelliPage> {
     HinooDraft? draft,
     Honoo? honoo,
   }) async {
+    final Set<CasaShareMode>? modes = await _showOwnerMultiShareDialog();
+    if (modes == null || modes.isEmpty || !mounted) return;
     _showBusyOverlay('Apro la casa...');
     try {
-      final Set<CasaShareMode>? modes = await _showOwnerMultiShareDialog();
-      if (modes == null || modes.isEmpty || !mounted) return;
       final user = SupabaseProvider.client.auth.currentUser;
       final campanelloHinooId = entry.campanello.campanelloHinooId;
       if (user == null || campanelloHinooId == null) return;
       try {
         await _campanelliController.approvePendingKnock(
           knockId: knock.id,
-          ownerId: user.id,
-          campanelloHinooId: campanelloHinooId,
           shareModes: modes.map((mode) => mode.dbValue).toList(growable: false),
         );
         if (mounted) {
@@ -959,9 +855,9 @@ class _CampanelliPageState extends State<CampanelliPage> {
         context: context,
         barrierDismissible: true,
         builder: (_) => const HonooConfirmDialog(
-          title: 'Qualcuno ha bussato alla tua casa',
-          confirmLabel: 'Apri',
-          cancelLabel: 'Non ora',
+          title: 'Qualcuno sta bussando alla tua casa, vuoi farlo entrare?',
+          confirmLabel: 'Sì',
+          cancelLabel: 'No',
         ),
       );
 
@@ -1001,14 +897,6 @@ class _CampanelliPageState extends State<CampanelliPage> {
         await _approvePendingKnock(knock, entry, honoo: honoo);
       }
     }
-  }
-
-  Future<KnockMessageChoice?> _showKnockMessageDialog() {
-    return showDialog<KnockMessageChoice>(
-      context: context,
-      barrierDismissible: true,
-      builder: (_) => const KnockMessageDialog(),
-    );
   }
 
   Future<void> _openPendingKnocksDialog() async {

--- a/lib/Pages/casa_share_selection_page.dart
+++ b/lib/Pages/casa_share_selection_page.dart
@@ -1,0 +1,213 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+import '../Entities/casa_share_mode.dart';
+import '../Utility/honoo_colors.dart';
+
+class CasaShareSelectionPage extends StatefulWidget {
+  const CasaShareSelectionPage({
+    super.key,
+    this.initialSelection = const <CasaShareMode>{},
+  });
+
+  final Set<CasaShareMode> initialSelection;
+
+  @override
+  State<CasaShareSelectionPage> createState() => _CasaShareSelectionPageState();
+}
+
+class _CasaShareSelectionPageState extends State<CasaShareSelectionPage> {
+  late final Set<CasaShareMode> _selected = Set<CasaShareMode>.of(
+    widget.initialSelection,
+  );
+
+  void _toggle(CasaShareMode mode) {
+    setState(() {
+      if (!_selected.add(mode)) _selected.remove(mode);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: HonooColor.background,
+      body: SafeArea(
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            final compact = constraints.maxHeight < 650;
+            final iconSize = compact ? 72.0 : 96.0;
+            final spacing = compact ? 18.0 : 32.0;
+            return Stack(
+              fit: StackFit.expand,
+              children: [
+                SingleChildScrollView(
+                  padding: const EdgeInsets.fromLTRB(24, 28, 24, 96),
+                  child: ConstrainedBox(
+                    constraints: BoxConstraints(
+                      minHeight: constraints.maxHeight - 124,
+                    ),
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        Text(
+                          'cosa vuoi mostrare?',
+                          key: const ValueKey('house-share-title'),
+                          textAlign: TextAlign.center,
+                          style: GoogleFonts.arvo(
+                            color: Colors.white,
+                            fontSize: compact ? 22 : 26,
+                            fontWeight: FontWeight.w400,
+                          ),
+                        ),
+                        SizedBox(height: compact ? 24 : 40),
+                        _ShareIcon(
+                          key: const ValueKey('house-share-home'),
+                          mode: CasaShareMode.home,
+                          asset: 'assets/icons/honoo_chest_blue.svg',
+                          selected: _selected.contains(CasaShareMode.home),
+                          size: iconSize,
+                          addWhiteOutline: true,
+                          onTap: () => _toggle(CasaShareMode.home),
+                        ),
+                        SizedBox(height: spacing),
+                        _ShareIcon(
+                          key: const ValueKey('house-share-moon'),
+                          mode: CasaShareMode.moon,
+                          asset: 'assets/icons/honoo_chest_white.svg',
+                          selected: _selected.contains(CasaShareMode.moon),
+                          size: iconSize,
+                          onTap: () => _toggle(CasaShareMode.moon),
+                        ),
+                        SizedBox(height: spacing),
+                        _ShareIcon(
+                          key: const ValueKey('house-share-all'),
+                          mode: CasaShareMode.all,
+                          asset: 'assets/icons/chest_home.svg',
+                          selected: _selected.contains(CasaShareMode.all),
+                          size: iconSize,
+                          addWhiteOutline: true,
+                          onTap: () => _toggle(CasaShareMode.all),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+                Positioned(
+                  right: 20,
+                  bottom: 14,
+                  child: Tooltip(
+                    message: 'Salva',
+                    preferBelow: false,
+                    child: IconButton(
+                      key: const ValueKey('house-share-confirm'),
+                      onPressed: _selected.isEmpty
+                          ? null
+                          : () => Navigator.of(
+                              context,
+                            ).pop(Set<CasaShareMode>.unmodifiable(_selected)),
+                      iconSize: compact ? 48 : 58,
+                      padding: const EdgeInsets.all(8),
+                      icon: Opacity(
+                        opacity: _selected.isEmpty ? 0.35 : 1,
+                        child: SvgPicture.asset(
+                          'assets/icons/ok.svg',
+                          width: compact ? 48 : 58,
+                          height: compact ? 48 : 58,
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            );
+          },
+        ),
+      ),
+    );
+  }
+}
+
+class _ShareIcon extends StatelessWidget {
+  const _ShareIcon({
+    super.key,
+    required this.mode,
+    required this.asset,
+    required this.selected,
+    required this.size,
+    required this.onTap,
+    this.addWhiteOutline = false,
+  });
+
+  final CasaShareMode mode;
+  final String asset;
+  final bool selected;
+  final double size;
+  final VoidCallback onTap;
+  final bool addWhiteOutline;
+
+  @override
+  Widget build(BuildContext context) {
+    final icon = Stack(
+      alignment: Alignment.center,
+      children: [
+        if (addWhiteOutline)
+          Transform.scale(
+            scale: 1.045,
+            child: SvgPicture.asset(
+              asset,
+              width: size,
+              height: size,
+              colorFilter: const ColorFilter.mode(
+                Colors.white,
+                BlendMode.srcIn,
+              ),
+            ),
+          ),
+        SvgPicture.asset(asset, width: size, height: size),
+      ],
+    );
+
+    return Tooltip(
+      message: mode.label,
+      preferBelow: false,
+      verticalOffset: 18,
+      waitDuration: const Duration(milliseconds: 250),
+      child: Semantics(
+        button: true,
+        selected: selected,
+        label: mode.label,
+        child: Material(
+          color: Colors.transparent,
+          child: InkWell(
+            customBorder: const CircleBorder(),
+            onTap: onTap,
+            child: AnimatedContainer(
+              duration: const Duration(milliseconds: 220),
+              curve: Curves.easeOut,
+              width: size + 34,
+              height: size + 24,
+              alignment: Alignment.center,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                color: selected
+                    ? Colors.white.withValues(alpha: 0.14)
+                    : Colors.transparent,
+                boxShadow: selected
+                    ? [
+                        BoxShadow(
+                          color: Colors.white.withValues(alpha: 0.9),
+                          blurRadius: 24,
+                          spreadRadius: 3,
+                        ),
+                      ]
+                    : const [],
+              ),
+              child: icon,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/Pages/new_hinoo_page.dart
+++ b/lib/Pages/new_hinoo_page.dart
@@ -601,7 +601,7 @@ class _NewHinooPageState extends State<NewHinooPage>
                     iconSize: secondaryActionIconSize,
                     color: HonooColor.onBackground,
                     icon: SvgPicture.asset(
-                      'assets/icons/sostituisci immagine.svg',
+                      'assets/icons/immagine.svg',
                       width: secondaryActionIconSize,
                       height: secondaryActionIconSize,
                       colorFilter: const ColorFilter.mode(

--- a/lib/Pages/shared_house_chest_page.dart
+++ b/lib/Pages/shared_house_chest_page.dart
@@ -1,0 +1,134 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+import '../Entities/chest_item.dart';
+import '../Services/house_shared_content_service.dart';
+import '../UI/hinoo_viewer.dart';
+import '../UI/honoo_card.dart';
+import '../Utility/honoo_colors.dart';
+import '../Widgets/honoo_app_title.dart';
+import '../Widgets/loading_spinner.dart';
+
+class SharedHouseChestPage extends StatefulWidget {
+  const SharedHouseChestPage({super.key, required this.ownerId});
+
+  final String ownerId;
+
+  @override
+  State<SharedHouseChestPage> createState() => _SharedHouseChestPageState();
+}
+
+class _SharedHouseChestPageState extends State<SharedHouseChestPage> {
+  final HouseSharedContentService _service = HouseSharedContentService();
+  final PageController _pageController = PageController();
+  List<ChestItem> _items = const [];
+  bool _loading = true;
+  Object? _error;
+  int _index = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    try {
+      final items = await _service.fetch(widget.ownerId);
+      if (!mounted) return;
+      setState(() {
+        _items = items;
+        _loading = false;
+      });
+    } catch (error) {
+      if (!mounted) return;
+      setState(() {
+        _error = error;
+        _loading = false;
+      });
+    }
+  }
+
+  @override
+  void dispose() {
+    _pageController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: HonooColor.background,
+      body: SafeArea(
+        child: Column(
+          children: [
+            Padding(
+              padding: const EdgeInsets.only(top: 8),
+              child: HonooAppTitle(onTap: () => Navigator.of(context).pop()),
+            ),
+            Expanded(child: _body()),
+            if (_items.length > 1)
+              Padding(
+                padding: const EdgeInsets.only(bottom: 10),
+                child: Text(
+                  '${_index + 1} / ${_items.length}',
+                  style: GoogleFonts.arvo(color: Colors.white70, fontSize: 13),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _body() {
+    if (_loading) {
+      return const Center(child: LoadingSpinner(color: Colors.white));
+    }
+    if (_error != null) {
+      return _message('Non riesco ad aprire lo scrigno. Riprova.');
+    }
+    if (_items.isEmpty) {
+      return _message('Non ci sono ancora contenuti da mostrare.');
+    }
+    return LayoutBuilder(
+      builder: (context, constraints) => PageView.builder(
+        key: const ValueKey('shared-house-content'),
+        controller: _pageController,
+        itemCount: _items.length,
+        onPageChanged: (value) => setState(() => _index = value),
+        itemBuilder: (context, index) {
+          final item = _items[index];
+          return item.when(
+            honoo: (honoo) => Center(
+              child: SizedBox(
+                width: constraints.maxWidth,
+                height: constraints.maxHeight,
+                child: HonooCard(honoo: honoo),
+              ),
+            ),
+            hinoo: (hinoo) => Center(
+              child: HinooViewer(
+                draft: hinoo.draft,
+                maxWidth: constraints.maxWidth,
+                maxHeight: constraints.maxHeight,
+                authorId: hinoo.ownerId,
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _message(String value) => Center(
+    child: Padding(
+      padding: const EdgeInsets.all(28),
+      child: Text(
+        value,
+        textAlign: TextAlign.center,
+        style: GoogleFonts.arvo(color: Colors.white, fontSize: 18),
+      ),
+    ),
+  );
+}

--- a/lib/Services/campanelli_repository.dart
+++ b/lib/Services/campanelli_repository.dart
@@ -6,7 +6,7 @@ import 'supabase_provider.dart';
 /// Mapping, ordinamento e stato UI restano fuori dal repository.
 class CampanelliDataRepository {
   CampanelliDataRepository({SupabaseClient? client})
-      : _client = client ?? SupabaseProvider.client;
+    : _client = client ?? SupabaseProvider.client;
 
   final SupabaseClient _client;
 
@@ -28,8 +28,10 @@ class CampanelliDataRepository {
 
   Future<List<dynamic>> fetchHinooRows(List<String> hinooIds) async {
     if (hinooIds.isEmpty) return const [];
-    final rows =
-        await _client.from('hinoo').select('id,pages').in_('id', hinooIds);
+    final rows = await _client
+        .from('hinoo')
+        .select('id,pages')
+        .in_('id', hinooIds);
     return _asList(rows);
   }
 
@@ -69,9 +71,36 @@ class CampanelliDataRepository {
     required String knockId,
     required DateTime grantedAt,
   }) async {
-    await _client.from('house_access').update({
-      'granted_at': grantedAt.toIso8601String(),
-    }).eq('id', knockId);
+    await _client
+        .from('house_access')
+        .update({'granted_at': grantedAt.toIso8601String()})
+        .eq('id', knockId);
+  }
+
+  Future<void> approveHouseKnock({
+    required String knockId,
+    required List<String> shareModes,
+  }) async {
+    final parsedKnockId = int.parse(knockId);
+    await _client.rpc(
+      'approve_house_knock',
+      params: {'p_knock_id': parsedKnockId, 'p_share_modes': shareModes},
+    );
+  }
+
+  Future<List<String>> fetchGrantedHouseTags(String visitorId) async {
+    final rows = await _client
+        .from('house_access')
+        .select('target_house_tag,share_modes')
+        .eq('visitor_id', visitorId)
+        .not('granted_at', 'is', null);
+    return _asList(rows)
+        .whereType<Map>()
+        .where((row) => row['share_modes'] is List &&
+            (row['share_modes'] as List).isNotEmpty)
+        .map((row) => row['target_house_tag']?.toString() ?? '')
+        .where((tag) => tag.isNotEmpty)
+        .toList(growable: false);
   }
 
   Future<void> sendHouseKnock({

--- a/lib/Services/house_shared_content_service.dart
+++ b/lib/Services/house_shared_content_service.dart
@@ -1,0 +1,40 @@
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import '../Entities/chest_item.dart';
+import '../Entities/honoo.dart';
+import 'supabase_provider.dart';
+
+class HouseSharedContentService {
+  HouseSharedContentService({SupabaseClient? client})
+    : _client = client ?? SupabaseProvider.client;
+
+  final SupabaseClient _client;
+
+  Future<List<ChestItem>> fetch(String ownerId) async {
+    final response = await _client.rpc(
+      'get_shared_house_chest',
+      params: {'p_owner_id': ownerId},
+    );
+    if (response is! List) return const [];
+
+    final items = <ChestItem>[];
+    for (final raw in response.whereType<Map>()) {
+      final kind = raw['kind']?.toString();
+      final data = raw['data'];
+      if (data is! Map) continue;
+      final row = Map<String, dynamic>.from(data);
+      if (kind == 'honoo') {
+        final honoo = Honoo.fromMap(row);
+        final createdAt =
+            DateTime.tryParse(honoo.createdAt) ??
+            DateTime.fromMillisecondsSinceEpoch(0);
+        items.add(ChestItem.honoo(honoo, createdAt));
+      } else if (kind == 'hinoo') {
+        final hinoo = ChestHinooItem.fromDatabaseRow(row);
+        if (hinoo != null) items.add(ChestItem.hinoo(hinoo));
+      }
+    }
+    items.sort((a, b) => b.createdAt.compareTo(a.createdAt));
+    return List<ChestItem>.unmodifiable(items);
+  }
+}

--- a/lib/UI/HinooBuilder/overlays/cambia_sfondo.dart
+++ b/lib/UI/HinooBuilder/overlays/cambia_sfondo.dart
@@ -192,7 +192,7 @@ class CambiaSfondoOverlay extends StatelessWidget {
                         ),
                       ),
                       icon: SvgPicture.asset(
-                        'assets/icons/sostituisci immagine.svg',
+                        'assets/icons/immagine.svg',
                         width: 24,
                         height: 24,
                         colorFilter: const ColorFilter.mode(

--- a/lib/UI/honoo_builder.dart
+++ b/lib/UI/honoo_builder.dart
@@ -772,7 +772,7 @@ class HonooBuilderState extends State<HonooBuilder> {
                       iconSize: secondaryActionIconSize,
                       color: HonooColor.onBackground,
                       icon: SvgPicture.asset(
-                        'assets/icons/sostituisci immagine.svg',
+                        'assets/icons/immagine.svg',
                         width: secondaryActionIconSize,
                         height: secondaryActionIconSize,
                         colorFilter: const ColorFilter.mode(
@@ -951,7 +951,7 @@ class HonooBuilderState extends State<HonooBuilder> {
                             ),
                           ),
                           icon: SvgPicture.asset(
-                            'assets/icons/sostituisci immagine.svg',
+                            'assets/icons/immagine.svg',
                             width: 20,
                             height: 20,
                             colorFilter: const ColorFilter.mode(

--- a/lib/Widgets/campanello_card.dart
+++ b/lib/Widgets/campanello_card.dart
@@ -76,7 +76,7 @@ class CampanelloCard extends StatelessWidget {
                 key: const ValueKey('edit-own-campanello'),
                 onPressed: onEditTap!,
                 tooltip: 'Modifica campanello',
-                asset: 'assets/icons/sostituisci immagine.svg',
+                asset: 'assets/icons/immagine.svg',
               ),
             ),
         ],

--- a/lib/Widgets/casa_section.dart
+++ b/lib/Widgets/casa_section.dart
@@ -89,7 +89,7 @@ class CasaSection extends StatelessWidget {
                 key: const ValueKey('edit-own-casa'),
                 onPressed: onEditTap!,
                 tooltip: 'Modifica casa',
-                asset: 'assets/icons/sostituisci immagine.svg',
+                asset: 'assets/icons/immagine.svg',
               ),
             ),
           Positioned(

--- a/supabase/migrations/20260811120000_house_access_scoped_sharing.sql
+++ b/supabase/migrations/20260811120000_house_access_scoped_sharing.sql
@@ -1,0 +1,140 @@
+alter table public.house_access
+  add column if not exists share_modes text[] not null default '{}';
+
+alter table public.house_access
+  drop constraint if exists house_access_share_modes_valid;
+
+alter table public.house_access
+  add constraint house_access_share_modes_valid check (
+    share_modes <@ array['home', 'moon', 'all']::text[]
+  );
+
+create index if not exists house_access_visitor_granted_idx
+  on public.house_access (visitor_id, granted_at)
+  where granted_at is not null;
+
+create or replace function public.approve_house_knock(
+  p_knock_id bigint,
+  p_share_modes text[]
+)
+returns void
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+begin
+  if auth.uid() is null then
+    raise exception 'Authentication required' using errcode = '42501';
+  end if;
+
+  if p_share_modes is null
+     or coalesce(array_length(p_share_modes, 1), 0) = 0
+     or not (p_share_modes <@ array['home', 'moon', 'all']::text[]) then
+    raise exception 'Invalid house share modes' using errcode = '22023';
+  end if;
+
+  update public.house_access ha
+  set granted_at = now(),
+      share_modes = array(select distinct unnest(p_share_modes))
+  where ha.id = p_knock_id
+    and ha.granted_at is null
+    and exists (
+      select 1
+      from public."case" c
+      where c.campanello_hinoo_id::text = ha.target_house_tag
+        and c.owner_id = auth.uid()
+    );
+
+  if not found then
+    raise exception 'Pending knock not found or not owned by user'
+      using errcode = '42501';
+  end if;
+end;
+$$;
+
+revoke all on function public.approve_house_knock(bigint, text[]) from public;
+grant execute on function public.approve_house_knock(bigint, text[])
+  to authenticated;
+
+create or replace function public.get_shared_house_chest(p_owner_id uuid)
+returns table(kind text, data jsonb, created_at timestamptz)
+language plpgsql
+stable
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  allowed_modes text[];
+begin
+  if auth.uid() is null then
+    raise exception 'Authentication required' using errcode = '42501';
+  end if;
+
+  select coalesce(array_agg(distinct granted.mode), '{}'::text[])
+  into allowed_modes
+  from public.house_access ha
+  join public."case" c
+    on c.campanello_hinoo_id::text = ha.target_house_tag
+  cross join lateral unnest(ha.share_modes) as granted(mode)
+  where ha.visitor_id = auth.uid()
+    and ha.granted_at is not null
+    and c.owner_id = p_owner_id;
+
+  if coalesce(array_length(allowed_modes, 1), 0) = 0 then
+    raise exception 'House access not granted' using errcode = '42501';
+  end if;
+
+  return query
+  select shared.kind, shared.data, shared.created_at
+  from (
+    select
+      'honoo'::text as kind,
+      jsonb_build_object(
+        'id', h.id,
+        'text', h.text,
+        'image_url', h.image_url,
+        'destination', h.destination,
+        'created_at', h.created_at,
+        'updated_at', h.updated_at,
+        'user_id', h.user_id,
+        'is_from_moon_saved', h.is_from_moon_saved
+      ) as data,
+      h.created_at
+    from public.honoo h
+    where h.user_id = p_owner_id
+      and h.destination = 'chest'
+      and (
+        'all' = any(allowed_modes)
+        or ('home' = any(allowed_modes) and not coalesce(h.is_from_moon_saved, false))
+        or ('moon' = any(allowed_modes) and coalesce(h.is_from_moon_saved, false))
+      )
+
+    union all
+
+    select
+      'hinoo'::text as kind,
+      jsonb_build_object(
+        'id', h.id,
+        'pages', h.pages,
+        'type', h.type,
+        'created_at', h.created_at,
+        'user_id', h.user_id,
+        'is_from_moon_saved', h.is_from_moon_saved
+      ) as data,
+      h.created_at
+    from public.hinoo h
+    where h.user_id = p_owner_id
+      and h.type = 'personal'::public.hinoo_type
+      and (
+        'all' = any(allowed_modes)
+        or ('home' = any(allowed_modes) and not coalesce(h.is_from_moon_saved, false))
+        or ('moon' = any(allowed_modes) and coalesce(h.is_from_moon_saved, false))
+      )
+  ) shared
+  order by shared.created_at desc;
+end;
+$$;
+
+revoke all on function public.get_shared_house_chest(uuid) from public;
+grant execute on function public.get_shared_house_chest(uuid)
+  to authenticated;

--- a/test/controllers/campanelli_controller_test.dart
+++ b/test/controllers/campanelli_controller_test.dart
@@ -255,43 +255,25 @@ void main() {
   });
 
   test('approva la bussata e la rimuove dallo stato', () async {
-    final approvedAt = DateTime.utc(2026, 7, 18, 10, 30);
     controller.addPendingKnockRow(const {
       'id': 'knock-1',
       'target_house_tag': 'hinoo-1',
       'created_at': '2026-07-18T10:00:00Z',
     });
-    when(() => repository.saveShareModes(
-          ownerId: 'owner-1',
-          campanelloHinooId: 'hinoo-1',
-          modes: ['honoo', 'hinoo'],
-          updatedAt: approvedAt,
-        )).thenAnswer((_) async {});
-    when(() => repository.grantHouseAccess(
+    when(() => repository.approveHouseKnock(
           knockId: 'knock-1',
-          grantedAt: approvedAt,
+          shareModes: ['home', 'moon'],
         )).thenAnswer((_) async {});
 
     await controller.approvePendingKnock(
       knockId: 'knock-1',
-      ownerId: 'owner-1',
-      campanelloHinooId: 'hinoo-1',
-      shareModes: const ['honoo', 'hinoo'],
-      approvedAt: approvedAt,
+      shareModes: const ['home', 'moon'],
     );
 
-    verifyInOrder([
-      () => repository.saveShareModes(
-            ownerId: 'owner-1',
-            campanelloHinooId: 'hinoo-1',
-            modes: ['honoo', 'hinoo'],
-            updatedAt: approvedAt,
-          ),
-      () => repository.grantHouseAccess(
-            knockId: 'knock-1',
-            grantedAt: approvedAt,
-          ),
-    ]);
+    verify(() => repository.approveHouseKnock(
+          knockId: 'knock-1',
+          shareModes: ['home', 'moon'],
+        )).called(1);
     expect(controller.state.pendingKnocks, isEmpty);
   });
 
@@ -322,50 +304,40 @@ void main() {
     when(() => repository.saveShareModes(
           ownerId: 'owner-1',
           campanelloHinooId: 'hinoo-1',
-          modes: ['honoo', 'conversations'],
+          modes: ['home', 'all'],
           updatedAt: updatedAt,
         )).thenAnswer((_) async {});
 
     await controller.saveShareModes(
       ownerId: 'owner-1',
       campanelloHinooId: 'hinoo-1',
-      modes: const ['honoo', 'conversations'],
+      modes: const ['home', 'all'],
       updatedAt: updatedAt,
     );
 
     verify(() => repository.saveShareModes(
           ownerId: 'owner-1',
           campanelloHinooId: 'hinoo-1',
-          modes: ['honoo', 'conversations'],
+          modes: ['home', 'all'],
           updatedAt: updatedAt,
         )).called(1);
   });
 
   test('mantiene la bussata pendente se la concessione fallisce', () async {
-    final approvedAt = DateTime.utc(2026, 7, 18, 10, 30);
     controller.addPendingKnockRow(const {
       'id': 'knock-1',
       'target_house_tag': 'hinoo-1',
       'created_at': '2026-07-18T10:00:00Z',
     });
-    when(() => repository.saveShareModes(
-          ownerId: any(named: 'ownerId'),
-          campanelloHinooId: any(named: 'campanelloHinooId'),
-          modes: any(named: 'modes'),
-          updatedAt: any(named: 'updatedAt'),
-        )).thenAnswer((_) async {});
-    when(() => repository.grantHouseAccess(
+    when(() => repository.approveHouseKnock(
           knockId: any(named: 'knockId'),
-          grantedAt: any(named: 'grantedAt'),
+          shareModes: any(named: 'shareModes'),
         )).thenThrow(StateError('offline'));
 
     await expectLater(
       controller.approvePendingKnock(
         knockId: 'knock-1',
-        ownerId: 'owner-1',
-        campanelloHinooId: 'hinoo-1',
-        shareModes: const ['honoo'],
-        approvedAt: approvedAt,
+        shareModes: const ['home'],
       ),
       throwsStateError,
     );

--- a/test/entities/casa_share_mode_test.dart
+++ b/test/entities/casa_share_mode_test.dart
@@ -3,21 +3,18 @@ import 'package:honoo/Entities/casa_share_mode.dart';
 
 void main() {
   test('mantiene etichette e valori database', () {
-    expect(CasaShareMode.honoo.label, 'I miei honoo');
-    expect(CasaShareMode.honoo.dbValue, 'honoo');
-    expect(CasaShareMode.hinoo.label, 'I miei hinoo');
-    expect(CasaShareMode.hinoo.dbValue, 'hinoo');
-    expect(CasaShareMode.conversations.label, 'Le mie conversazioni');
-    expect(CasaShareMode.conversations.dbValue, 'conversations');
+    expect(CasaShareMode.home.label, 'honoo e hinoo di casa');
+    expect(CasaShareMode.home.dbValue, 'home');
+    expect(CasaShareMode.moon.label, 'honoo e hinoo dalla luna');
+    expect(CasaShareMode.moon.dbValue, 'moon');
+    expect(CasaShareMode.all.label, 'tutto');
+    expect(CasaShareMode.all.dbValue, 'all');
   });
 
   test('converte i valori database e rifiuta quelli sconosciuti', () {
-    expect(CasaShareMode.fromDb('honoo'), CasaShareMode.honoo);
-    expect(CasaShareMode.fromDb('hinoo'), CasaShareMode.hinoo);
-    expect(
-      CasaShareMode.fromDb('conversations'),
-      CasaShareMode.conversations,
-    );
+    expect(CasaShareMode.fromDb('home'), CasaShareMode.home);
+    expect(CasaShareMode.fromDb('moon'), CasaShareMode.moon);
+    expect(CasaShareMode.fromDb('all'), CasaShareMode.all);
     expect(CasaShareMode.fromDb('unknown'), isNull);
     expect(CasaShareMode.fromDb(null), isNull);
   });

--- a/test/pages/new_hinoo_page_test.dart
+++ b/test/pages/new_hinoo_page_test.dart
@@ -118,7 +118,7 @@ void main() {
     );
     expect(
       (replaceIcon.bytesLoader as SvgAssetLoader).assetName,
-      'assets/icons/sostituisci immagine.svg',
+      'assets/icons/immagine.svg',
     );
     expect(
       tester.getCenter(replaceImage).dx,

--- a/test/services/campanelli_repository_test.dart
+++ b/test/services/campanelli_repository_test.dart
@@ -122,6 +122,45 @@ void main() {
     verify(() => houseAccess.eq('id', 'knock-1')).called(1);
   });
 
+  test('approveHouseKnock salva i filtri sulla singola bussata', () async {
+    final rpc = MockQueryChain()..queueResponse(null);
+    when(() => harness.client.rpc(
+          'approve_house_knock',
+          params: any(named: 'params'),
+        )).thenAnswer((_) => rpc);
+
+    await repository.approveHouseKnock(
+      knockId: '42',
+      shareModes: const ['home', 'moon'],
+    );
+
+    verify(() => harness.client.rpc(
+          'approve_house_knock',
+          params: {
+            'p_knock_id': 42,
+            'p_share_modes': ['home', 'moon'],
+          },
+        )).called(1);
+  });
+
+  test('fetchGrantedHouseTags restituisce solo tag validi', () async {
+    when(() => houseAccess.not('granted_at', 'is', null))
+        .thenAnswer((_) => houseAccess);
+    houseAccess.queueResponse(const [
+      {'target_house_tag': 'house-1', 'share_modes': ['home']},
+      {'target_house_tag': '', 'share_modes': ['all']},
+      {'target_house_tag': 'legacy-house', 'share_modes': []},
+      {'target_house_tag': 'house-2', 'share_modes': ['moon']},
+    ]);
+
+    expect(
+      await repository.fetchGrantedHouseTags('visitor-1'),
+      ['house-1', 'house-2'],
+    );
+    verify(() => houseAccess.eq('visitor_id', 'visitor-1')).called(1);
+    verify(() => houseAccess.not('granted_at', 'is', null)).called(1);
+  });
+
   test('saveShareModes mantiene payload e chiave di conflitto', () async {
     final updatedAt = DateTime.utc(2026, 7, 18, 10, 30);
     when(() => settings.upsert(

--- a/test/services/house_shared_content_service_test.dart
+++ b/test/services/house_shared_content_service_test.dart
@@ -1,0 +1,60 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:honoo/Services/house_shared_content_service.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../test_supabase_helper.dart';
+
+void main() {
+  setUpAll(registerSupabaseFallbacks);
+
+  test('mappa e ordina lo scrigno autorizzato restituito dalla RPC', () async {
+    final harness = SupabaseTestHarness(withAuthenticatedUser: true);
+    final rpc = MockQueryChain()
+      ..queueResponse([
+        {
+          'kind': 'honoo',
+          'data': {
+            'id': 'honoo-1',
+            'text': 'Honoo condiviso',
+            'image_url': '',
+            'destination': 'chest',
+            'created_at': '2026-08-10T10:00:00Z',
+            'updated_at': '2026-08-10T10:00:00Z',
+            'user_id': 'owner-1',
+            'is_from_moon_saved': false,
+          },
+        },
+        {
+          'kind': 'hinoo',
+          'data': {
+            'id': 'hinoo-1',
+            'pages': [
+              {
+                'text': 'Hinoo condiviso',
+                'backgroundImage': '',
+              },
+            ],
+            'type': 'personal',
+            'created_at': '2026-08-11T10:00:00Z',
+            'user_id': 'owner-1',
+            'is_from_moon_saved': true,
+          },
+        },
+      ]);
+    when(() => harness.client.rpc(
+          'get_shared_house_chest',
+          params: any(named: 'params'),
+        )).thenAnswer((_) => rpc);
+
+    final items = await HouseSharedContentService(client: harness.client)
+        .fetch('owner-1');
+
+    expect(items, hasLength(2));
+    expect(items.first.hinoo?.id, 'hinoo-1');
+    expect(items.last.honoo?.dbId, 'honoo-1');
+    verify(() => harness.client.rpc(
+          'get_shared_house_chest',
+          params: {'p_owner_id': 'owner-1'},
+        )).called(1);
+  });
+}

--- a/test/ui/honoo_image_editor_controls_test.dart
+++ b/test/ui/honoo_image_editor_controls_test.dart
@@ -116,7 +116,7 @@ void main() {
     expect(editButton.iconSize, replaceButton.iconSize);
     expect(
       (replaceIcon.bytesLoader as SvgAssetLoader).assetName,
-      'assets/icons/sostituisci immagine.svg',
+      'assets/icons/immagine.svg',
     );
     expect(
       (editIcon.bytesLoader as SvgAssetLoader).assetName,

--- a/test/widgets/campanelli_interaction_dialogs_test.dart
+++ b/test/widgets/campanelli_interaction_dialogs_test.dart
@@ -1,50 +1,19 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:honoo/Entities/casa_share_mode.dart';
-import 'package:honoo/Entities/knock_message_choice.dart';
-import 'package:honoo/Widgets/casa_share_dialogs.dart';
-import 'package:honoo/Widgets/knock_message_dialog.dart';
+import 'package:honoo/Pages/casa_share_selection_page.dart';
 
 void main() {
-  testWidgets('scelta messaggio restituisce Hinoo su viewport mobile',
-      (tester) async {
-    KnockMessageChoice? result;
-    await tester.pumpWidget(
-      MaterialApp(
-        home: Builder(
-          builder: (context) => TextButton(
-            onPressed: () async {
-              result = await showDialog<KnockMessageChoice>(
-                context: context,
-                builder: (_) => const KnockMessageDialog(),
-              );
-            },
-            child: const Text('Apri'),
-          ),
-        ),
-      ),
-    );
-    await tester.tap(find.text('Apri'));
-    await tester.pumpAndSettle();
-    expect(find.text('Vuoi inviare un messaggio\nprima di bussare?'),
-        findsOneWidget);
-    await tester.tap(find.text('Scrivi un hinoo'));
-    await tester.pumpAndSettle();
-    expect(result, KnockMessageChoice.hinoo);
-  });
-
-  testWidgets('condivisione multipla salva la selezione', (tester) async {
-    Set<CasaShareMode>? saved;
+  testWidgets('pagina responsive salva una selezione multipla', (tester) async {
     Set<CasaShareMode>? result;
     await tester.pumpWidget(
       MaterialApp(
         home: Builder(
           builder: (context) => TextButton(
             onPressed: () async {
-              result = await showDialog<Set<CasaShareMode>>(
-                context: context,
-                builder: (_) => CasaMultiShareDialog(
-                  onConfirm: (modes) async => saved = Set.of(modes),
+              result = await Navigator.of(context).push<Set<CasaShareMode>>(
+                MaterialPageRoute(
+                  builder: (_) => const CasaShareSelectionPage(),
                 ),
               );
             },
@@ -55,49 +24,31 @@ void main() {
     );
     await tester.tap(find.text('Apri'));
     await tester.pumpAndSettle();
-    await tester.tap(find.text(CasaShareMode.honoo.label));
-    await tester.tap(find.text(CasaShareMode.hinoo.label));
+    expect(find.text('cosa vuoi mostrare?'), findsOneWidget);
+    expect(find.byKey(const ValueKey('house-share-home')), findsOneWidget);
+    expect(find.byKey(const ValueKey('house-share-moon')), findsOneWidget);
+    expect(find.byKey(const ValueKey('house-share-all')), findsOneWidget);
+    await tester.tap(find.byKey(const ValueKey('house-share-home')));
+    await tester.tap(find.byKey(const ValueKey('house-share-moon')));
     await tester.pump();
-    await tester.tap(find.text('Condividi'));
+    await tester.tap(find.byKey(const ValueKey('house-share-confirm')));
     await tester.pumpAndSettle();
 
-    expect(saved, {CasaShareMode.honoo, CasaShareMode.hinoo});
-    expect(result, saved);
+    expect(result, {CasaShareMode.home, CasaShareMode.moon});
   });
 
-  testWidgets('visitatore sceglie il contenuto su viewport desktop',
-      (tester) async {
-    CasaShareMode? result;
+  testWidgets('icone restano visibili su viewport desktop', (tester) async {
     tester.view.physicalSize = const Size(1200, 900);
     tester.view.devicePixelRatio = 1;
     addTearDown(tester.view.resetPhysicalSize);
     addTearDown(tester.view.resetDevicePixelRatio);
 
-    await tester.pumpWidget(
-      MaterialApp(
-        home: Builder(
-          builder: (context) => TextButton(
-            onPressed: () async {
-              result = await showDialog<CasaShareMode>(
-                context: context,
-                builder: (_) => const VisitorShareChoiceDialog(
-                  modes: {
-                    CasaShareMode.honoo,
-                    CasaShareMode.conversations,
-                  },
-                ),
-              );
-            },
-            child: const Text('Apri'),
-          ),
-        ),
-      ),
-    );
-    await tester.tap(find.text('Apri'));
+    await tester.pumpWidget(const MaterialApp(home: CasaShareSelectionPage()));
     await tester.pumpAndSettle();
     expect(tester.takeException(), isNull);
-    await tester.tap(find.text(CasaShareMode.conversations.label));
-    await tester.pumpAndSettle();
-    expect(result, CasaShareMode.conversations);
+    expect(find.byKey(const ValueKey('house-share-confirm')), findsOneWidget);
+    expect(find.byTooltip('honoo e hinoo di casa'), findsOneWidget);
+    expect(find.byTooltip('honoo e hinoo dalla luna'), findsOneWidget);
+    expect(find.byTooltip('tutto'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Cosa cambia

- sostituisce tutti i riferimenti alla vecchia icona immagine con `assets/icons/immagine.svg`
- invia una bussata immediata alle case chiuse e mostra al proprietario il popup di autorizzazione nello stile dell’app
- aggiunge la schermata responsive “cosa vuoi mostrare?” con i tre filtri richiesti, tooltip, selezione multipla, bagliore e conferma tramite `ok.svg`
- salva i permessi sulla singola bussata e apre direttamente al visitatore lo scrigno filtrato
- aggiunge una RPC `security definer` che espone soltanto i contenuti autorizzati, distinguendo contenuti di casa e salvati dalla luna
- aggiunge test per modalità, UI responsive, controller, repository e mapping dello scrigno condiviso

## Impatto

Il proprietario decide esattamente quali categorie mostrare a ciascun visitatore. Le autorizzazioni persistono e non ampliano i vecchi accessi privi di una selezione esplicita.

## Verifiche

- `flutter analyze`
- 44 test mirati Flutter
- `git diff --check`
- nessun riferimento residuo a `sostituisci immagine.svg`

La lint SQL locale non è stata eseguita perché lo stack Supabase locale non era attivo; la migrazione sarà verificata dalla CI.