### PR TITLE
Refine home experience and direct auth flows

### DIFF
--- a/lib/IsolaDelleStorie/Utility/isola_delle_storie_content_manager.dart
+++ b/lib/IsolaDelleStorie/Utility/isola_delle_storie_content_manager.dart
@@ -156,7 +156,7 @@ ogni settimana ti assegnerò\nun esercizio,\nda svolgere nelle tre fasi,\n<b>scr
   //static const String e00 ="""Questo\nè un percorso di scrittura,\nche si presenta\ncome l’esplorazione di un’<b>Isola<b>.\n\nUn viaggio,\nnove tappe,\nventotto esercizi.\n\nOgni esercizio\nè articolato in tre fasi,\nche io chiamo\n<b>scrittura libera,<b>\n<b>honoo<b> ("onù")\ne\n<b>hinoo<b> (“inù”).\n\n<b>Scrittura libera<b>\nA partire dal tema proposto,\nscrivi per\n almeno dieci minuti,\nnella forma che preferisci.\n\nDedica cioè\nuno spazio quotidiano\nalla scrittura,\ne difendilo.\n\nIn questa fase\npuoi accompagnare\nla scrittura\nad altri metodi\ndi rappresentazione,\ncome la fotografia\no il disegno.\n\nIn effetti\nsarebbe più esatto dire:\n“a partire dal tema proposto,\ninizia una riflessione,\nannotando quello che affiora\nnel modo\nche ti sembra più comodo”.\n\nSecondo me,\nun ottimo risultato\nsarebbe riuscire a \ndedicare a questa fase\nalmeno\nquaranta, cinquanta minuti\nal giorno,\nma non considerarlo\nl'obiettivo.\n\nL’obiettivo\nè quello di confrontarsi\ncon questa prima fase\ntutti i giorni,\nsenza saltare nessun giorno.\n\nAvrai bisogno\ndi un orologio:\nsegna l’orario in cui inizi\nla tua <b>scrittura libera<b>\ne continua\nfinché non saranno trascorsi\n<b>almeno dieci minuti<b>.\n\nQuando smetti,\nscrivi l’orario in cui smetti,\ne calcola\nquanto è durata la tua scrittura.\n\nLavora\ncon il massimo della\nconcentrazione,\ndopo aver cercato di eliminare\ntutte le possibili\nfonti di distrazione.\n\nIo scriverei al mattino,\ncon un pennarello molto fluido,\nsu fogli bianchi,\nsenza righe.\n\nSi tratta di gusti:\nti invito a scoprire i tuoi.\n\nTi consiglio\ndi non mostrare a nessuno\nquello che verrà fuori\nin questa prima fase di scrittura.\n\n<b>honoo<b>\nRileggi con attenzione\ntutto quello\nche\nsei riuscito a far affiorare\ndurante la <b>scrittura libera<b>,\ne poi,\na partire da quello che hai scritto,\nrealizza almeno un <b>honoo<b>.\n\nUn <b>honoo<b>\nè una composizione\narticolata in un <b>breve testo<b>,\nal massimo <b>144 caratteri<b>,\nspazi compresi,\ndisposti\nin un massimo\ndi <b>cinque righe<b>,\ne un’<b>immagine quadrata<b>.\n\nIl testo\nè <b>formattato al centro<b>\ne scritto in <b>carattere Arvo<b>.\n\nIn questo contesto, \nconsidero l’<b>honoo<b>\nuna tecnica\nper evidenziare\npunti caldi\ndal magma informe\ndella <b>scrittura libera<b>,\ne per iniziare\na coagulare\nquesti punti caldi\nin strutture più complesse.\n\n<b>hinoo<b>\nDopo aver realizzato\nalmeno un <b>honoo<b>,\nscrivi\nalmeno un <b>hinoo<b>.\n\nCol termine <b>hinoo<b>\nintendo\nuna composizione\narticolata\nin una <b>immagine quadrata<b>\nin alto\ne in un <b>testo<b>\ndel numero di righe che vuoi,\ncon un numero massimo\ndi caratteri per rigo,\ncirca 32, spazi inclusi.\n\nNelle mie intenzioni,\nla scelta espressiva\ndi dove andare a capo,\nnei testi dell’<b>honoo<b>\ne dell’<b>hinoo<b>,\naccende\nun riflettore\nsu alcuni elementi,\ne ci indica\nla strada\nverso\nla nostra storia.\n\nL’ideale\nsarebbe svolgere\nnell’arco della stessa giornata.\nle tre fasi\ndi ogni esercizio:\n<b>scrittura libera<b>,\n<b>honoo<b>\ne\n<b>hinoo<b>.\n\nSe vuoi comporre\ni tuoi <b>honoo<b>\ne i tuoi <b>hinoo<b>,\nun giorno\npotrai cliccare\nsulla Bottiglia.\nPer il momento,\npuoi trovare i format\nper <b>honoo<b> ed <b>hinoo<b>\n<l>cliccando qui||drive.google.com/drive/folders/1eoqYRLrj1RFsKYXsCUR55YEqVerBFrOA?usp=drive_link<l>\n\nSe vuoi vedere\ngli <b>honoo<b>\ne gli <b>hinoo<b>\ndegli altri,\nclicca sulla Luna.\n\nSe clicchi sullo Scrigno,\npuoi vedere\ngli <b>honoo<b> e gli <b>hinoo<b>\nche hai scritto,\ngli <b>honoo<b> e gli <b>hinoo<b>\nche hai salvato,\ne gli <b>honoo<b> e gli <b>hinoo<b>\nche hai ricevuto in risposta\nai tuoi <b>honoo<b> e <b>hinoo<b>.\n\nSe vuoi iniziare\nil tuo viaggio sull’<b>Isola<b>,\nclicca su <b>1<b>\ne vai alla\n<b>Grotta delle Rondini<b>.\n""";
 
   static const String fullIslandDescription =
