### PR TITLE
Fix house editing, knocking, and chest filters

### DIFF
--- a/lib/Entities/campanelli_view_data.dart
+++ b/lib/Entities/campanelli_view_data.dart
@@ -8,6 +8,7 @@ class CampanelloData {
     required this.backgroundImage,
     required this.text,
     required this.linkedHouseId,
+    this.bgTransform,
   });
 
   final String id;
@@ -16,12 +17,14 @@ class CampanelloData {
   final ImageProvider backgroundImage;
   final String text;
   final String linkedHouseId;
+  final List<double>? bgTransform;
 
   factory CampanelloData.fromBackend({
     required Map<String, dynamic> row,
     required ImageProvider backgroundImage,
     required String text,
     required String linkedHouseId,
+    List<double>? bgTransform,
   }) {
     return CampanelloData(
       id: row['id']?.toString() ?? '',
@@ -30,6 +33,7 @@ class CampanelloData {
       backgroundImage: backgroundImage,
       text: text,
       linkedHouseId: linkedHouseId,
+      bgTransform: bgTransform,
     );
   }
 }

--- a/lib/IsolaDelleStorie/Pages/campanelli_page.dart
+++ b/lib/IsolaDelleStorie/Pages/campanelli_page.dart
@@ -71,13 +71,16 @@ class _CampanelliPageState extends State<CampanelliPage> {
   bool _showCarouselArrows = true;
   Timer? _carouselHintTimer;
   bool _isKnocking = false;
+  bool _knockOverlayVisible = false;
+  final Map<String, Completer<void>> _knockWaiters =
+      <String, Completer<void>>{};
   bool _isShowingKnockRequest = false;
   final Set<String> _shownKnockRequestIds = <String>{};
   bool get _hasOwnHouse => _campanelliController.state.hasOwnHouse;
   bool get _hasPendingOrAcceptedInvite =>
       _campanelliController.state.hasPendingOrAcceptedInvite;
   late final StreamSubscription<CampanelliRealtimeEvent>
-      _realtimeEventsSubscription;
+  _realtimeEventsSubscription;
   List<PendingKnock> get _pendingKnocks =>
       _campanelliController.state.pendingKnocks;
   Set<String> get _pendingKnockTags => _campanelliController.pendingKnockTags;
@@ -100,6 +103,7 @@ class _CampanelliPageState extends State<CampanelliPage> {
 
   void _showBusyOverlay(String message) {
     if (!mounted) return;
+    _knockOverlayVisible = true;
     unawaited(
       showDialog<void>(
         context: context,
@@ -110,7 +114,8 @@ class _CampanelliPageState extends State<CampanelliPage> {
   }
 
   void _hideBusyOverlay() {
-    if (!mounted) return;
+    if (!mounted || !_knockOverlayVisible) return;
+    _knockOverlayVisible = false;
     Navigator.of(context, rootNavigator: true).maybePop();
   }
 
@@ -200,7 +205,7 @@ class _CampanelliPageState extends State<CampanelliPage> {
 
     setState(() => _isKnocking = true);
     try {
-      _showBusyOverlay('Invio la bussata...');
+      _showBusyOverlay('Sto bussando');
       try {
         final user = SupabaseProvider.client.auth.currentUser;
         final targetTag = campanello.campanelloHinooId;
@@ -211,15 +216,21 @@ class _CampanelliPageState extends State<CampanelliPage> {
           _hideBusyOverlay();
           return;
         }
+        final waiter = Completer<void>();
+        _knockWaiters[targetTag] = waiter;
         await _campanelliController.sendHouseKnock(
           targetHouseTag: targetTag,
           visitorId: user.id,
         );
+        await waiter.future.timeout(const Duration(seconds: 12));
+        _hideBusyOverlay();
+      } on TimeoutException {
         _hideBusyOverlay();
         if (mounted) {
-          showHonooToast(
+          await showHonooMessageDialog(
             context,
-            message: 'Bussata inviata. Attendi risposta.',
+            message: 'Il proprietario non è in casa\nProva più tardi',
+            duration: const Duration(seconds: 3),
           );
         }
       } catch (e) {
@@ -231,6 +242,9 @@ class _CampanelliPageState extends State<CampanelliPage> {
             message: 'Invio non riuscito. Ritenta tra poco.',
           );
         }
+      } finally {
+        final targetTag = campanello.campanelloHinooId;
+        if (targetTag != null) _knockWaiters.remove(targetTag);
       }
     } finally {
       if (mounted) setState(() => _isKnocking = false);
@@ -282,17 +296,19 @@ class _CampanelliPageState extends State<CampanelliPage> {
     final user = SupabaseProvider.client.auth.currentUser;
     final bool isOwner = user != null && campanello.ownerId == user.id;
     if (isOwner) {
+      final filter = await Navigator.of(context).push<CasaShareMode>(
+        MaterialPageRoute(builder: (_) => const CasaChestFilterPage()),
+      );
+      if (!mounted || filter == null) return;
       await Navigator.of(context).push<void>(
-        MaterialPageRoute(builder: (_) => const ChestPage()),
+        MaterialPageRoute(builder: (_) => ChestPage(initialFilter: filter)),
       );
       return;
     }
     final ownerId = campanello.ownerId;
     if (ownerId == null || ownerId.isEmpty) return;
     await Navigator.of(context).push<void>(
-      MaterialPageRoute(
-        builder: (_) => SharedHouseChestPage(ownerId: ownerId),
-      ),
+      MaterialPageRoute(builder: (_) => SharedHouseChestPage(ownerId: ownerId)),
     );
   }
 
@@ -552,42 +568,46 @@ class _CampanelliPageState extends State<CampanelliPage> {
         return;
       }
 
-      final entries = loadState.entries.map((entry) {
-        final casaId = 'casa_${entry.hinooId}';
-        return _CampanelloEntry(
-          campanello: CampanelloData.fromBackend(
-            row: {
-              'id': 'campanello_${entry.hinooId}',
-              'campanello_hinoo_id': entry.hinooId,
-              'owner_id': entry.ownerId,
-            },
-            backgroundImage: _campanelloBackgroundProvider(
-              entry.campanelloBackgroundUrl,
-            ),
-            text: entry.text,
-            linkedHouseId: casaId,
-          ),
-          casa: CasaData.fromBackend(
-            row: {'id': casaId, 'bg_transform': entry.bgTransform},
-            backgroundImage: _houseBackgroundProvider(
-              entry.houseImageUrl,
-              entry.campanelloBackgroundUrl,
-            ),
-            bgScale: entry.bgScale,
-            bgOffsetX: entry.bgOffsetX,
-            bgOffsetY: entry.bgOffsetY,
-          ),
-          campanelloBackgroundUrl: entry.campanelloBackgroundUrl,
-          houseImageUrl: entry.houseImageUrl,
-          campanelloIsTextWhite: entry.campanelloIsTextWhite,
-          campanelloBgScale: entry.bgScale,
-          campanelloBgOffsetX: entry.bgOffsetX,
-          campanelloBgOffsetY: entry.bgOffsetY,
-          campanelloBgTransform: entry.campanelloBgTransform,
-        );
-      }).toList(growable: false);
-      final grantedHouseTags =
-          await _campanelliController.loadGrantedHouseTags(user.id);
+      final entries = loadState.entries
+          .map((entry) {
+            final casaId = 'casa_${entry.hinooId}';
+            return _CampanelloEntry(
+              campanello: CampanelloData.fromBackend(
+                row: {
+                  'id': 'campanello_${entry.hinooId}',
+                  'campanello_hinoo_id': entry.hinooId,
+                  'owner_id': entry.ownerId,
+                },
+                backgroundImage: _campanelloBackgroundProvider(
+                  entry.campanelloBackgroundUrl,
+                ),
+                text: entry.text,
+                linkedHouseId: casaId,
+                bgTransform: entry.campanelloBgTransform,
+              ),
+              casa: CasaData.fromBackend(
+                row: {'id': casaId, 'bg_transform': entry.bgTransform},
+                backgroundImage: _houseBackgroundProvider(
+                  entry.houseImageUrl,
+                  entry.campanelloBackgroundUrl,
+                ),
+                bgScale: entry.bgScale,
+                bgOffsetX: entry.bgOffsetX,
+                bgOffsetY: entry.bgOffsetY,
+              ),
+              campanelloBackgroundUrl: entry.campanelloBackgroundUrl,
+              houseImageUrl: entry.houseImageUrl,
+              campanelloIsTextWhite: entry.campanelloIsTextWhite,
+              campanelloBgScale: entry.bgScale,
+              campanelloBgOffsetX: entry.bgOffsetX,
+              campanelloBgOffsetY: entry.bgOffsetY,
+              campanelloBgTransform: entry.campanelloBgTransform,
+            );
+          })
+          .toList(growable: false);
+      final grantedHouseTags = await _campanelliController.loadGrantedHouseTags(
+        user.id,
+      );
 
       if (mounted) {
         setState(() {
@@ -595,10 +615,13 @@ class _CampanelliPageState extends State<CampanelliPage> {
           _ownedHinooIds = List<String>.from(ownedHinooIds);
           _unlockedCampanelli.addAll(
             entries
-                .where((entry) =>
-                    entry.campanello.ownerId == user.id ||
-                    grantedHouseTags
-                        .contains(entry.campanello.campanelloHinooId))
+                .where(
+                  (entry) =>
+                      entry.campanello.ownerId == user.id ||
+                      grantedHouseTags.contains(
+                        entry.campanello.campanelloHinooId,
+                      ),
+                )
                 .map((entry) => entry.campanello.id),
           );
         });
@@ -693,6 +716,9 @@ class _CampanelliPageState extends State<CampanelliPage> {
       case CampanelliPendingKnockRemoved():
         setState(() {});
       case CampanelliAccessGranted(:final targetTag):
+        final waiter = _knockWaiters[targetTag];
+        if (waiter != null && !waiter.isCompleted) waiter.complete();
+        _hideBusyOverlay();
         showHonooToast(context, message: 'La casa è stata aperta');
         try {
           HapticFeedback.lightImpact();
@@ -948,6 +974,9 @@ class _CampanelliPageState extends State<CampanelliPage> {
   void dispose() {
     _carouselHintTimer?.cancel();
     _realtimeEventsSubscription.cancel();
+    for (final waiter in _knockWaiters.values) {
+      if (!waiter.isCompleted) waiter.complete();
+    }
     _pageController.dispose();
     _campanelloPageController.dispose();
     _campanelliController.dispose();

--- a/lib/Pages/casa_builder_page.dart
+++ b/lib/Pages/casa_builder_page.dart
@@ -1,9 +1,7 @@
 import 'dart:math' as math;
 import 'dart:typed_data';
-import 'dart:ui' as ui;
 
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:honoo/Entities/hinoo.dart';
 import 'package:honoo/Services/hinoo_storage_uploader.dart';
@@ -15,6 +13,7 @@ import 'package:honoo/Utility/honoo_colors.dart';
 import 'package:honoo/Utility/responsive_layout.dart';
 import 'package:honoo/Widgets/honoo_dialogs.dart';
 import 'package:honoo/Widgets/loading_spinner.dart';
+import 'package:honoo/Widgets/cover_transform_image.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:image_picker/image_picker.dart';
 
@@ -41,8 +40,9 @@ class CasaBuilderPage extends StatefulWidget {
 class _CasaBuilderPageState extends State<CasaBuilderPage> {
   final HouseInviteService _inviteService = HouseInviteService();
   final TransformationController _imageController = TransformationController();
-  final GlobalKey _captureKey = GlobalKey();
   ImageProvider? _imageProvider;
+  Uint8List? _pickedImageBytes;
+  String _pickedImageExtension = 'jpg';
   bool _isSaving = false;
   bool _isUploadingImage = false;
   bool _hasPickedImage = false;
@@ -130,6 +130,12 @@ class _CasaBuilderPageState extends State<CasaBuilderPage> {
       final Uint8List bytes = await selected.readAsBytes();
       setState(() {
         _imageProvider = MemoryImage(bytes);
+        _pickedImageBytes = bytes;
+        final extension = selected.name.split('.').last.toLowerCase();
+        _pickedImageExtension =
+            {'jpg', 'jpeg', 'png', 'webp'}.contains(extension)
+            ? extension
+            : 'jpg';
         _imageScale = _imageMinScale;
         _hasPickedImage = true;
       });
@@ -137,32 +143,6 @@ class _CasaBuilderPageState extends State<CasaBuilderPage> {
     } catch (e) {
       if (!mounted) return;
       showHonooToast(context, message: 'Errore immagine: $e');
-    }
-  }
-
-  Future<Uint8List?> _captureCasaImage() async {
-    try {
-      final RenderRepaintBoundary? boundary =
-          _captureKey.currentContext?.findRenderObject()
-              as RenderRepaintBoundary?;
-      if (boundary == null) return null;
-      final double deviceRatio = MediaQuery.of(context).devicePixelRatio;
-      final Size logical = boundary.size;
-      const double maxOut = 2560.0;
-      final double longEdge = logical.width > logical.height
-          ? logical.width
-          : logical.height;
-      double pixelRatio = deviceRatio;
-      if (longEdge * deviceRatio > maxOut && longEdge > 0) {
-        pixelRatio = (maxOut / longEdge).clamp(1.0, deviceRatio);
-      }
-      final ui.Image image = await boundary.toImage(pixelRatio: pixelRatio);
-      final ByteData? byteData = await image.toByteData(
-        format: ui.ImageByteFormat.png,
-      );
-      return byteData?.buffer.asUint8List();
-    } catch (e) {
-      return null;
     }
   }
 
@@ -188,15 +168,15 @@ class _CasaBuilderPageState extends State<CasaBuilderPage> {
       String imageUrl = widget.initialHouseImageUrl ?? '';
       if (_hasPickedImage || imageUrl.isEmpty) {
         setState(() => _isUploadingImage = true);
-        final Uint8List? pngBytes = await _captureCasaImage();
-        if (pngBytes == null || pngBytes.isEmpty) {
-          throw Exception('Impossibile generare l\'immagine della casa.');
+        final Uint8List? imageBytes = _pickedImageBytes;
+        if (imageBytes == null || imageBytes.isEmpty) {
+          throw Exception('Impossibile leggere l\'immagine della casa.');
         }
         imageUrl = await HinooStorageUploader.uploadBackground(
-          bytes: pngBytes,
-          ext: 'png',
+          bytes: imageBytes,
+          ext: _pickedImageExtension,
           userId: user.id,
-          // Il PNG della casa comprende l'intero canvas e sui collegamenti più
+          // L'immagine originale può essere pesante e sui collegamenti più
           // lenti può richiedere più dei 15 secondi usati dagli upload normali.
           writeTimeout: const Duration(minutes: 1),
         );
@@ -342,31 +322,14 @@ class _CasaBuilderPageState extends State<CasaBuilderPage> {
                       child: SizedBox(
                         width: HinooTypography.baselineCanvasWidth,
                         height: HinooTypography.baselineCanvasHeight,
-                        child: RepaintBoundary(
-                          key: _captureKey,
-                          child: ClipRect(
-                            child: InteractiveViewer(
-                              transformationController: _imageController,
-                              panEnabled: true,
-                              scaleEnabled: true,
-                              minScale: _imageMinScale,
-                              maxScale: _imageMaxScale,
-                              boundaryMargin: const EdgeInsets.all(200),
-                              child: SizedBox.expand(
-                                child: _imageProvider == null
-                                    ? Image.asset(
-                                        'assets/stanza-02_carta.jpg',
-                                        fit: BoxFit.cover,
-                                        alignment: Alignment.center,
-                                      )
-                                    : Image(
-                                        image: _imageProvider!,
-                                        fit: BoxFit.cover,
-                                        alignment: Alignment.center,
-                                      ),
-                              ),
-                            ),
-                          ),
+                        child: CoverTransformImage(
+                          image:
+                              _imageProvider ??
+                              const AssetImage('assets/stanza-02_carta.jpg'),
+                          transformationController: _imageController,
+                          interactive: _imageProvider != null,
+                          minScale: _imageMinScale,
+                          maxScale: _imageMaxScale,
                         ),
                       ),
                     ),

--- a/lib/Pages/casa_share_selection_page.dart
+++ b/lib/Pages/casa_share_selection_page.dart
@@ -17,6 +17,71 @@ class CasaShareSelectionPage extends StatefulWidget {
   State<CasaShareSelectionPage> createState() => _CasaShareSelectionPageState();
 }
 
+/// Menu di ingresso allo Scrigno dalla propria casa. La scelta è immediata:
+/// non rappresenta un'autorizzazione e quindi non ha stato selezionato né OK.
+class CasaChestFilterPage extends StatelessWidget {
+  const CasaChestFilterPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: HonooColor.background,
+      body: SafeArea(
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            final compact = constraints.maxHeight < 650;
+            final iconSize = compact ? 72.0 : 96.0;
+            final spacing = compact ? 28.0 : 46.0;
+            return Center(
+              child: SingleChildScrollView(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 24,
+                  vertical: 32,
+                ),
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    _ShareIcon(
+                      key: const ValueKey('house-chest-home'),
+                      mode: CasaShareMode.home,
+                      asset: 'assets/icons/honoo_chest_blue.svg',
+                      selected: false,
+                      size: iconSize,
+                      addWhiteOutline: true,
+                      onTap: () =>
+                          Navigator.of(context).pop(CasaShareMode.home),
+                    ),
+                    SizedBox(height: spacing),
+                    _ShareIcon(
+                      key: const ValueKey('house-chest-moon'),
+                      mode: CasaShareMode.moon,
+                      asset: 'assets/icons/honoo_chest_white.svg',
+                      selected: false,
+                      size: iconSize,
+                      onTap: () =>
+                          Navigator.of(context).pop(CasaShareMode.moon),
+                    ),
+                    SizedBox(height: spacing),
+                    _ShareIcon(
+                      key: const ValueKey('house-chest-all'),
+                      mode: CasaShareMode.all,
+                      asset: 'assets/icons/chest_home.svg',
+                      selected: false,
+                      size: iconSize,
+                      addWhiteOutline: true,
+                      onTap: () => Navigator.of(context).pop(CasaShareMode.all),
+                    ),
+                  ],
+                ),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+}
+
 class _CasaShareSelectionPageState extends State<CasaShareSelectionPage> {
   late final Set<CasaShareMode> _selected = Set<CasaShareMode>.of(
     widget.initialSelection,

--- a/lib/Pages/chest_page.dart
+++ b/lib/Pages/chest_page.dart
@@ -19,6 +19,7 @@ import '../Entities/hinoo.dart';
 import '../Entities/chest_item.dart';
 import '../Entities/hinoo_thread_entry.dart';
 import '../Entities/reply_navigation_result.dart';
+import '../Entities/casa_share_mode.dart';
 
 import '../Utility/honoo_colors.dart';
 import '../Utility/chest_content_style.dart';
@@ -51,12 +52,14 @@ class ChestPage extends StatefulWidget {
     this.focusConversationId,
     this.highlightLatest = false,
     this.focusReplyId,
+    this.initialFilter = CasaShareMode.all,
   });
 
   final bool focusReplies;
   final String? focusConversationId;
   final bool highlightLatest;
   final String? focusReplyId;
+  final CasaShareMode initialFilter;
 
   @override
   State<ChestPage> createState() => _ChestPageState();
@@ -312,6 +315,7 @@ class _ChestPageState extends State<ChestPage> with WidgetsBindingObserver {
       widget.focusConversationId ?? '',
       widget.focusReplies ? '1' : '0',
       widget.highlightLatest ? '1' : '0',
+      widget.initialFilter.name,
       _initialLoadCompleted ? 'loaded' : 'loading',
       _pendingRevealEntryId ?? '',
       _mode.name,
@@ -339,7 +343,24 @@ class _ChestPageState extends State<ChestPage> with WidgetsBindingObserver {
         .map<ChestItem>((r) => ChestItem.hinoo(r))
         .toList();
 
-    final items = [...honooItems, ...hinooItems];
+    final items = [...honooItems, ...hinooItems]
+        .where((item) {
+          switch (widget.initialFilter) {
+            case CasaShareMode.all:
+              return true;
+            case CasaShareMode.home:
+              return item.when(
+                honoo: (honoo) => !honoo.isFromMoonSaved,
+                hinoo: (hinoo) => !hinoo.isFromMoonSaved,
+              );
+            case CasaShareMode.moon:
+              return item.when(
+                honoo: (honoo) => honoo.isFromMoonSaved,
+                hinoo: (hinoo) => hinoo.isFromMoonSaved,
+              );
+          }
+        })
+        .toList(growable: false);
     final organization = ChestOrganizer.organize<ChestItem>(
       items: items,
       createdAtOf: (item) => item.createdAt,

--- a/lib/Pages/new_hinoo_page.dart
+++ b/lib/Pages/new_hinoo_page.dart
@@ -581,9 +581,14 @@ class _NewHinooPageState extends State<NewHinooPage>
     builder?.editTextPublic?.call();
   }
 
-  void _saveEditorImage() {
+  Future<void> _saveEditorImage() async {
     final dynamic builder = _builderKey.currentState;
     builder?.confirmBackgroundPublic?.call();
+    if (widget.isCampanello &&
+        (widget.editingCampanelloId?.isNotEmpty ?? false)) {
+      await WidgetsBinding.instance.endOfFrame;
+      if (mounted) await _submitHinoo();
+    }
   }
 
   Future<void> _deleteEditorContent() async {
@@ -696,6 +701,9 @@ class _NewHinooPageState extends State<NewHinooPage>
         widget.isCampanello &&
         (widget.editingCampanelloId?.isNotEmpty ?? false);
     if (editingExistingCampanello) {
+      if (_campanelloEditStarted && _builderStep == 'changeBg') {
+        return _buildImageEditingControls();
+      }
       const double actionSize = 30;
       return SizedBox(
         key: const Key('campanello-editor-controls'),

--- a/lib/UI/honoo_card.dart
+++ b/lib/UI/honoo_card.dart
@@ -32,7 +32,13 @@ class HonooCard extends StatelessWidget {
     final contentStyle =
         contentStyleOverride ??
         ChestContentStyle.forHonoo(honoo, viewerUserId: currentUserId);
-    final Color cardBg = contentStyle.backgroundColor;
+    // Sulla Luna il fondo esterno della card deve essere bianco: usando il
+    // blu dello Scrigno questo affiorava agli angoli arrotondati come piccoli
+    // rettangoli tra pannello testo e immagine.
+    final Color cardBg =
+        contentStyleOverride == null && honoo.type == HonooType.moon
+        ? HonooColor.tertiary
+        : contentStyle.backgroundColor;
     final bool isReceivedReply = identical(
       contentStyle,
       ChestContentStyle.receivedReply,

--- a/lib/Widgets/campanello_card.dart
+++ b/lib/Widgets/campanello_card.dart
@@ -4,6 +4,7 @@ import 'package:google_fonts/google_fonts.dart';
 import '../Entities/campanelli_view_data.dart';
 import '../UI/hinoo_typography.dart';
 import '../Utility/honoo_colors.dart';
+import 'cover_transform_image.dart';
 import 'text_box_download_button.dart';
 
 class CampanelloCard extends StatelessWidget {
@@ -57,12 +58,20 @@ class CampanelloCard extends StatelessWidget {
         HinooTypography.horizontalPadding,
         HinooTypography.editorTextBottomPadding,
       ),
-      child: Align(
+      child: Center(
         key: const ValueKey('campanello-saved-text-position'),
-        alignment: Alignment.topCenter,
         child: _buildText(textStyle),
       ),
     );
+
+    final rawTransform = data.campanello!.bgTransform;
+    Matrix4? transform;
+    if (rawTransform != null && rawTransform.length == 16) {
+      final values = List<double>.from(rawTransform);
+      values[12] *= width / HinooTypography.baselineCanvasWidth;
+      values[13] *= height / HinooTypography.baselineCanvasHeight;
+      transform = Matrix4.fromList(values);
+    }
 
     return SizedBox(
       width: width,
@@ -70,7 +79,13 @@ class CampanelloCard extends StatelessWidget {
       child: Stack(
         fit: StackFit.expand,
         children: [
-          Image(image: data.campanello!.backgroundImage, fit: BoxFit.cover),
+          if (transform != null)
+            CoverTransformImage.transformed(
+              image: data.campanello!.backgroundImage,
+              transform: transform,
+            )
+          else
+            Image(image: data.campanello!.backgroundImage, fit: BoxFit.cover),
           savedText,
           if (onEditTap != null || onEditImageTap != null)
             Positioned(

--- a/lib/Widgets/casa_section.dart
+++ b/lib/Widgets/casa_section.dart
@@ -4,6 +4,7 @@ import 'package:google_fonts/google_fonts.dart';
 import '../Entities/campanelli_view_data.dart';
 import '../Utility/honoo_colors.dart';
 import 'text_box_download_button.dart';
+import 'cover_transform_image.dart';
 
 class CasaSection extends StatelessWidget {
   const CasaSection({
@@ -62,12 +63,9 @@ class CasaSection extends StatelessWidget {
       child: Stack(
         fit: StackFit.expand,
         children: [
-          ClipRect(
-            child: Transform(
-              transform: transform,
-              alignment: Alignment.center,
-              child: Image(image: casa.backgroundImage, fit: BoxFit.cover),
-            ),
+          CoverTransformImage.transformed(
+            image: casa.backgroundImage,
+            transform: transform,
           ),
           if (!isUnlocked)
             Center(

--- a/test/pages/casa_chest_filter_page_test.dart
+++ b/test/pages/casa_chest_filter_page_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:honoo/Entities/casa_share_mode.dart';
+import 'package:honoo/Pages/casa_share_selection_page.dart';
+
+void main() {
+  testWidgets('il menu dello scrigno di casa sceglie subito il filtro', (
+    tester,
+  ) async {
+    CasaShareMode? result;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (context) => TextButton(
+            onPressed: () async {
+              result = await Navigator.of(context).push<CasaShareMode>(
+                MaterialPageRoute(builder: (_) => const CasaChestFilterPage()),
+              );
+            },
+            child: const Text('apri'),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('apri'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('cosa vuoi mostrare?'), findsNothing);
+    expect(find.byKey(const ValueKey('house-share-confirm')), findsNothing);
+    expect(find.byKey(const ValueKey('house-chest-home')), findsOneWidget);
+    expect(find.byKey(const ValueKey('house-chest-moon')), findsOneWidget);
+    expect(find.byKey(const ValueKey('house-chest-all')), findsOneWidget);
+
+    await tester.tap(find.byKey(const ValueKey('house-chest-moon')));
+    await tester.pumpAndSettle();
+    expect(result, CasaShareMode.moon);
+  });
+}

--- a/test/widgets/campanelli_renderers_test.dart
+++ b/test/widgets/campanelli_renderers_test.dart
@@ -62,22 +62,25 @@ void main() {
     );
 
     expect(find.text('Un campanello'), findsOneWidget);
-    final savedTextPosition = tester.widget<Align>(
+    final savedTextPosition = tester.widget<Center>(
       find.byKey(const ValueKey('campanello-saved-text-position')),
     );
-    expect(savedTextPosition.alignment, Alignment.topCenter);
+    expect(savedTextPosition.widthFactor, isNull);
     final background = find.byWidgetPredicate(
       (widget) => widget is Image && widget.image == campanello.backgroundImage,
     );
     expect(background, findsOneWidget);
+    final textPadding = tester.widget<Padding>(
+      find
+          .ancestor(
+            of: find.byKey(const ValueKey('campanello-saved-text-position')),
+            matching: find.byType(Padding),
+          )
+          .first,
+    );
     expect(
-      tester
-              .getRect(
-                find.byKey(const ValueKey('campanello-saved-text-position')),
-              )
-              .top -
-          tester.getRect(background).top,
-      closeTo(HinooTypography.editorTextTopPadding(320), 0.01),
+      (textPadding.padding as EdgeInsets).top,
+      HinooTypography.editorTextTopPadding(320),
     );
   });
 

--- a/test/widgets/honoo_card_layout_test.dart
+++ b/test/widgets/honoo_card_layout_test.dart
@@ -53,6 +53,7 @@ void main() {
       find.byKey(const Key('honoo-card-gap')),
     );
     expect(gap.color, HonooColor.tertiary);
+    expect(tester.widget<Card>(find.byType(Card)).color, HonooColor.tertiary);
   });
 
   testWidgets(


### PR DESCRIPTION
## Cosa cambia

- uniforma gli editor immagine di casa e campanello al ritaglio Hinoo, conservando la posizione scelta
- salva correttamente le modifiche e le propaga agli altri punti dell'app, incluso lo scrigno
- aggiunge il menu filtri dello scrigno nella propria casa e mantiene la toolbar coerente
- mostra lo stato «Sto bussando» e il messaggio di timeout quando il proprietario non risponde
- allinea il testo del campanello al padding superiore degli Hinoo
- corregge i piccoli rettangoli blu negli Honoo visualizzati sulla Luna
- aggiunge test mirati per filtri e rendering

## Verifiche

- `flutter analyze`
- `flutter test --no-pub` — 122 test superati, 4 ignorati perché richiedono credenziali/flag live
- `git diff --check`
