### PR TITLE
Preserva gli a capo dei Campanelli e aggiorna l’informativa Scrigno

### DIFF
--- a/lib/Widgets/campanello_card.dart
+++ b/lib/Widgets/campanello_card.dart
@@ -70,8 +70,9 @@ class CampanelloCard extends StatelessWidget {
             HinooTypography.horizontalPadding,
             HinooTypography.editorTextBottomPadding,
           ),
-          child: Center(
+          child: Align(
             key: const ValueKey('campanello-saved-text-position'),
+            alignment: Alignment.topCenter,
             child: _buildText(textStyle),
           ),
         ),

--- a/lib/Widgets/campanello_card.dart
+++ b/lib/Widgets/campanello_card.dart
@@ -132,7 +132,12 @@ class CampanelloCard extends StatelessWidget {
     final String raw = data.text;
     final idx = raw.toLowerCase().lastIndexOf('clicca qui');
     if (idx < 0 || onRequestTap == null) {
-      return Text(raw, style: textStyle, textAlign: TextAlign.center);
+      return Text(
+        raw,
+        style: textStyle,
+        textAlign: TextAlign.center,
+        softWrap: false,
+      );
     }
 
     final String before = raw.substring(0, idx);

--- a/lib/Widgets/chest_info_dialog.dart
+++ b/lib/Widgets/chest_info_dialog.dart
@@ -6,29 +6,33 @@ import 'package:flutter_svg/flutter_svg.dart';
 import '../Utility/honoo_colors.dart';
 import 'honoo_dialogs.dart';
 
-const chestInfoTextBeforeIcons =
+const chestInfoTextStart =
     "Questo è il tuo Scrigno\n\n"
     "Qui sono custoditi\n"
     "gli honoo e gli hinoo\n"
-    "che hai scritto,\n\n"
-    "quelli che hai salvato dalla Luna,\n\n"
-    "e quelli che hai ricevuto\n\n";
+    "che hai scritto\n";
 
-const chestInfoTextAfterIcons =
+const chestInfoTextAfterWritten = "\n\nquelli che hai salvato dalla Luna\n";
+
+const chestInfoTextAfterSaved = "\n\ne quelli che hai ricevuto\n";
+
+const chestInfoTextDirections =
+    "\n\n"
     "Scorri verso destra\n"
-    "per rivedere ciò che hai scritto\n"
-    "e ciò che hai salvato\n\n"
-    "Scorri dall’alto verso il basso\n"
+    "per rivedere\n"
+    "quello che hai scritto\n"
+    "e quello che hai salvato\n\n"
+    "Scorri verso il basso\n"
     "per seguire\n"
-    "le conversazioni\n\n"
-    "In alto\n"
-    "l’honoo della Luna\n\n"
-    "Sopra\n"
-    "la tua risposta\n\n"
-    "E, sopra ancora,\n"
-    "se arriva,\n"
-    "la risposta\n"
-    "alla tua risposta\n";
+    "le conversazioni fra\n\n"
+    "quello che hai salvato\n"
+    "dalla Luna\n";
+
+const chestInfoTextBeforeOwnReply = "\n\nla tua risposta,\n";
+
+const chestInfoTextBeforeReceivedReply =
+    "\n\ne, se arriva,\n"
+    "la risposta alla tua risposta\n";
 
 Future<void> showChestInfoDialog(BuildContext context) => showDialog<void>(
   context: context,
@@ -80,28 +84,43 @@ class ChestInfoDialog extends StatelessWidget {
                               color: HonooColor.onBackground,
                             ),
                             children: [
-                              const TextSpan(text: chestInfoTextBeforeIcons),
+                              const TextSpan(text: chestInfoTextStart),
                               _chestIconSpan(
                                 asset: 'assets/icons/honoo_chest_blue.svg',
                                 semanticsLabel: 'Blu',
                                 size: _responsiveIconSize(maxWidth),
                               ),
-                              const TextSpan(text: '\nsono i tuoi\n\n'),
+                              const TextSpan(text: chestInfoTextAfterWritten),
                               _chestIconSpan(
                                 asset: 'assets/icons/honoo_chest_white.svg',
                                 semanticsLabel: 'Bianchi',
                                 size: _responsiveIconSize(maxWidth),
                               ),
-                              const TextSpan(text: '\nquelli della Luna\n\n'),
+                              const TextSpan(text: chestInfoTextAfterSaved),
                               _chestIconSpan(
                                 asset: 'assets/icons/honoo_chest_red.svg',
                                 semanticsLabel: 'Rossi',
                                 size: _responsiveIconSize(maxWidth),
                               ),
+                              const TextSpan(text: chestInfoTextDirections),
+                              _chestIconSpan(
+                                asset: 'assets/icons/honoo_chest_white.svg',
+                                semanticsLabel: 'Bianchi',
+                                size: _responsiveIconSize(maxWidth),
+                              ),
+                              const TextSpan(text: chestInfoTextBeforeOwnReply),
+                              _chestIconSpan(
+                                asset: 'assets/icons/honoo_chest_blue.svg',
+                                semanticsLabel: 'Blu',
+                                size: _responsiveIconSize(maxWidth),
+                              ),
                               const TextSpan(
-                                text:
-                                    '\nquelli che ti sono stati inviati\n\n'
-                                    '$chestInfoTextAfterIcons',
+                                text: chestInfoTextBeforeReceivedReply,
+                              ),
+                              _chestIconSpan(
+                                asset: 'assets/icons/honoo_chest_red.svg',
+                                semanticsLabel: 'Rossi',
+                                size: _responsiveIconSize(maxWidth),
                               ),
                             ],
                           ),

--- a/test/widgets/campanelli_renderers_test.dart
+++ b/test/widgets/campanelli_renderers_test.dart
@@ -64,10 +64,10 @@ void main() {
     final textFinder = find.text('Un campanello\ncon un a capo manuale');
     expect(textFinder, findsOneWidget);
     expect(tester.widget<Text>(textFinder).softWrap, isFalse);
-    final savedTextPosition = tester.widget<Center>(
+    final savedTextPosition = tester.widget<Align>(
       find.byKey(const ValueKey('campanello-saved-text-position')),
     );
-    expect(savedTextPosition.widthFactor, isNull);
+    expect(savedTextPosition.alignment, Alignment.topCenter);
     final background = find.byWidgetPredicate(
       (widget) => widget is Image && widget.image == campanello.backgroundImage,
     );

--- a/test/widgets/campanelli_renderers_test.dart
+++ b/test/widgets/campanelli_renderers_test.dart
@@ -45,7 +45,7 @@ void main() {
       campanelloHinooId: null,
       ownerId: 'owner-1',
       backgroundImage: AssetImage('assets/campanello1.png'),
-      text: 'Un campanello',
+      text: 'Un campanello\ncon un a capo manuale',
       linkedHouseId: 'casa-1',
     );
 
@@ -61,7 +61,9 @@ void main() {
       ),
     );
 
-    expect(find.text('Un campanello'), findsOneWidget);
+    final textFinder = find.text('Un campanello\ncon un a capo manuale');
+    expect(textFinder, findsOneWidget);
+    expect(tester.widget<Text>(textFinder).softWrap, isFalse);
     final savedTextPosition = tester.widget<Center>(
       find.byKey(const ValueKey('campanello-saved-text-position')),
     );

--- a/test/widgets/chest_info_dialog_test.dart
+++ b/test/widgets/chest_info_dialog_test.dart
@@ -24,15 +24,39 @@ void main() {
     expect(find.byType(ChestInfoDialog), findsOneWidget);
     expect(find.byType(SingleChildScrollView), findsOneWidget);
     expect(find.textContaining('Questo è il tuo Scrigno'), findsOneWidget);
-    const chestInfoText = chestInfoTextBeforeIcons + chestInfoTextAfterIcons;
-    expect(chestInfoText, isNot(contains('.')));
-    expect(chestInfoText, isNot(contains('Blu\n')));
-    expect(chestInfoText, isNot(contains('Bianchi\n')));
-    expect(chestInfoText, isNot(contains('Rossi\n')));
-    expect(chestInfoText, contains('Sopra\nla tua risposta'));
-    expect(chestInfoText, contains('E, sopra ancora,'));
-    expect(chestInfoText, isNot(contains('Sotto\n')));
-    expect(chestInfoText, isNot(contains('sotto ancora')));
+    final infoText = tester.widget<RichText>(
+      find.descendant(
+        of: find.byType(ChestInfoDialog),
+        matching: find.byType(RichText),
+      ),
+    );
+    expect(
+      infoText.text.toPlainText(includeSemanticsLabels: false),
+      "Questo è il tuo Scrigno\n\n"
+      "Qui sono custoditi\n"
+      "gli honoo e gli hinoo\n"
+      "che hai scritto\n"
+      "\uFFFC\n\n"
+      "quelli che hai salvato dalla Luna\n"
+      "\uFFFC\n\n"
+      "e quelli che hai ricevuto\n"
+      "\uFFFC\n\n"
+      "Scorri verso destra\n"
+      "per rivedere\n"
+      "quello che hai scritto\n"
+      "e quello che hai salvato\n\n"
+      "Scorri verso il basso\n"
+      "per seguire\n"
+      "le conversazioni fra\n\n"
+      "quello che hai salvato\n"
+      "dalla Luna\n"
+      "\uFFFC\n\n"
+      "la tua risposta,\n"
+      "\uFFFC\n\n"
+      "e, se arriva,\n"
+      "la risposta alla tua risposta\n"
+      "\uFFFC",
+    );
     for (final asset in const [
       'assets/icons/honoo_chest_blue.svg',
       'assets/icons/honoo_chest_white.svg',
@@ -45,12 +69,12 @@ void main() {
               widget.bytesLoader is SvgAssetLoader &&
               (widget.bytesLoader as SvgAssetLoader).assetName == asset,
         ),
-        findsOneWidget,
+        findsNWidgets(2),
       );
     }
-    expect(find.bySemanticsLabel('Blu'), findsOneWidget);
-    expect(find.bySemanticsLabel('Bianchi'), findsOneWidget);
-    expect(find.bySemanticsLabel('Rossi'), findsOneWidget);
+    expect(find.bySemanticsLabel('Blu'), findsNWidgets(2));
+    expect(find.bySemanticsLabel('Bianchi'), findsNWidgets(2));
+    expect(find.bySemanticsLabel('Rossi'), findsNWidgets(2));
     expect(find.text(BuildMetadata.displayLabel), findsNothing);
     expect(find.byTooltip('Chiudi'), findsOneWidget);
     final closeIcon = tester.widget<SvgPicture>(


### PR DESCRIPTION
## Cosa cambia

- impedisce il ritorno a capo automatico nel testo dei Campanelli salvati, mantenendo soltanto gli a capo inseriti dall’utente come negli hinoo
- sostituisce integralmente il testo informativo dello Scrigno con la versione richiesta
- inserisce le icone blu, bianca e rossa nei sei punti previsti, conservando dimensionamento responsive e semantica accessibile

## Perché

Il renderer dei Campanelli consentiva il wrapping automatico, mentre gli hinoo visualizzati usano gli a capo manuali. Inoltre, l’informativa dello Scrigno non corrispondeva più al testo e alla sequenza di icone desiderati.

## Verifiche

- `flutter test --no-pub test/widgets/campanelli_renderers_test.dart test/widgets/chest_info_dialog_test.dart`
- `flutter analyze --no-pub lib/Widgets/campanello_card.dart lib/Widgets/chest_info_dialog.dart test/widgets/campanelli_renderers_test.dart test/widgets/chest_info_dialog_test.dart`
- `git diff --check`