-      """Nella parte occidentale\ndell'Isola\nnon ci sono veramente\ni leoni,\nma qualcuno che conosci\no che vorrebbe conoscerti.""";
+      """Nella parte occidentale\ndell'Isola\nnon ci sono veramente\ni leoni,\nma qualcuno che conosci\no che vorrebbe conoscerti""";
   static const String fullIslandHeadDescription = "Isola delle Storie";
 
   static RichText getRichText(String text) {
@@ -164,21 +164,27 @@ ogni settimana ti assegnerò\nun esercizio,\nda svolgere nelle tre fasi,\n<b>scr
     List<TextSpan> textSpans = [];
     for (int i = 0; i < splitted.length; i++) {
       if (i % 2 == 0) {
-        textSpans.add(TextSpan(
+        textSpans.add(
+          TextSpan(
             text: splitted[i],
             style: GoogleFonts.arvo(
               color: HonooColor.onBackground,
               fontSize: 18,
               fontWeight: FontWeight.w400,
-            )));
+            ),
+          ),
+        );
       } else {
-        textSpans.add(TextSpan(
+        textSpans.add(
+          TextSpan(
             text: splitted[i],
             style: GoogleFonts.arvo(
               color: HonooColor.onBackground,
               fontSize: 18,
               fontWeight: FontWeight.w700,
-            )));
+            ),
+          ),
+        );
       }
     }
     return RichText(

--- a/lib/Pages/auth_gate.dart
+++ b/lib/Pages/auth_gate.dart
@@ -1,10 +1,6 @@
 // auth_gate.dart (per supabase_flutter 1.x)
-import 'dart:async';
 import 'package:flutter/material.dart';
-import 'package:honoo/Pages/placeholder_page.dart';
 import 'home_page.dart';
-import 'package:honoo/Services/supabase_provider.dart';
-import 'package:supabase_flutter/supabase_flutter.dart';
 
 class AuthGate extends StatefulWidget {
   const AuthGate({super.key});
@@ -14,42 +10,8 @@ class AuthGate extends StatefulWidget {
 }
 
 class _AuthGateState extends State<AuthGate> {
-  StreamSubscription<AuthState>? _authSub;
-  bool _navigated = false;
-
-  @override
-  void initState() {
-    super.initState();
-
-    _authSub = SupabaseProvider.client.auth.onAuthStateChange.listen((state) {
-      if (!mounted || _navigated) return;
-      final session = state.session;
-
-      if (session != null) {
-        _navigated = true;
-        Navigator.of(context).pushAndRemoveUntil(
-          MaterialPageRoute(builder: (_) => const HomePage()),
-          (route) => false,
-        );
-      } else {
-        _navigated = true;
-        Navigator.of(context).pushAndRemoveUntil(
-          MaterialPageRoute(builder: (_) => const PlaceholderPage()),
-          (route) => false,
-        );
-      }
-    });
-  }
-
-  @override
-  void dispose() {
-    _authSub?.cancel();
-    super.dispose();
-  }
-
   @override
   Widget build(BuildContext context) {
-    final Session? session = SupabaseProvider.client.auth.currentSession;
-    return session != null ? const HomePage() : const PlaceholderPage();
+    return const HomePage();
   }
 }

--- a/lib/Pages/chest_page.dart
+++ b/lib/Pages/chest_page.dart
@@ -9,6 +9,7 @@ import 'package:honoo/Services/download_capture_service.dart';
 import 'package:honoo/Services/chest_hint_service.dart';
 import 'package:honoo/Services/duplication_result.dart';
 import 'package:honoo/Services/reply_system_notification.dart';
+import 'package:honoo/Services/auth_navigation_service.dart';
 
 import '../Controller/honoo_controller.dart';
 import '../Controller/hinoo_controller.dart';
@@ -91,6 +92,7 @@ class _ChestPageState extends State<ChestPage> with WidgetsBindingObserver {
   String? _detachedFocusedConversationId;
   bool _detachedConversationVisible = true;
   bool _initialLoadCompleted = false;
+  bool _authResolved = false;
   int _conversationRefreshToken = 0;
   String? _pendingRevealEntryId;
   Object? _honooLoadError;
@@ -166,6 +168,19 @@ class _ChestPageState extends State<ChestPage> with WidgetsBindingObserver {
     _pendingRevealEntryId = widget.focusReplyId;
     WidgetsBinding.instance.addObserver(this);
     _chestController.addListener(_onChestStateChanged);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      unawaited(_authenticateAndInitialize());
+    });
+  }
+
+  Future<void> _authenticateAndInitialize() async {
+    final bool loggedIn = await AuthNavigationService.ensureLoggedIn(context);
+    if (!mounted) return;
+    if (!loggedIn) {
+      Navigator.of(context).pop();
+      return;
+    }
+    setState(() => _authResolved = true);
     unawaited(_initialize());
     _maybeShowScrignoHint();
   }
@@ -942,16 +957,7 @@ class _ChestPageState extends State<ChestPage> with WidgetsBindingObserver {
     final user = SupabaseProvider.client.auth.currentUser;
     if (user == null) {
       if (!mounted) return;
-      await showDialog<bool>(
-        context: context,
-        barrierDismissible: true,
-        builder: (_) => const HonooConfirmDialog(
-          title: 'Devi accedere',
-          message:
-              'Per scaricare questo contenuto, devi fare prima il log in. Vuoi andare alla pagina di login?',
-          confirmLabel: 'Vai al login',
-        ),
-      );
+      await AuthNavigationService.ensureLoggedIn(context);
       return;
     }
 
@@ -1085,6 +1091,12 @@ class _ChestPageState extends State<ChestPage> with WidgetsBindingObserver {
 
   @override
   Widget build(BuildContext context) {
+    if (!_authResolved) {
+      return const Scaffold(
+        backgroundColor: HonooColor.background,
+        body: Center(child: LoadingSpinner(color: Colors.white)),
+      );
+    }
     return AnimatedBuilder(
       animation: Listenable.merge([ctrl.isLoading, ctrl.version]),
       builder: (context, _) {

--- a/lib/Pages/home_page.dart
+++ b/lib/Pages/home_page.dart
@@ -161,10 +161,11 @@ class _HomeIntro extends StatelessWidget {
   static const double _designWidth = 360;
   static const double _bottleIconSize = 42;
   static const double _moonIconSize = 28;
-  static const double _islandIconSize = 43;
+  static const double _islandIconSize = 55;
   static const double _bottleIconVerticalOffset = 9;
   static const double _moonIconVerticalOffset = 1;
-  static const double _islandIconVerticalOffset = 10;
+  static const double _islandIconVerticalOffset = 17;
+  static const double _islandFollowupTextVerticalOffset = -2;
 
   @override
   Widget build(BuildContext context) {
@@ -193,8 +194,7 @@ class _HomeIntro extends StatelessWidget {
                 text:
                     'Niente è per sempre\n'
                     'E nessuno può regalarti la Luna\n\n'
-                    'È vero\n'
-                    'Ma non per i poeti\n\n'
+                    'È vero. Ma non per i poeti\n\n'
                     'Vuoi essere un poeta di honoo?\n\n'
                     'Scegli',
               ),
@@ -234,9 +234,40 @@ class _HomeIntro extends StatelessWidget {
                 onPressed: () => SeaFooterBar.openIsland(context),
                 tint: HonooColor.onBackground,
               ),
-              const TextSpan(
-                text: '\ne inizia il viaggio\nverso le tue storie',
+              const TextSpan(text: '\n'),
+              WidgetSpan(
+                alignment: PlaceholderAlignment.baseline,
+                baseline: TextBaseline.alphabetic,
+                child: Transform.translate(
+                  key: const Key('home_island_followup_text_offset'),
+                  offset: const Offset(0, _islandFollowupTextVerticalOffset),
+                  child: Text(
+                    'e viaggia nelle tue storie',
+                    key: const Key('home_island_followup_text'),
+                    style: regularStyle,
+                  ),
+                ),
               ),
+              const TextSpan(text: '\n\nO'),
+              const WidgetSpan(
+                child: SizedBox(key: Key('home_honoo_leading_gap'), width: 8),
+              ),
+              WidgetSpan(
+                alignment: PlaceholderAlignment.baseline,
+                baseline: TextBaseline.alphabetic,
+                child: HonooAppTitle(
+                  key: const Key('home_inline_honoo'),
+                  fontSize: 23,
+                  onTap: () {
+                    Navigator.of(context).push(
+                      MaterialPageRoute(
+                        builder: (_) => const PlaceholderPage(),
+                      ),
+                    );
+                  },
+                ),
+              ),
+              const TextSpan(text: '\ne vedi tutto'),
             ],
           ),
           key: const Key('home_intro_text'),

--- a/lib/Pages/new_hinoo_page.dart
+++ b/lib/Pages/new_hinoo_page.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:honoo/Services/supabase_provider.dart';
 import 'package:honoo/Services/house_invite_service.dart';
+import 'package:honoo/Services/auth_navigation_service.dart';
 
 import 'package:honoo/Utility/honoo_colors.dart';
 import 'package:honoo/Widgets/honoo_dialogs.dart';
@@ -18,7 +19,6 @@ import 'package:honoo/UI/hinoo_typography.dart';
 import '../UI/hinoo_builder.dart';
 
 import 'chest_page.dart';
-import 'email_login_page.dart';
 import 'home_page.dart';
 import 'placeholder_page.dart';
 import '../Entities/hinoo.dart';
@@ -204,37 +204,7 @@ class _NewHinooPageState extends State<NewHinooPage>
     final user = SupabaseProvider.client.auth.currentUser;
     if (user == null) {
       if (!mounted) return;
-
-      final bool? goLogin = await showDialog<bool>(
-        context: context,
-        barrierDismissible: true,
-        builder: (_) => const HonooConfirmDialog(
-          title: 'Devi accedere prima',
-          message:
-              'Per salvare questo hinoo,\ndevi fare prima il login.\nVuoi andare alla pagina di login?',
-          confirmLabel: 'Vai al login',
-        ),
-      );
-
-      if (goLogin == true && mounted) {
-        // ✅ aspetta il risultato, ma NON salvare in automatico
-        final ok = await Navigator.push<bool>(
-          context,
-          MaterialPageRoute(
-            builder: (_) =>
-                EmailLoginPage(pendingHinooDraft: hinooDraft.toJson()),
-          ),
-        );
-
-        if (!mounted) return;
-
-        if (ok == true) {
-          showHonooToast(
-            context,
-            message: 'Accesso completato. Ora puoi salvare lo hinoo.',
-          );
-        }
-      }
+      await AuthNavigationService.ensureLoggedIn(context);
       return;
     }
 
@@ -537,21 +507,7 @@ class _NewHinooPageState extends State<NewHinooPage>
     final user = SupabaseProvider.client.auth.currentUser;
     if (user == null) {
       if (!mounted) return;
-      final bool? goLogin = await showDialog<bool>(
-        context: context,
-        barrierDismissible: true,
-        builder: (_) => const HonooConfirmDialog(
-          title: 'Devi prima accedere',
-          message: 'Vuoi andare alla pagina di login?',
-          confirmLabel: 'Vai al login',
-        ),
-      );
-      if (goLogin == true && mounted) {
-        Navigator.push(
-          context,
-          MaterialPageRoute(builder: (_) => const EmailLoginPage()),
-        );
-      }
+      await AuthNavigationService.ensureLoggedIn(context);
       return;
     }
 

--- a/lib/Pages/new_honoo_page.dart
+++ b/lib/Pages/new_honoo_page.dart
@@ -8,11 +8,11 @@ import 'package:honoo/Services/supabase_provider.dart';
 import '../Entities/honoo.dart';
 import '../Entities/reply_navigation_result.dart';
 import '../Services/honoo_image_uploader.dart';
+import '../Services/auth_navigation_service.dart';
 import '../UI/honoo_builder.dart';
 import 'package:honoo/Services/honoo_service.dart';
 import 'package:honoo/Services/duplication_result.dart';
 
-import 'email_login_page.dart';
 import 'chest_page.dart';
 import 'new_hinoo_page.dart';
 import 'home_page.dart';
@@ -95,43 +95,10 @@ class _NewHonooPageState extends State<NewHonooPage> {
   Future<bool> _submitHonoo({bool openChestAfterSave = false}) async {
     final user = SupabaseProvider.client.auth.currentUser;
 
-    // 1) Se non sei loggato: vai al login e torna qui (senza auto-salvare)
+    // Se la sessione scade, apri direttamente il login e conserva l'editor.
     if (user == null) {
       if (!mounted) return false;
-
-      final bool? goLogin = await showDialog<bool>(
-        context: context,
-        barrierDismissible: true,
-        builder: (_) => const HonooConfirmDialog(
-          title: 'Devi prima accedere',
-          message: '\nVuoi andare alla pagina di login?',
-          confirmLabel: 'Vai al login',
-        ),
-      );
-
-      if (goLogin != true || !mounted) return false;
-
-      // ✅ aspetta la fine del login
-      final bool? ok = await Navigator.push<bool>(
-        context,
-        MaterialPageRoute(
-          builder: (context) => EmailLoginPage(
-            pendingHonooText: _text,
-            pendingImageUrl: _imageUrl,
-          ),
-        ),
-      );
-
-      if (!mounted) return false;
-
-      // ✅ niente auto-save: solo feedback opzionale
-      if (ok == true) {
-        showHonooToast(
-          context,
-          message: 'Accesso completato. Premi di nuovo OK per salvare.',
-        );
-      }
-
+      await AuthNavigationService.ensureLoggedIn(context);
       return false;
     }
 
@@ -345,21 +312,7 @@ class _NewHonooPageState extends State<NewHonooPage> {
     final user = SupabaseProvider.client.auth.currentUser;
     if (user == null) {
       if (!mounted) return;
-      final bool? goLogin = await showDialog<bool>(
-        context: context,
-        barrierDismissible: true,
-        builder: (_) => const HonooConfirmDialog(
-          title: 'Devi prima accedere',
-          message: '\nVuoi andare alla pagina di login?',
-          confirmLabel: 'Vai al login',
-        ),
-      );
-      if (goLogin == true && mounted) {
-        Navigator.push(
-          context,
-          MaterialPageRoute(builder: (_) => const EmailLoginPage()),
-        );
-      }
+      await AuthNavigationService.ensureLoggedIn(context);
       return;
     }
 

--- a/lib/Pages/placeholder_page.dart
+++ b/lib/Pages/placeholder_page.dart
@@ -36,10 +36,13 @@ class _PlaceholderPageState extends State<PlaceholderPage> {
   static const double _laboratoriBottomSpacing = 30;
   static const double _lunaTopSpacing = -5;
   static const double _lunaBottomSpacing = 30;
+  static const double _lunaIconSizeIncrease = 15;
+  static const double _lunaIconVerticalOffset = -2;
   static const double _festeTopSpacing = 5;
   static const double _festeBottomSpacing = 30;
+  static const double _festeIconSizeIncrease = 6;
   static const double _isolaTopSpacing = -5;
-  static const double _isolaBottomSpacing = 20;
+  static const double _isolaBottomSpacing = 30;
   static const double _podcastTopSpacing = 5;
   static const double _podcastBottomSpacing = 30;
   static const double _performanceSecondTopSpacing = 15;
@@ -51,8 +54,9 @@ class _PlaceholderPageState extends State<PlaceholderPage> {
   static const double _libriTopSpacing = 5;
   static const double _libriBottomSpacing = 30;
   static const double _regiaAgentiTopSpacing = 18 * 1.3;
-  static const double _regiaAgentiBottomSpacing = 20;
-  static const double _regiaAgentiIconSizeReduction = 8;
+  static const double _regiaAgentiBottomSpacing = 30;
+  static const double _regiaAgentiIconSizeReduction = 15;
+  static const double _regiaAgentiIconVerticalOffset = -2;
   static const Color _linkIconColor = Color.fromRGBO(183, 183, 206, 1);
 
   List<Widget> _iconBlockWithSpacing(
@@ -61,14 +65,22 @@ class _PlaceholderPageState extends State<PlaceholderPage> {
     double topSpacing = 0,
     double bottomSpacing = 0,
     VoidCallback? onTap,
+    Key? bottomSpacingKey,
+    Key? transformKey,
+    double verticalOffset = 0,
   }) {
     return [
       if (topSpacing > 0) SizedBox(height: topSpacing),
       GestureDetector(
         onTap: onTap,
-        child: Image.asset(asset, height: size),
+        child: Transform.translate(
+          key: transformKey,
+          offset: Offset(0, verticalOffset),
+          child: Image.asset(asset, height: size),
+        ),
       ),
-      if (bottomSpacing > 0) SizedBox(height: bottomSpacing),
+      if (bottomSpacing > 0)
+        SizedBox(key: bottomSpacingKey, height: bottomSpacing),
     ];
   }
 
@@ -100,18 +112,24 @@ class _PlaceholderPageState extends State<PlaceholderPage> {
     Key? iconKey,
     Key? topSpacingKey,
     Key? bottomSpacingKey,
+    Key? transformKey,
+    double verticalOffset = 0,
   }) {
     return [
       if (topSpacing > 0) SizedBox(key: topSpacingKey, height: topSpacing),
       GestureDetector(
         onTap: onTap,
-        child: SvgPicture.asset(
-          key: iconKey,
-          asset,
-          height: size,
-          colorFilter: ColorFilter.mode(
-            color ?? HonooColor.onBackground,
-            BlendMode.srcIn,
+        child: Transform.translate(
+          key: transformKey,
+          offset: Offset(0, verticalOffset),
+          child: SvgPicture.asset(
+            key: iconKey,
+            asset,
+            height: size,
+            colorFilter: ColorFilter.mode(
+              color ?? HonooColor.onBackground,
+              BlendMode.srcIn,
+            ),
           ),
         ),
       ),
@@ -190,13 +208,13 @@ class _PlaceholderPageState extends State<PlaceholderPage> {
     final ResponsiveLayoutMode layoutMode = ResponsiveLayout.modeForWidth(
       screenWidth,
     );
-    const String performanceLine = 'performance';
-    const String laboratoriLine = 'laboratori teatrali';
-    const String esplorazioniLine = 'esplorazioni lunari';
-    const String festeLine = 'feste';
-    const String viaggiLine = "viaggi sull'Isola delle Storie";
+    const String performanceLine = 'Performance';
+    const String laboratoriLine = 'Laboratori teatrali';
+    const String esplorazioniLine = 'Esplorazioni lunari';
+    const String festeLine = 'Feste';
+    const String viaggiLine = "Viaggi sull'Isola delle Storie";
     const String podcastLine = 'Podcast e dirette';
-    const String libriLine = 'libri';
+    const String libriLine = 'Libri';
     const String regiaAgentiLine = 'Regia degli Agenti';
     const String venceslaoLine = 'Venceslao Cembalo';
     final String text1First = Utility().text1First;
@@ -356,9 +374,11 @@ class _PlaceholderPageState extends State<PlaceholderPage> {
       ),
       ..._iconBlockWithSpacing(
         "assets/icons/luna.png",
-        inlineIconHeight,
+        inlineIconHeight + _lunaIconSizeIncrease,
         topSpacing: _lunaTopSpacing,
         bottomSpacing: _lunaBottomSpacing,
+        transformKey: const Key('luna_icon_transform'),
+        verticalOffset: _lunaIconVerticalOffset,
         onTap: () {
           Navigator.of(
             context,
@@ -377,7 +397,7 @@ class _PlaceholderPageState extends State<PlaceholderPage> {
       ),
       ..._iconBlockWithSpacing(
         "assets/icons/feste.png",
-        inlineIconHeight,
+        inlineIconHeight + _festeIconSizeIncrease,
         topSpacing: _festeTopSpacing,
         bottomSpacing: _festeBottomSpacing,
         onTap: () {
@@ -402,6 +422,7 @@ class _PlaceholderPageState extends State<PlaceholderPage> {
         inlineIconHeight,
         topSpacing: _isolaTopSpacing,
         bottomSpacing: _isolaBottomSpacing,
+        bottomSpacingKey: const Key('isola_icon_bottom_spacing'),
         onTap: () {
           Navigator.of(
             context,
@@ -428,6 +449,8 @@ class _PlaceholderPageState extends State<PlaceholderPage> {
         iconKey: const Key('regia_agenti_icon'),
         topSpacingKey: const Key('regia_agenti_icon_top_spacing'),
         bottomSpacingKey: const Key('regia_agenti_icon_bottom_spacing'),
+        transformKey: const Key('regia_agenti_icon_transform'),
+        verticalOffset: _regiaAgentiIconVerticalOffset,
         onTap: () {
           Navigator.of(
             context,
@@ -456,7 +479,6 @@ class _PlaceholderPageState extends State<PlaceholderPage> {
           ).push(MaterialPageRoute(builder: (_) => const PodcastDirettePage()));
         },
       ),
-      _textBlock('e', baseTextStyle),
       _linkTextBlock(
         context,
         libriLine,

--- a/lib/Pages/regia_agenti_page.dart
+++ b/lib/Pages/regia_agenti_page.dart
@@ -39,7 +39,7 @@ class RegiaAgentiPage extends StatelessWidget {
       'e di Gherkin,\n'
       'cioè\n'
       'di imparare\n'
-      'a tessere idee\n'
+      'a tessere scenari\n'
       'che una macchina\n'
       'possa comprendere,\n'
       'realizzare\n'

--- a/lib/Services/auth_navigation_service.dart
+++ b/lib/Services/auth_navigation_service.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+import '../Pages/email_login_page.dart';
+import 'supabase_provider.dart';
+
+class AuthNavigationService {
+  const AuthNavigationService._();
+
+  static Future<bool> ensureLoggedIn(BuildContext context) async {
+    if (SupabaseProvider.client.auth.currentUser != null) return true;
+
+    final bool? loggedIn = await Navigator.of(
+      context,
+    ).push<bool>(MaterialPageRoute(builder: (_) => const EmailLoginPage()));
+
+    return loggedIn == true && SupabaseProvider.client.auth.currentUser != null;
+  }
+}

--- a/lib/UI/honoo_builder.dart
+++ b/lib/UI/honoo_builder.dart
@@ -12,6 +12,7 @@ import 'package:image_picker/image_picker.dart';
 import 'package:honoo/Utility/heic_converter.dart' as heic;
 
 import 'package:honoo/Services/supabase_provider.dart';
+import 'package:honoo/Services/auth_navigation_service.dart';
 import 'package:honoo/Utility/honoo_colors.dart';
 import 'package:honoo/Utility/typographic_substitutions_formatter.dart';
 import 'package:honoo/Widgets/honoo_dialogs.dart';
@@ -24,7 +25,6 @@ import 'package:honoo/Widgets/text_box_download_button.dart';
 import 'package:flutter/foundation.dart' show kIsWeb, visibleForTesting;
 import 'package:honoo/web/heic_converter.dart' as heicweb;
 
-import '../Pages/email_login_page.dart';
 import '../Services/honoo_image_uploader.dart';
 
 class HonooBuilder extends StatefulWidget {
@@ -328,23 +328,7 @@ class HonooBuilderState extends State<HonooBuilder> {
     final session = client.auth.currentSession;
     if (session == null) {
       if (!mounted) return;
-      final bool? goLogin = await showDialog<bool>(
-        context: context,
-        barrierDismissible: true,
-        builder: (_) => const HonooConfirmDialog(
-          title: 'Devi accedere prima',
-          message:
-              'Per caricare un’immagine,\ndevi fare prima il login.\nVuoi andare alla pagina di login?',
-          confirmLabel: 'Vai al login',
-        ),
-      );
-
-      if (goLogin == true && mounted) {
-        Navigator.push(
-          context,
-          MaterialPageRoute(builder: (_) => const EmailLoginPage()),
-        );
-      }
+      await AuthNavigationService.ensureLoggedIn(context);
       return;
     }
 

--- a/lib/Utility/utility.dart
+++ b/lib/Utility/utility.dart
@@ -22,7 +22,7 @@ class Utility {
   final String text1Six =
       """\n\nse ci clicchi sopra,\ntorni qui\na questa pagina\n\n""";
   final String sostieniText =
-      '\nVuoi collaborare\na questo progetto?\n\nScrivimi a\nvenceslao.cembalo@gmail.com\n\nSe fai la dichiarazione\ndei redditi,\npuoi scegliere\ndi destinare\nil 5 per mille\na honoo\n\nNon è una donazione in più\nNon costa nulla\n\nÈ una parte\ndelle tue imposte\nche puoi decidere\na chi destinare\n\nFirma\nnel riquadro\ndedicato agli Enti\ndel Terzo Settore\ne scrivi\nil codice fiscale\ndi honoo\n\nCodice fiscale di\nhonoo - laboratorio multimediale:\n95349850636\n\nSe ti va,\nclicca qui:\n\nhttps://ko-fi.com/honoo2026\n\nper offrire\nun bicchiere di Idromele\nagli Gnometti delle Idee\n\nOppure\nun paio di fiaschi\n\nI risultati\nsaranno scintillanti:\ngli Gnometti delle Idee\nsono sconsideratamente generosi\ncon chi è generoso\n\nProva\ne di me dirai\nche gli amici\nli consiglio bene\n';
+      '\nVuoi collaborare\na questo progetto?\n\nScrivimi a\nvenceslao.cembalo@gmail.com\n\nSe fai la dichiarazione\ndei redditi,\npuoi scegliere\ndi destinare\nil 5 per mille\na honoo\n\nNon è una donazione in più\nNon costa nulla\n\nÈ una parte\ndelle tue imposte\nche puoi decidere\na chi destinare\n\nFirma\nnel riquadro\ndedicato agli Enti\ndel Terzo Settore\ne scrivi\nil codice fiscale\ndi honoo\n\nCodice fiscale di\nhonoo - laboratorio multimediale:\n95349850636\n\nSe ti va,\nclicca qui:\n\nhttps://ko-fi.com/honoo2026\n\nper offrire\nun bicchiere di Idromele\nagli Gnometti delle Idee\n\nOppure\nun paio di fiaschi\n\nI risultati\nsaranno scintillanti:\ngli Gnometti delle Idee\nsono sconsideratamente generosi\ncon chi è generoso\n\nProva\ne di me dirai\nche gli amici\nli consiglio bene\n\n';
   final String textHome1 = 'Ti regaliamo la Luna.\nPer sempre.';
   final String textHome2 =
       'Niente è per sempre,\ne nessuno può regalarti la Luna.\n\nÈ vero,\nma non per i poeti.\n\nVuoi essere un poeta di honoo?\n\nClicca sulla Bottiglia,\ne componi i tuoi honoo e hinoo.\n\nOppure sulla Luna,\ne guarda gli honoo\ne gli hinoo degli altri.\n\nO sull’Isola,\ne inizia il viaggio\nverso le tue storie.';
@@ -31,11 +31,11 @@ class Utility {
   final String libriText =
       'Sto preparando\nle versioni cartacee\ndei miei libri\n\nHo acquistato\ni codici ISBN\ne una licenza\nInDesign\n\nÈ un lavoro lento\nArtigianale\n\nQui troverai la notizia,\nquando saranno pronti:\n\nIsola delle Storie\n\nIsole delle Storie\n(con illustrazioni di Joel Folda)\n\nImmacolato\n\nI limoni sono finiti\n\nAlmeno\navresti potuto\ncambiare i nomi\n\nPapà,\nma tu mi vuoi bene?\n';
   final String campanelliText =
-      'In questa parte dell’Isola\nci sono case.\n\nVuoi scoprire chi ci abita?\n\nScorrendo verso destra\npuoi leggere\nciò che ogni abitante\nha scelto di raccontarti.\n\nSe vuoi,\nprova a bussare:\nmagari ti fa entrare.';
+      'In questa parte dell’Isola\nci sono case\n\nVuoi scoprire chi ci abita?\n\nScorrendo verso destra\npuoi leggere\nciò che ogni abitante\nha scelto di raccontarti\n\nSe vuoi,\nprova a bussare:\nmagari ti fa entrare';
   final String campanelloExample1Text =
-      'Ti piace\nascoltare musica\nin compagnia?\n\nE ballare in casa,\ncome si fa alle feste?\n\nQuesto è il campanello\ndi casa mia.\n\nPuoi bussare,\nse vuoi.\n\nMagari sono a casa.\nMagari sto ascoltando musica.\nMagari è musica che ti piace.';
+      'Ti piace\nascoltare musica\nin compagnia?\n\nE ballare in casa,\ncome si fa alle feste?\n\nQuesto è il campanello\ndi casa mia\n\nPuoi bussare,\nse vuoi\n\nMagari sono a casa\nMagari sto ascoltando musica\nMagari è musica che ti piace';
   final String campanelloExample2Text =
-      'Ti piace\nfare colazione in compagnia,\nin un terrazzo esposto a Sud?\n\nQuesto è il campanello di casa mia.\n\nPuoi bussare,\nse vuoi.\n\nMagari sono sul terrazzo.\nMagari c’è il sole.\nMagari sto facendo colazione.';
+      'Ti piace\nfare colazione in compagnia,\nin un terrazzo esposto a Sud?\n\nQuesto è il campanello di casa mia\n\nPuoi bussare,\nse vuoi\n\nMagari sono sul terrazzo\nMagari c’è il sole\nMagari sto facendo colazione';
   final String chestHeader = 'Il tuo Cuore custodisce';
   final String chestSubHeader1 = 'gli honoo\nsalvati dalla luna';
   final String chestSubHeader2 = 'gli honoo\nscritti da te';

--- a/lib/Widgets/composer_onboarding.dart
+++ b/lib/Widgets/composer_onboarding.dart
@@ -6,6 +6,7 @@ import 'package:google_fonts/google_fonts.dart';
 
 import '../Pages/new_hinoo_page.dart';
 import '../Pages/new_honoo_page.dart';
+import '../Services/auth_navigation_service.dart';
 import '../Utility/honoo_colors.dart';
 
 class ComposerLauncher {
@@ -27,12 +28,20 @@ class ComposerOnboardingPage extends StatelessWidget {
   void _dismiss(BuildContext context) => Navigator.of(context).pop();
 
   Future<void> _openHonooComposer(BuildContext context) async {
+    if (!await AuthNavigationService.ensureLoggedIn(context) ||
+        !context.mounted) {
+      return;
+    }
     await Navigator.of(
       context,
     ).push<void>(MaterialPageRoute(builder: (_) => const NewHonooPage()));
   }
 
   Future<void> _openHinooComposer(BuildContext context) async {
+    if (!await AuthNavigationService.ensureLoggedIn(context) ||
+        !context.mounted) {
+      return;
+    }
     await Navigator.of(
       context,
     ).push<void>(MaterialPageRoute(builder: (_) => const NewHinooPage()));

--- a/lib/Widgets/honoo_app_title.dart
+++ b/lib/Widgets/honoo_app_title.dart
@@ -4,10 +4,11 @@ import 'package:honoo/Utility/honoo_colors.dart';
 import 'package:honoo/Utility/utility.dart';
 
 class HonooAppTitle extends StatelessWidget {
-  const HonooAppTitle({super.key, this.onTap, this.color});
+  const HonooAppTitle({super.key, this.onTap, this.color, this.fontSize = 28});
 
   final VoidCallback? onTap;
   final Color? color;
+  final double fontSize;
 
   @override
   Widget build(BuildContext context) {
@@ -16,7 +17,7 @@ class HonooAppTitle extends StatelessWidget {
       curve: Curves.easeOutCubic,
       style: GoogleFonts.libreFranklin(
         color: color ?? HonooColor.secondary,
-        fontSize: 28,
+        fontSize: fontSize,
         fontWeight: FontWeight.w600,
       ),
       child: Text(Utility().appName, textAlign: TextAlign.center),

--- a/test/pages/auth_gate_smoke_test.dart
+++ b/test/pages/auth_gate_smoke_test.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:honoo/Pages/auth_gate.dart';
-import 'package:honoo/Pages/placeholder_page.dart';
+import 'package:honoo/Pages/home_page.dart';
 
 import '../test_supabase_helper.dart';
 
@@ -20,10 +20,9 @@ void main() {
     harness.disableOverrides();
   });
 
-  testWidgets('AuthGate: senza sessione mostra subito la landing',
-      (tester) async {
+  testWidgets('AuthGate: senza sessione mostra subito la home', (tester) async {
     await tester.pumpWidget(const MaterialApp(home: AuthGate()));
 
-    expect(find.byType(PlaceholderPage), findsOneWidget);
+    expect(find.byType(HomePage), findsOneWidget);
   });
 }

--- a/test/pages/chest_auth_navigation_test.dart
+++ b/test/pages/chest_auth_navigation_test.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:honoo/Pages/chest_page.dart';
+import 'package:honoo/Pages/email_login_page.dart';
+
+import '../test_supabase_helper.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  setUpAll(registerSupabaseFallbacks);
+
+  late SupabaseTestHarness supabase;
+
+  setUp(() {
+    supabase = SupabaseTestHarness();
+    supabase.enableOverrides();
+  });
+
+  tearDown(() => supabase.disableOverrides());
+
+  testWidgets('lo Scrigno apre direttamente il login per un anonimo', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (context) => Scaffold(
+            body: TextButton(
+              onPressed: () => Navigator.of(context).push<void>(
+                MaterialPageRoute(builder: (_) => const ChestPage()),
+              ),
+              child: const Text('Apri Scrigno'),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Apri Scrigno'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(EmailLoginPage), findsOneWidget);
+    expect(find.byType(AlertDialog), findsNothing);
+  });
+}

--- a/test/pages/home_page_layout_test.dart
+++ b/test/pages/home_page_layout_test.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:honoo/Pages/home_page.dart';
+import 'package:honoo/Pages/placeholder_page.dart';
 import 'package:honoo/Services/home_service.dart';
 import 'package:honoo/Utility/reply_notification_signal.dart';
 import 'package:honoo/Widgets/sea_footer_bar.dart';
@@ -61,19 +62,31 @@ void main() {
     final intro = find.byKey(const Key('home_intro_text'));
     expect(intro, findsOneWidget);
     expect(find.textContaining('Ti regaliamo la Luna'), findsOneWidget);
-    expect(find.textContaining('verso le tue storie'), findsOneWidget);
+    expect(
+      find.textContaining('È vero. Ma non per i poeti\n\nVuoi essere'),
+      findsOneWidget,
+    );
+    expect(find.byKey(const Key('home_island_followup_text')), findsOneWidget);
+    final islandFollowupTransform = tester.widget<Transform>(
+      find.byKey(const Key('home_island_followup_text_offset')),
+    );
+    expect(islandFollowupTransform.transform.getTranslation().y, -2);
+    expect(find.textContaining('e vedi tutto'), findsOneWidget);
     expect(find.byType(Scrollable), findsNothing);
     expect(find.byKey(const Key('home_inline_bottle')), findsOneWidget);
     expect(find.byKey(const Key('home_inline_moon')), findsOneWidget);
     expect(find.byKey(const Key('home_inline_island')), findsOneWidget);
+    expect(find.byKey(const Key('home_inline_honoo')), findsOneWidget);
     expect(find.byKey(const Key('home_bottle_leading_gap')), findsOneWidget);
     expect(find.byKey(const Key('home_moon_leading_gap')), findsOneWidget);
     expect(find.byKey(const Key('home_island_leading_gap')), findsOneWidget);
+    expect(find.byKey(const Key('home_honoo_leading_gap')), findsOneWidget);
 
     for (final key in const [
       Key('home_bottle_leading_gap'),
       Key('home_moon_leading_gap'),
       Key('home_island_leading_gap'),
+      Key('home_honoo_leading_gap'),
     ]) {
       expect(tester.getSize(find.byKey(key)).width, 8);
     }
@@ -81,7 +94,7 @@ void main() {
     for (final entry in const [
       (Key('home_inline_bottle'), 42.0),
       (Key('home_inline_moon'), 28.0),
-      (Key('home_inline_island'), 43.0),
+      (Key('home_inline_island'), 55.0),
     ]) {
       final key = entry.$1;
       final button = tester.widget<IconButton>(find.byKey(key));
@@ -90,12 +103,29 @@ void main() {
       expect(button.constraints!.maxHeight, entry.$2);
     }
 
+    final inlineHonooStyle = tester.widget<AnimatedDefaultTextStyle>(
+      find.descendant(
+        of: find.byKey(const Key('home_inline_honoo')),
+        matching: find.byType(AnimatedDefaultTextStyle),
+      ),
+    );
+    expect(inlineHonooStyle.style.fontSize, 23);
+
     await pumpHomeAtSize(tester, const Size(1440, 1000));
 
     expect(find.byKey(const Key('home_intro_text')), findsOneWidget);
     expect(find.byType(Scrollable), findsNothing);
 
     await tester.pumpWidget(const SizedBox.shrink());
+  });
+
+  testWidgets("la scritta honoo apre la placeholder page", (tester) async {
+    await pumpHomeAtSize(tester, const Size(320, 600));
+
+    await tester.tap(find.byKey(const Key('home_inline_honoo')));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(PlaceholderPage), findsOneWidget);
   });
 
   testWidgets('una risposta vecchia non ripristina il badge già azzerato', (

--- a/test/pages/placeholder_mobile_background_test.dart
+++ b/test/pages/placeholder_mobile_background_test.dart
@@ -31,6 +31,29 @@ void main() {
 
     expect(scaffold.backgroundColor, HonooColor.background);
     expect(find.byType(SmoothImage), findsNothing);
+
+    final luna = tester.widget<Image>(
+      find.byWidgetPredicate(
+        (widget) =>
+            widget is Image &&
+            widget.image is AssetImage &&
+            (widget.image as AssetImage).assetName == 'assets/icons/luna.png',
+      ),
+    );
+    final feste = tester.widget<Image>(
+      find.byWidgetPredicate(
+        (widget) =>
+            widget is Image &&
+            widget.image is AssetImage &&
+            (widget.image as AssetImage).assetName == 'assets/icons/feste.png',
+      ),
+    );
+    expect(luna.height, 75);
+    final lunaTransform = tester.widget<Transform>(
+      find.byKey(const Key('luna_icon_transform')),
+    );
+    expect(lunaTransform.transform.getTranslation().y, -2);
+    expect(feste.height, 66);
   });
 
   testWidgets('tablet e desktop mantengono il background attuale', (

--- a/test/pages/regia_agenti_page_test.dart
+++ b/test/pages/regia_agenti_page_test.dart
@@ -31,7 +31,11 @@ void main() {
     );
     expect(aiIcon, findsOneWidget);
     final svg = tester.widget<SvgPicture>(aiIcon);
-    expect(svg.height, 52);
+    expect(svg.height, 45);
+    final transform = tester.widget<Transform>(
+      find.byKey(const Key('regia_agenti_icon_transform')),
+    );
+    expect(transform.transform.getTranslation().y, -2);
     expect(
       svg.colorFilter,
       const ColorFilter.mode(Color.fromRGBO(183, 183, 206, 1), BlendMode.srcIn),
@@ -46,7 +50,11 @@ void main() {
       tester
           .getSize(find.byKey(const Key('regia_agenti_icon_bottom_spacing')))
           .height,
-      20,
+      30,
+    );
+    expect(
+      tester.getSize(find.byKey(const Key('isola_icon_bottom_spacing'))).height,
+      30,
     );
 
     final visibleTexts = tester
@@ -54,11 +62,26 @@ void main() {
         .map((widget) => widget.data)
         .whereType<String>()
         .toList();
-    final viaggiIndex = visibleTexts.indexOf("viaggi sull'Isola delle Storie");
+    expect(
+      visibleTexts,
+      containsAll(<String>[
+        'Performance',
+        'Laboratori teatrali',
+        'Esplorazioni lunari',
+        'Feste',
+        "Viaggi sull'Isola delle Storie",
+        'Regia degli Agenti',
+        'Podcast e dirette',
+        'Libri',
+      ]),
+    );
+    final viaggiIndex = visibleTexts.indexOf("Viaggi sull'Isola delle Storie");
     final regiaIndex = visibleTexts.indexOf('Regia degli Agenti');
     final podcastIndex = visibleTexts.indexOf('Podcast e dirette');
+    final libriIndex = visibleTexts.indexOf('Libri');
     expect(regiaIndex, viaggiIndex + 1);
     expect(regiaIndex, lessThan(podcastIndex));
+    expect(libriIndex, podcastIndex + 1);
 
     await tester.ensureVisible(link);
     await tester.tap(link);
@@ -90,6 +113,8 @@ void main() {
     expect(text.textSpan?.toPlainText(), contains('Behavior Driven Design'));
     expect(text.textSpan?.toPlainText(), contains('Sì,\nstiamo parlando'));
     expect(text.textSpan?.toPlainText(), contains('guidando agenti AI'));
+    expect(text.textSpan?.toPlainText(), contains('a tessere scenari'));
+    expect(text.textSpan?.toPlainText(), isNot(contains('a tessere idee')));
     expect(
       text.textSpan?.toPlainText(),
       endsWith('E dirigere\ngli agenti\nsignifica\nimparare\na tessere'),

--- a/test/utility/interface_text_test.dart
+++ b/test/utility/interface_text_test.dart
@@ -1,4 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:honoo/IsolaDelleStorie/Utility/isola_delle_storie_content_manager.dart';
+import 'package:honoo/Utility/utility.dart';
 import 'package:honoo/Utility/interface_text.dart';
 
 void main() {
@@ -16,5 +18,24 @@ void main() {
   test('mantiene i puntini di sospensione e il testo senza punto', () {
     expect(withoutInterfaceTrailingPeriod('Attendi...'), 'Attendi...');
     expect(withoutInterfaceTrailingPeriod('Salva honoo'), 'Salva honoo');
+  });
+
+  test(
+    'le sezioni raggiunte da clicca qui non chiudono i paragrafi col punto',
+    () {
+      final utility = Utility();
+      for (final text in <String>[
+        IsolaDelleStoreContentManager.fullIslandDescription,
+        utility.campanelliText,
+        utility.campanelloExample1Text,
+        utility.campanelloExample2Text,
+      ]) {
+        expect(text, isNot(contains('.')));
+      }
+    },
+  );
+
+  test('il testo di sostegno mantiene uno spazio finale', () {
+    expect(Utility().sostieniText, endsWith('li consiglio bene\n\n'));
   });
 }

--- a/test/widgets/composer_onboarding_test.dart
+++ b/test/widgets/composer_onboarding_test.dart
@@ -3,14 +3,26 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:honoo/Pages/new_hinoo_page.dart';
 import 'package:honoo/Pages/new_honoo_page.dart';
+import 'package:honoo/Pages/email_login_page.dart';
 import 'package:honoo/Utility/honoo_colors.dart';
 import 'package:honoo/Widgets/composer_onboarding.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import '../test_supabase_helper.dart';
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
+  setUpAll(registerSupabaseFallbacks);
 
-  setUp(() => SharedPreferences.setMockInitialValues({}));
+  late SupabaseTestHarness supabase;
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    supabase = SupabaseTestHarness(withAuthenticatedUser: true);
+    supabase.enableOverrides();
+  });
+
+  tearDown(() => supabase.disableOverrides());
 
   Future<void> pumpOnboarding(
     WidgetTester tester, {
@@ -95,6 +107,36 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byType(NewHinooPage), findsOneWidget);
+  });
+
+  testWidgets('da anonimo la bottiglia apre direttamente il login', (
+    tester,
+  ) async {
+    supabase.disableOverrides();
+    supabase = SupabaseTestHarness();
+    supabase.enableOverrides();
+    await pumpOnboarding(tester, size: const Size(390, 844));
+
+    await tester.tap(find.byKey(const Key('composer_onboarding_bottle')));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(EmailLoginPage), findsOneWidget);
+    expect(find.byType(NewHonooPage), findsNothing);
+    expect(find.byType(AlertDialog), findsNothing);
+  });
+
+  testWidgets('da anonimo la piuma apre direttamente il login', (tester) async {
+    supabase.disableOverrides();
+    supabase = SupabaseTestHarness();
+    supabase.enableOverrides();
+    await pumpOnboarding(tester, size: const Size(390, 844));
+
+    await tester.tap(find.byKey(const Key('composer_onboarding_feather')));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(EmailLoginPage), findsOneWidget);
+    expect(find.byType(NewHinooPage), findsNothing);
+    expect(find.byType(AlertDialog), findsNothing);
   });
 
   testWidgets('testo e icone delle azioni restano sulla stessa riga', (


### PR DESCRIPTION
## Cosa cambia

- aggiorna Home e Placeholder con testi, dimensioni, spaziature e collegamenti richiesti
- rende Home la prima pagina visibile dopo il caricamento
- apre direttamente il login per creazione Honoo/Hinoo e accesso allo Scrigno quando l’utente non è autenticato
- uniforma i testi informativi e la pagina Regia degli agenti
- aggiunge test di regressione per layout, contenuti e navigazione di autenticazione

## Impatto

L’ingresso nell’app parte dalla Home e le azioni protette portano subito al login, senza popup intermedi. L’esperienza mobile e la gerarchia visiva delle icone risultano allineate alle specifiche editoriali.

## Verifiche

- `flutter analyze --no-pub`
- suite Flutter completa: 336 test superati, 7 ignorati
- anteprima mobile verificata su server locale
