### PR TITLE
Fix house chest and campanelli layouts

### DIFF
--- a/lib/Controller/chest_organizer.dart
+++ b/lib/Controller/chest_organizer.dart
@@ -1,3 +1,5 @@
+import '../Entities/casa_share_mode.dart';
+
 class ChestOrganization<T> {
   const ChestOrganization({
     required this.items,
@@ -25,6 +27,23 @@ class ChestNotificationTarget {
 /// Regole pure di ordinamento e raggruppamento dello Scrigno.
 class ChestOrganizer {
   const ChestOrganizer._();
+
+  static bool matchesCasaFilter({
+    required CasaChestFilter? filter,
+    required bool isFromMoonSaved,
+    required bool hasConversation,
+  }) {
+    switch (filter) {
+      case null:
+        return true;
+      case CasaChestFilter.authored:
+        return !hasConversation && !isFromMoonSaved;
+      case CasaChestFilter.moonSaved:
+        return !hasConversation && isFromMoonSaved;
+      case CasaChestFilter.conversations:
+        return hasConversation;
+    }
+  }
 
   static ChestOrganization<T> organize<T>({
     required List<T> items,

--- a/lib/Entities/casa_share_mode.dart
+++ b/lib/Entities/casa_share_mode.dart
@@ -38,3 +38,25 @@ enum CasaShareMode {
     }
   }
 }
+
+/// Filtri di visualizzazione dello Scrigno aperto dalla propria casa.
+///
+/// Sono distinti da [CasaShareMode]: `all` continua a significare "tutto"
+/// nelle autorizzazioni di condivisione, mentre qui le tre icone rappresentano
+/// categorie reciprocamente esclusive.
+enum CasaChestFilter {
+  authored,
+  moonSaved,
+  conversations;
+
+  String get label {
+    switch (this) {
+      case CasaChestFilter.authored:
+        return 'honoo e hinoo scritti da te';
+      case CasaChestFilter.moonSaved:
+        return 'honoo e hinoo salvati dalla luna';
+      case CasaChestFilter.conversations:
+        return 'conversazioni';
+    }
+  }
+}

--- a/lib/IsolaDelleStorie/Pages/campanelli_page.dart
+++ b/lib/IsolaDelleStorie/Pages/campanelli_page.dart
@@ -1007,6 +1007,15 @@ class _CampanelliPageState extends State<CampanelliPage> {
           final double safeBottom = MediaQuery.of(context).viewPadding.bottom;
           final double footerSpacing = footerBottomPadding + safeBottom;
           final double footerBottomSpacing = footerSpacing / 2;
+          final double carouselArrowSize = switch (layoutMode) {
+            ResponsiveLayoutMode.mobile => 24,
+            ResponsiveLayoutMode.tablet => 26,
+            ResponsiveLayoutMode.desktop ||
+            ResponsiveLayoutMode.wideDesktop ||
+            ResponsiveLayoutMode.largeDesktop => 28,
+          };
+          final double carouselArrowVerticalInset =
+              footerIconSize + footerSpacing + 12;
           final double scrignoSize = math.min(
             footerIconSize * 4,
             math.min(maxWidth, maxHeight),
@@ -1365,6 +1374,10 @@ class _CampanelliPageState extends State<CampanelliPage> {
                             );
                           },
                           arrowColor: Colors.white,
+                          arrowSize: carouselArrowSize,
+                          horizontalInset: isMobile ? 4 : 10,
+                          arrowAlignment: Alignment.bottomCenter,
+                          verticalInset: carouselArrowVerticalInset,
                           child: const SizedBox.expand(),
                         ),
                       ),

--- a/lib/IsolaDelleStorie/Pages/campanelli_page.dart
+++ b/lib/IsolaDelleStorie/Pages/campanelli_page.dart
@@ -296,12 +296,12 @@ class _CampanelliPageState extends State<CampanelliPage> {
     final user = SupabaseProvider.client.auth.currentUser;
     final bool isOwner = user != null && campanello.ownerId == user.id;
     if (isOwner) {
-      final filter = await Navigator.of(context).push<CasaShareMode>(
+      final filter = await Navigator.of(context).push<CasaChestFilter>(
         MaterialPageRoute(builder: (_) => const CasaChestFilterPage()),
       );
       if (!mounted || filter == null) return;
       await Navigator.of(context).push<void>(
-        MaterialPageRoute(builder: (_) => ChestPage(initialFilter: filter)),
+        MaterialPageRoute(builder: (_) => ChestPage(casaFilter: filter)),
       );
       return;
     }

--- a/lib/IsolaDelleStorie/Pages/pending_hinoo_page.dart
+++ b/lib/IsolaDelleStorie/Pages/pending_hinoo_page.dart
@@ -44,13 +44,9 @@ class PendingHinooPage extends StatelessWidget {
 
           return Column(
             children: [
-              SizedBox(
+              const SizedBox(
                 height: headerH,
-                child: Center(
-                  child: HonooAppTitle(
-                    onTap: () => Navigator.of(context).pop(false),
-                  ),
-                ),
+                child: Center(child: HonooAppTitle()),
               ),
               Expanded(
                 child: Center(

--- a/lib/IsolaDelleStorie/Pages/pending_honoo_page.dart
+++ b/lib/IsolaDelleStorie/Pages/pending_honoo_page.dart
@@ -50,13 +50,9 @@ class PendingHonooPage extends StatelessWidget {
 
           return Column(
             children: [
-              SizedBox(
+              const SizedBox(
                 height: headerH,
-                child: Center(
-                  child: HonooAppTitle(
-                    onTap: () => Navigator.of(context).pop(false),
-                  ),
-                ),
+                child: Center(child: HonooAppTitle()),
               ),
               Expanded(
                 child: Center(

--- a/lib/Pages/casa_share_selection_page.dart
+++ b/lib/Pages/casa_share_selection_page.dart
@@ -43,33 +43,35 @@ class CasaChestFilterPage extends StatelessWidget {
                   children: [
                     _ShareIcon(
                       key: const ValueKey('house-chest-home'),
-                      mode: CasaShareMode.home,
+                      label: CasaChestFilter.authored.label,
                       asset: 'assets/icons/honoo_chest_blue.svg',
                       selected: false,
                       size: iconSize,
                       addWhiteOutline: true,
                       onTap: () =>
-                          Navigator.of(context).pop(CasaShareMode.home),
+                          Navigator.of(context).pop(CasaChestFilter.authored),
                     ),
                     SizedBox(height: spacing),
                     _ShareIcon(
                       key: const ValueKey('house-chest-moon'),
-                      mode: CasaShareMode.moon,
+                      label: CasaChestFilter.moonSaved.label,
                       asset: 'assets/icons/honoo_chest_white.svg',
                       selected: false,
                       size: iconSize,
                       onTap: () =>
-                          Navigator.of(context).pop(CasaShareMode.moon),
+                          Navigator.of(context).pop(CasaChestFilter.moonSaved),
                     ),
                     SizedBox(height: spacing),
                     _ShareIcon(
                       key: const ValueKey('house-chest-all'),
-                      mode: CasaShareMode.all,
+                      label: CasaChestFilter.conversations.label,
                       asset: 'assets/icons/chest_home.svg',
                       selected: false,
                       size: iconSize,
                       addWhiteOutline: true,
-                      onTap: () => Navigator.of(context).pop(CasaShareMode.all),
+                      onTap: () => Navigator.of(
+                        context,
+                      ).pop(CasaChestFilter.conversations),
                     ),
                   ],
                 ),
@@ -128,7 +130,7 @@ class _CasaShareSelectionPageState extends State<CasaShareSelectionPage> {
                         SizedBox(height: compact ? 24 : 40),
                         _ShareIcon(
                           key: const ValueKey('house-share-home'),
-                          mode: CasaShareMode.home,
+                          label: CasaShareMode.home.label,
                           asset: 'assets/icons/honoo_chest_blue.svg',
                           selected: _selected.contains(CasaShareMode.home),
                           size: iconSize,
@@ -138,7 +140,7 @@ class _CasaShareSelectionPageState extends State<CasaShareSelectionPage> {
                         SizedBox(height: spacing),
                         _ShareIcon(
                           key: const ValueKey('house-share-moon'),
-                          mode: CasaShareMode.moon,
+                          label: CasaShareMode.moon.label,
                           asset: 'assets/icons/honoo_chest_white.svg',
                           selected: _selected.contains(CasaShareMode.moon),
                           size: iconSize,
@@ -147,7 +149,7 @@ class _CasaShareSelectionPageState extends State<CasaShareSelectionPage> {
                         SizedBox(height: spacing),
                         _ShareIcon(
                           key: const ValueKey('house-share-all'),
-                          mode: CasaShareMode.all,
+                          label: CasaShareMode.all.label,
                           asset: 'assets/icons/chest_home.svg',
                           selected: _selected.contains(CasaShareMode.all),
                           size: iconSize,
@@ -196,7 +198,7 @@ class _CasaShareSelectionPageState extends State<CasaShareSelectionPage> {
 class _ShareIcon extends StatelessWidget {
   const _ShareIcon({
     super.key,
-    required this.mode,
+    required this.label,
     required this.asset,
     required this.selected,
     required this.size,
@@ -204,7 +206,7 @@ class _ShareIcon extends StatelessWidget {
     this.addWhiteOutline = false,
   });
 
-  final CasaShareMode mode;
+  final String label;
   final String asset;
   final bool selected;
   final double size;
@@ -234,14 +236,14 @@ class _ShareIcon extends StatelessWidget {
     );
 
     return Tooltip(
-      message: mode.label,
+      message: label,
       preferBelow: false,
       verticalOffset: 18,
       waitDuration: const Duration(milliseconds: 250),
       child: Semantics(
         button: true,
         selected: selected,
-        label: mode.label,
+        label: label,
         child: Material(
           color: Colors.transparent,
           child: InkWell(

--- a/lib/Pages/chest_page.dart
+++ b/lib/Pages/chest_page.dart
@@ -54,6 +54,7 @@ class ChestPage extends StatefulWidget {
     this.highlightLatest = false,
     this.focusReplyId,
     this.initialFilter = CasaShareMode.all,
+    this.casaFilter,
   });
 
   final bool focusReplies;
@@ -61,6 +62,7 @@ class ChestPage extends StatefulWidget {
   final bool highlightLatest;
   final String? focusReplyId;
   final CasaShareMode initialFilter;
+  final CasaChestFilter? casaFilter;
 
   @override
   State<ChestPage> createState() => _ChestPageState();
@@ -331,6 +333,7 @@ class _ChestPageState extends State<ChestPage> with WidgetsBindingObserver {
       widget.focusReplies ? '1' : '0',
       widget.highlightLatest ? '1' : '0',
       widget.initialFilter.name,
+      widget.casaFilter?.name ?? '',
       _initialLoadCompleted ? 'loaded' : 'loading',
       _pendingRevealEntryId ?? '',
       _mode.name,
@@ -360,19 +363,33 @@ class _ChestPageState extends State<ChestPage> with WidgetsBindingObserver {
 
     final items = [...honooItems, ...hinooItems]
         .where((item) {
+          final conversationId = _conversationIdForItemFilter(item);
+          final hasConversation =
+              (conversationId != null &&
+                  (_honooLatestReplies.containsKey(conversationId) ||
+                      _hinooLatestReplies.containsKey(conversationId))) ||
+              item.when(
+                honoo: (honoo) => honoo.hasReplies,
+                hinoo: (_) => false,
+              );
+          final isFromMoonSaved = item.when(
+            honoo: (honoo) => honoo.isFromMoonSaved,
+            hinoo: (hinoo) => hinoo.isFromMoonSaved,
+          );
+          if (widget.casaFilter != null) {
+            return ChestOrganizer.matchesCasaFilter(
+              filter: widget.casaFilter,
+              isFromMoonSaved: isFromMoonSaved,
+              hasConversation: hasConversation,
+            );
+          }
           switch (widget.initialFilter) {
             case CasaShareMode.all:
               return true;
             case CasaShareMode.home:
-              return item.when(
-                honoo: (honoo) => !honoo.isFromMoonSaved,
-                hinoo: (hinoo) => !hinoo.isFromMoonSaved,
-              );
+              return !isFromMoonSaved;
             case CasaShareMode.moon:
-              return item.when(
-                honoo: (honoo) => honoo.isFromMoonSaved,
-                hinoo: (hinoo) => hinoo.isFromMoonSaved,
-              );
+              return isFromMoonSaved;
           }
         })
         .toList(growable: false);
@@ -502,6 +519,12 @@ class _ChestPageState extends State<ChestPage> with WidgetsBindingObserver {
   String? _convIdOfItem(ChestItem it) => it.when(
     honoo: (h) => h.conversationId,
     hinoo: (row) => row.conversationId ?? row.draft.conversationId,
+  );
+
+  String? _conversationIdForItemFilter(ChestItem item) => item.when(
+    honoo: (honoo) => honoo.conversationId ?? honoo.dbId,
+    hinoo: (hinoo) =>
+        hinoo.conversationId ?? hinoo.draft.conversationId ?? hinoo.id,
   );
 
   String? _conversationIdForDeletion(ChestItem item) {

--- a/lib/Pages/chest_page.dart
+++ b/lib/Pages/chest_page.dart
@@ -1157,7 +1157,6 @@ class _ChestPageState extends State<ChestPage> with WidgetsBindingObserver {
         return ThreadLayoutScaffold(
           backgroundColor: pageStyle.backgroundColor,
           header: HonooAppTitle(
-            color: pageStyle.logoColor,
             onTap: () {
               Navigator.of(context).pushAndRemoveUntil(
                 MaterialPageRoute(builder: (_) => const PlaceholderPage()),

--- a/lib/Pages/conversation_page.dart
+++ b/lib/Pages/conversation_page.dart
@@ -81,7 +81,6 @@ class _ConversationPageState extends State<ConversationPage> {
     return ThreadLayoutScaffold(
       backgroundColor: pageStyle.backgroundColor,
       header: HonooAppTitle(
-        color: pageStyle.logoColor,
         onTap: () {
           Navigator.of(context).pushAndRemoveUntil(
             MaterialPageRoute(builder: (_) => const PlaceholderPage()),

--- a/lib/Pages/shared_house_chest_page.dart
+++ b/lib/Pages/shared_house_chest_page.dart
@@ -62,9 +62,9 @@ class _SharedHouseChestPageState extends State<SharedHouseChestPage> {
       body: SafeArea(
         child: Column(
           children: [
-            Padding(
-              padding: const EdgeInsets.only(top: 8),
-              child: HonooAppTitle(onTap: () => Navigator.of(context).pop()),
+            const Padding(
+              padding: EdgeInsets.only(top: 8),
+              child: HonooAppTitle(),
             ),
             Expanded(child: _body()),
             if (_items.length > 1)

--- a/lib/Widgets/campanello_card.dart
+++ b/lib/Widgets/campanello_card.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 
@@ -30,6 +32,10 @@ class CampanelloCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final double verticalPadding = HinooTypography.verticalPadding(width);
+    final double textCanvasHeight = math.min(
+      height,
+      width / HinooTypography.aspectRatio,
+    );
     final TextStyle textStyle = GoogleFonts.lora(
       fontSize: 18,
       height: HinooTypography.lineHeight,
@@ -51,16 +57,24 @@ class CampanelloCard extends StatelessWidget {
       );
     }
 
-    final Widget savedText = Padding(
-      padding: EdgeInsets.fromLTRB(
-        HinooTypography.horizontalPadding,
-        HinooTypography.editorTextTopPadding(width),
-        HinooTypography.horizontalPadding,
-        HinooTypography.editorTextBottomPadding,
-      ),
-      child: Center(
-        key: const ValueKey('campanello-saved-text-position'),
-        child: _buildText(textStyle),
+    final Widget savedText = Align(
+      alignment: Alignment.topCenter,
+      child: SizedBox(
+        key: const ValueKey('campanello-text-canvas'),
+        width: width,
+        height: textCanvasHeight,
+        child: Padding(
+          padding: EdgeInsets.fromLTRB(
+            HinooTypography.horizontalPadding,
+            HinooTypography.editorTextTopPadding(width),
+            HinooTypography.horizontalPadding,
+            HinooTypography.editorTextBottomPadding,
+          ),
+          child: Center(
+            key: const ValueKey('campanello-saved-text-position'),
+            child: _buildText(textStyle),
+          ),
+        ),
       ),
     );
 

--- a/lib/Widgets/chest_info_dialog.dart
+++ b/lib/Widgets/chest_info_dialog.dart
@@ -6,19 +6,15 @@ import 'package:flutter_svg/flutter_svg.dart';
 import '../Utility/honoo_colors.dart';
 import 'honoo_dialogs.dart';
 
-const chestInfoText =
+const chestInfoTextBeforeIcons =
     "Questo è il tuo Scrigno\n\n"
     "Qui sono custoditi\n"
     "gli honoo e gli hinoo\n"
     "che hai scritto,\n\n"
     "quelli che hai salvato dalla Luna,\n\n"
-    "e quelli che hai ricevuto\n\n"
-    "Blu\n"
-    "sono i tuoi\n\n"
-    "Bianchi\n"
-    "quelli della Luna\n\n"
-    "Rossi\n"
-    "quelli che ti sono stati inviati\n\n"
+    "e quelli che hai ricevuto\n\n";
+
+const chestInfoTextAfterIcons =
     "Scorri verso destra\n"
     "per rivedere ciò che hai scritto\n"
     "e ciò che hai salvato\n\n"
@@ -78,10 +74,36 @@ class ChestInfoDialog extends StatelessWidget {
                       ),
                       child: SingleChildScrollView(
                         physics: const BouncingScrollPhysics(),
-                        child: Text(
-                          chestInfoText,
-                          style: HonooDialogStyles.body(
-                            color: HonooColor.onBackground,
+                        child: Text.rich(
+                          TextSpan(
+                            style: HonooDialogStyles.body(
+                              color: HonooColor.onBackground,
+                            ),
+                            children: [
+                              const TextSpan(text: chestInfoTextBeforeIcons),
+                              _chestIconSpan(
+                                asset: 'assets/icons/honoo_chest_blue.svg',
+                                semanticsLabel: 'Blu',
+                                size: _responsiveIconSize(maxWidth),
+                              ),
+                              const TextSpan(text: '\nsono i tuoi\n\n'),
+                              _chestIconSpan(
+                                asset: 'assets/icons/honoo_chest_white.svg',
+                                semanticsLabel: 'Bianchi',
+                                size: _responsiveIconSize(maxWidth),
+                              ),
+                              const TextSpan(text: '\nquelli della Luna\n\n'),
+                              _chestIconSpan(
+                                asset: 'assets/icons/honoo_chest_red.svg',
+                                semanticsLabel: 'Rossi',
+                                size: _responsiveIconSize(maxWidth),
+                              ),
+                              const TextSpan(
+                                text:
+                                    '\nquelli che ti sono stati inviati\n\n'
+                                    '$chestInfoTextAfterIcons',
+                              ),
+                            ],
                           ),
                           textAlign: TextAlign.center,
                         ),
@@ -112,6 +134,27 @@ class ChestInfoDialog extends StatelessWidget {
           ),
         );
       },
+    ),
+  );
+
+  static double _responsiveIconSize(double availableWidth) =>
+      (availableWidth * 0.2).clamp(44.0, 72.0);
+
+  static WidgetSpan _chestIconSpan({
+    required String asset,
+    required String semanticsLabel,
+    required double size,
+  }) => WidgetSpan(
+    alignment: PlaceholderAlignment.middle,
+    child: Semantics(
+      image: true,
+      label: semanticsLabel,
+      child: SvgPicture.asset(
+        asset,
+        width: size,
+        height: size,
+        excludeFromSemantics: true,
+      ),
     ),
   );
 }

--- a/lib/Widgets/desktop_carousel_arrows.dart
+++ b/lib/Widgets/desktop_carousel_arrows.dart
@@ -14,6 +14,8 @@ class DesktopCarouselArrows extends StatelessWidget {
     this.arrowColor = Colors.white,
     this.arrowSize = 48,
     this.horizontalInset = 16,
+    this.arrowAlignment = Alignment.center,
+    this.verticalInset = 0,
   });
 
   final Widget child;
@@ -24,6 +26,8 @@ class DesktopCarouselArrows extends StatelessWidget {
   final Color arrowColor;
   final double arrowSize;
   final double horizontalInset;
+  final AlignmentGeometry arrowAlignment;
+  final double verticalInset;
 
   @override
   Widget build(BuildContext context) {
@@ -36,23 +40,29 @@ class DesktopCarouselArrows extends StatelessWidget {
             left: horizontalInset,
             top: 0,
             bottom: 0,
-            child: Center(
-              child: Tooltip(
-                message: 'Indietro',
-                child: GestureDetector(
-                  key: const ValueKey<String>('desktop_carousel_prev'),
-                  behavior: HitTestBehavior.opaque,
-                  onTap: onPrev,
-                  child: SizedBox.square(
-                    dimension: arrowSize + 16,
-                    child: Center(
-                      child: SvgPicture.asset(
-                        'assets/icons/arrow_left.svg',
-                        width: arrowSize,
-                        height: arrowSize,
-                        colorFilter:
-                            ColorFilter.mode(arrowColor, BlendMode.srcIn),
-                        semanticsLabel: 'Indietro',
+            child: Padding(
+              padding: EdgeInsets.symmetric(vertical: verticalInset),
+              child: Align(
+                alignment: arrowAlignment,
+                child: Tooltip(
+                  message: 'Indietro',
+                  child: GestureDetector(
+                    key: const ValueKey<String>('desktop_carousel_prev'),
+                    behavior: HitTestBehavior.opaque,
+                    onTap: onPrev,
+                    child: SizedBox.square(
+                      dimension: arrowSize + 16,
+                      child: Center(
+                        child: SvgPicture.asset(
+                          'assets/icons/arrow_left.svg',
+                          width: arrowSize,
+                          height: arrowSize,
+                          colorFilter: ColorFilter.mode(
+                            arrowColor,
+                            BlendMode.srcIn,
+                          ),
+                          semanticsLabel: 'Indietro',
+                        ),
                       ),
                     ),
                   ),
@@ -65,23 +75,29 @@ class DesktopCarouselArrows extends StatelessWidget {
             right: horizontalInset,
             top: 0,
             bottom: 0,
-            child: Center(
-              child: Tooltip(
-                message: 'Avanti',
-                child: GestureDetector(
-                  key: const ValueKey<String>('desktop_carousel_next'),
-                  behavior: HitTestBehavior.opaque,
-                  onTap: onNext,
-                  child: SizedBox.square(
-                    dimension: arrowSize + 16,
-                    child: Center(
-                      child: SvgPicture.asset(
-                        'assets/icons/arrow_right.svg',
-                        width: arrowSize,
-                        height: arrowSize,
-                        colorFilter:
-                            ColorFilter.mode(arrowColor, BlendMode.srcIn),
-                        semanticsLabel: 'Avanti',
+            child: Padding(
+              padding: EdgeInsets.symmetric(vertical: verticalInset),
+              child: Align(
+                alignment: arrowAlignment,
+                child: Tooltip(
+                  message: 'Avanti',
+                  child: GestureDetector(
+                    key: const ValueKey<String>('desktop_carousel_next'),
+                    behavior: HitTestBehavior.opaque,
+                    onTap: onNext,
+                    child: SizedBox.square(
+                      dimension: arrowSize + 16,
+                      child: Center(
+                        child: SvgPicture.asset(
+                          'assets/icons/arrow_right.svg',
+                          width: arrowSize,
+                          height: arrowSize,
+                          colorFilter: ColorFilter.mode(
+                            arrowColor,
+                            BlendMode.srcIn,
+                          ),
+                          semanticsLabel: 'Avanti',
+                        ),
                       ),
                     ),
                   ),

--- a/lib/Widgets/honoo_app_title.dart
+++ b/lib/Widgets/honoo_app_title.dart
@@ -3,6 +3,8 @@ import 'package:google_fonts/google_fonts.dart';
 import 'package:honoo/Utility/honoo_colors.dart';
 import 'package:honoo/Utility/utility.dart';
 
+import '../Pages/placeholder_page.dart';
+
 class HonooAppTitle extends StatelessWidget {
   const HonooAppTitle({super.key, this.onTap, this.color, this.fontSize = 28});
 
@@ -12,6 +14,14 @@ class HonooAppTitle extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final VoidCallback effectiveOnTap =
+        onTap ??
+        () {
+          Navigator.of(context).pushAndRemoveUntil(
+            MaterialPageRoute(builder: (_) => const PlaceholderPage()),
+            (route) => false,
+          );
+        };
     final text = AnimatedDefaultTextStyle(
       duration: const Duration(milliseconds: 220),
       curve: Curves.easeOutCubic,
@@ -23,14 +33,14 @@ class HonooAppTitle extends StatelessWidget {
       child: Text(Utility().appName, textAlign: TextAlign.center),
     );
 
-    if (onTap == null) {
-      return text;
-    }
-
     return GestureDetector(
       behavior: HitTestBehavior.translucent,
-      onTap: onTap,
-      child: Semantics(button: true, label: 'Home', child: text),
+      onTap: effectiveOnTap,
+      child: Semantics(
+        button: true,
+        label: 'Apri la pagina honoo',
+        child: text,
+      ),
     );
   }
 }

--- a/test/chest_ordering_test.dart
+++ b/test/chest_ordering_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:honoo/Entities/casa_share_mode.dart';
 import 'package:honoo/Controller/chest_organizer.dart';
 
 class _Item {
@@ -29,6 +30,49 @@ ChestOrganization<_Item> _organize(List<_Item> items) {
 }
 
 void main() {
+  test('i filtri dello Scrigno di casa sono reciprocamente esclusivi', () {
+    expect(
+      ChestOrganizer.matchesCasaFilter(
+        filter: CasaChestFilter.authored,
+        isFromMoonSaved: false,
+        hasConversation: false,
+      ),
+      isTrue,
+    );
+    expect(
+      ChestOrganizer.matchesCasaFilter(
+        filter: CasaChestFilter.moonSaved,
+        isFromMoonSaved: true,
+        hasConversation: false,
+      ),
+      isTrue,
+    );
+    expect(
+      ChestOrganizer.matchesCasaFilter(
+        filter: CasaChestFilter.conversations,
+        isFromMoonSaved: true,
+        hasConversation: true,
+      ),
+      isTrue,
+    );
+    expect(
+      ChestOrganizer.matchesCasaFilter(
+        filter: CasaChestFilter.authored,
+        isFromMoonSaved: false,
+        hasConversation: true,
+      ),
+      isFalse,
+    );
+    expect(
+      ChestOrganizer.matchesCasaFilter(
+        filter: CasaChestFilter.moonSaved,
+        isFromMoonSaved: true,
+        hasConversation: true,
+      ),
+      isFalse,
+    );
+  });
+
   group('ChestOrganizer', () {
     test('ordina gli elementi normali per data DESC e id stabile', () {
       final now = DateTime(2024, 1, 1, 12);

--- a/test/pages/campanelli_page_layout_test.dart
+++ b/test/pages/campanelli_page_layout_test.dart
@@ -42,6 +42,12 @@ void main() {
     final CampanelloCard card = tester.widget(find.byType(CampanelloCard));
     expect(card.width, 390);
     expect(card.height, 844);
+    final DesktopCarouselArrows arrows = tester.widget(
+      find.byType(DesktopCarouselArrows),
+    );
+    expect(arrows.arrowSize, 24);
+    expect(arrows.arrowAlignment, Alignment.bottomCenter);
+    expect(arrows.verticalInset, greaterThan(0));
     expect(tester.takeException(), isNull);
   });
 
@@ -75,6 +81,11 @@ void main() {
     expect(card.width, closeTo(506.25, 0.01));
     expect(card.height, 900);
     expect(tester.getSize(find.byType(CampanelliFooter)).width, 506.25);
+    final DesktopCarouselArrows arrows = tester.widget(
+      find.byType(DesktopCarouselArrows),
+    );
+    expect(arrows.arrowSize, 28);
+    expect(arrows.arrowAlignment, Alignment.bottomCenter);
 
     await tester.drag(find.byType(CampanelloCard), const Offset(0, -900));
     await tester.pumpAndSettle();

--- a/test/pages/casa_chest_filter_page_test.dart
+++ b/test/pages/casa_chest_filter_page_test.dart
@@ -7,14 +7,14 @@ void main() {
   testWidgets('il menu dello scrigno di casa sceglie subito il filtro', (
     tester,
   ) async {
-    CasaShareMode? result;
+    CasaChestFilter? result;
 
     await tester.pumpWidget(
       MaterialApp(
         home: Builder(
           builder: (context) => TextButton(
             onPressed: () async {
-              result = await Navigator.of(context).push<CasaShareMode>(
+              result = await Navigator.of(context).push<CasaChestFilter>(
                 MaterialPageRoute(builder: (_) => const CasaChestFilterPage()),
               );
             },
@@ -35,6 +35,6 @@ void main() {
 
     await tester.tap(find.byKey(const ValueKey('house-chest-moon')));
     await tester.pumpAndSettle();
-    expect(result, CasaShareMode.moon);
+    expect(result, CasaChestFilter.moonSaved);
   });
 }

--- a/test/widgets/campanelli_renderers_test.dart
+++ b/test/widgets/campanelli_renderers_test.dart
@@ -82,6 +82,44 @@ void main() {
       (textPadding.padding as EdgeInsets).top,
       HinooTypography.editorTextTopPadding(320),
     );
+    expect(
+      tester.getSize(find.byKey(const ValueKey('campanello-text-canvas'))),
+      const Size(320, 500),
+    );
+  });
+
+  testWidgets('il testo mantiene il canvas 9:16 nel formato tutto schermo', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(390, 844);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    const campanello = CampanelloData(
+      id: 'campanello-1',
+      campanelloHinooId: null,
+      ownerId: 'owner-1',
+      backgroundImage: AssetImage('assets/campanello1.png'),
+      text: 'Un campanello',
+      linkedHouseId: 'casa-1',
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: CampanelloCard(
+            data: CampanelloPageData.campanello(campanello),
+            width: 390,
+            height: 844,
+          ),
+        ),
+      ),
+    );
+
+    expect(
+      tester.getSize(find.byKey(const ValueKey('campanello-text-canvas'))),
+      const Size(390, 693.3333333333334),
+    );
   });
 
   testWidgets('il campanello proprietario espone il comando modifica', (

--- a/test/widgets/chest_info_dialog_test.dart
+++ b/test/widgets/chest_info_dialog_test.dart
@@ -24,15 +24,33 @@ void main() {
     expect(find.byType(ChestInfoDialog), findsOneWidget);
     expect(find.byType(SingleChildScrollView), findsOneWidget);
     expect(find.textContaining('Questo è il tuo Scrigno'), findsOneWidget);
+    const chestInfoText = chestInfoTextBeforeIcons + chestInfoTextAfterIcons;
     expect(chestInfoText, isNot(contains('.')));
-    expect(chestInfoText, contains('Bianchi\n'));
-    expect(chestInfoText, contains('Rossi\n'));
+    expect(chestInfoText, isNot(contains('Blu\n')));
+    expect(chestInfoText, isNot(contains('Bianchi\n')));
+    expect(chestInfoText, isNot(contains('Rossi\n')));
     expect(chestInfoText, contains('Sopra\nla tua risposta'));
     expect(chestInfoText, contains('E, sopra ancora,'));
-    expect(chestInfoText, isNot(contains('Bianco\n')));
-    expect(chestInfoText, isNot(contains('Rosso\n')));
     expect(chestInfoText, isNot(contains('Sotto\n')));
     expect(chestInfoText, isNot(contains('sotto ancora')));
+    for (final asset in const [
+      'assets/icons/honoo_chest_blue.svg',
+      'assets/icons/honoo_chest_white.svg',
+      'assets/icons/honoo_chest_red.svg',
+    ]) {
+      expect(
+        find.byWidgetPredicate(
+          (widget) =>
+              widget is SvgPicture &&
+              widget.bytesLoader is SvgAssetLoader &&
+              (widget.bytesLoader as SvgAssetLoader).assetName == asset,
+        ),
+        findsOneWidget,
+      );
+    }
+    expect(find.bySemanticsLabel('Blu'), findsOneWidget);
+    expect(find.bySemanticsLabel('Bianchi'), findsOneWidget);
+    expect(find.bySemanticsLabel('Rossi'), findsOneWidget);
     expect(find.text(BuildMetadata.displayLabel), findsNothing);
     expect(find.byTooltip('Chiudi'), findsOneWidget);
     final closeIcon = tester.widget<SvgPicture>(

--- a/test/widgets/honoo_app_title_test.dart
+++ b/test/widgets/honoo_app_title_test.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:honoo/Pages/placeholder_page.dart';
+import 'package:honoo/Utility/honoo_colors.dart';
+import 'package:honoo/Widgets/honoo_app_title.dart';
+
+void main() {
+  testWidgets('il titolo honoo e rosso e apre la pagina principale', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(body: Center(child: HonooAppTitle())),
+      ),
+    );
+
+    final AnimatedDefaultTextStyle titleStyle = tester.widget(
+      find.descendant(
+        of: find.byType(HonooAppTitle),
+        matching: find.byType(AnimatedDefaultTextStyle),
+      ),
+    );
+    expect(titleStyle.style.color, HonooColor.secondary);
+
+    await tester.tap(find.byType(HonooAppTitle));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(PlaceholderPage), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- make the three house chest filters mutually exclusive: authored content, Moon-saved content, and conversations
- replace the Blu, Bianchi, and Rossi labels in the chest info dialog with responsive accessible SVG icons
- keep campanelli text aligned to the same 9:16 composition used during creation while preserving full-screen backgrounds
- reduce and reposition responsive carousel arrows away from the text and footer
- make every honoo header red and link it to PlaceholderPage
- add focused unit and widget coverage

## Verification
- house chest tests: 11 passed
- campanelli/header tests: 13 passed
- Flutter analyze on changed files: no issues
- git diff --check: clean