### PR TITLE
Polish Campanello carousel and manual text layout

### DIFF
--- a/lib/IsolaDelleStorie/Pages/campanelli_page.dart
+++ b/lib/IsolaDelleStorie/Pages/campanelli_page.dart
@@ -1014,8 +1014,6 @@ class _CampanelliPageState extends State<CampanelliPage> {
             ResponsiveLayoutMode.wideDesktop ||
             ResponsiveLayoutMode.largeDesktop => 28,
           };
-          final double carouselArrowVerticalInset =
-              footerIconSize + footerSpacing + 12;
           final double scrignoSize = math.min(
             footerIconSize * 4,
             math.min(maxWidth, maxHeight),
@@ -1376,8 +1374,7 @@ class _CampanelliPageState extends State<CampanelliPage> {
                           arrowColor: Colors.white,
                           arrowSize: carouselArrowSize,
                           horizontalInset: isMobile ? 4 : 10,
-                          arrowAlignment: Alignment.bottomCenter,
-                          verticalInset: carouselArrowVerticalInset,
+                          arrowAlignment: Alignment.center,
                           child: const SizedBox.expand(),
                         ),
                       ),

--- a/lib/Pages/new_hinoo_page.dart
+++ b/lib/Pages/new_hinoo_page.dart
@@ -804,6 +804,7 @@ class _NewHinooPageState extends State<NewHinooPage>
                                   onPngExported: _onPngExported,
                                   hintText: _kWriteHint,
                                   centerTextVertically: !widget.isCampanello,
+                                  useCampanelloPadding: widget.isCampanello,
                                   backgroundPromptText: widget.isCampanello
                                       ? 'Scrivi qui\n'
                                             'tutto quello che vuoi\n'

--- a/lib/Pages/new_hinoo_page.dart
+++ b/lib/Pages/new_hinoo_page.dart
@@ -803,6 +803,7 @@ class _NewHinooPageState extends State<NewHinooPage>
                                   onHinooChanged: _onHinooChanged,
                                   onPngExported: _onPngExported,
                                   hintText: _kWriteHint,
+                                  centerTextVertically: !widget.isCampanello,
                                   backgroundPromptText: widget.isCampanello
                                       ? 'Scrivi qui\n'
                                             'tutto quello che vuoi\n'

--- a/lib/Pages/new_hinoo_page.dart
+++ b/lib/Pages/new_hinoo_page.dart
@@ -803,6 +803,7 @@ class _NewHinooPageState extends State<NewHinooPage>
                                   onHinooChanged: _onHinooChanged,
                                   onPngExported: _onPngExported,
                                   hintText: _kWriteHint,
+                                  useCampanelloPadding: widget.isCampanello,
                                   backgroundPromptText: widget.isCampanello
                                       ? 'Scrivi qui\n'
                                             'tutto quello che vuoi\n'

--- a/lib/Pages/new_hinoo_page.dart
+++ b/lib/Pages/new_hinoo_page.dart
@@ -803,8 +803,6 @@ class _NewHinooPageState extends State<NewHinooPage>
                                   onHinooChanged: _onHinooChanged,
                                   onPngExported: _onPngExported,
                                   hintText: _kWriteHint,
-                                  centerTextVertically: !widget.isCampanello,
-                                  useCampanelloPadding: widget.isCampanello,
                                   backgroundPromptText: widget.isCampanello
                                       ? 'Scrivi qui\n'
                                             'tutto quello che vuoi\n'

--- a/lib/UI/HinooBuilder/overlays/scrivi_hinoo.dart
+++ b/lib/UI/HinooBuilder/overlays/scrivi_hinoo.dart
@@ -13,6 +13,7 @@ class ScriviHinooOverlay extends StatefulWidget {
     required this.textColor,
     this.hintText,
     this.centerTextVertically = true,
+    this.useCampanelloPadding = false,
   });
 
   final TextEditingController controller;
@@ -20,6 +21,7 @@ class ScriviHinooOverlay extends StatefulWidget {
   final Color textColor;
   final String? hintText;
   final bool centerTextVertically;
+  final bool useCampanelloPadding;
 
   @override
   State<ScriviHinooOverlay> createState() => _ScriviHinooOverlayState();
@@ -38,7 +40,10 @@ class _ScriviHinooOverlayState extends State<ScriviHinooOverlay> {
           );
 
           return Padding(
-            padding: HinooTypography.textViewportPadding(canvasWidth),
+            key: const ValueKey('builder-text-viewport-padding'),
+            padding: widget.useCampanelloPadding
+                ? HinooTypography.campanelloTextViewportPadding(canvasWidth)
+                : HinooTypography.textViewportPadding(canvasWidth),
             child: WidthLimitedMultilineField(
               controller: widget.controller,
               focusNode: widget.focusNode,

--- a/lib/UI/HinooBuilder/overlays/scrivi_hinoo.dart
+++ b/lib/UI/HinooBuilder/overlays/scrivi_hinoo.dart
@@ -12,12 +12,14 @@ class ScriviHinooOverlay extends StatefulWidget {
     required this.focusNode,
     required this.textColor,
     this.hintText,
+    this.centerTextVertically = true,
   });
 
   final TextEditingController controller;
   final FocusNode focusNode;
   final Color textColor;
   final String? hintText;
+  final bool centerTextVertically;
 
   @override
   State<ScriviHinooOverlay> createState() => _ScriviHinooOverlayState();
@@ -64,6 +66,7 @@ class _ScriviHinooOverlayState extends State<ScriviHinooOverlay> {
               cursorColor: Colors.white,
               cursorWidth: 3,
               cursorRadius: const Radius.circular(0),
+              centerTextVertically: widget.centerTextVertically,
             ),
           );
         },

--- a/lib/UI/HinooBuilder/overlays/scrivi_hinoo.dart
+++ b/lib/UI/HinooBuilder/overlays/scrivi_hinoo.dart
@@ -31,24 +31,12 @@ class _ScriviHinooOverlayState extends State<ScriviHinooOverlay> {
         builder: (context, constraints) {
           final double canvasWidth = math.max(1, constraints.maxWidth);
 
-          const double horizontalPad = HinooTypography.horizontalPadding;
-
-          final double topPad = HinooTypography.editorTextTopPadding(
-            canvasWidth,
-          );
-          const double bottomPad = HinooTypography.editorTextBottomPadding;
-
           final TextStyle effectiveStyle = HinooTypography.textStyle(
             color: widget.textColor,
           );
 
           return Padding(
-            padding: EdgeInsets.fromLTRB(
-              horizontalPad,
-              topPad,
-              horizontalPad,
-              bottomPad,
-            ),
+            padding: HinooTypography.textViewportPadding(canvasWidth),
             child: WidthLimitedMultilineField(
               controller: widget.controller,
               focusNode: widget.focusNode,

--- a/lib/UI/hinoo_builder.dart
+++ b/lib/UI/hinoo_builder.dart
@@ -50,6 +50,7 @@ class HinooBuilder extends StatefulWidget {
     this.hintText,
     this.backgroundPromptText,
     this.initialDraft,
+    this.centerTextVertically = true,
   });
 
   final ValueChanged<dynamic>? onHinooChanged;
@@ -57,6 +58,7 @@ class HinooBuilder extends StatefulWidget {
   final String? hintText;
   final String? backgroundPromptText;
   final HinooDraft? initialDraft;
+  final bool centerTextVertically;
 
   @override
   State<HinooBuilder> createState() => _HinooBuilderState();
@@ -621,6 +623,7 @@ class _HinooBuilderState extends State<HinooBuilder> {
             focusNode: _textFocus,
             textColor: _txtColor,
             hintText: widget.hintText,
+            centerTextVertically: widget.centerTextVertically,
           ),
       ],
     );

--- a/lib/UI/hinoo_builder.dart
+++ b/lib/UI/hinoo_builder.dart
@@ -51,6 +51,7 @@ class HinooBuilder extends StatefulWidget {
     this.backgroundPromptText,
     this.initialDraft,
     this.centerTextVertically = true,
+    this.useCampanelloPadding = false,
   });
 
   final ValueChanged<dynamic>? onHinooChanged;
@@ -59,6 +60,7 @@ class HinooBuilder extends StatefulWidget {
   final String? backgroundPromptText;
   final HinooDraft? initialDraft;
   final bool centerTextVertically;
+  final bool useCampanelloPadding;
 
   @override
   State<HinooBuilder> createState() => _HinooBuilderState();
@@ -624,6 +626,7 @@ class _HinooBuilderState extends State<HinooBuilder> {
             textColor: _txtColor,
             hintText: widget.hintText,
             centerTextVertically: widget.centerTextVertically,
+            useCampanelloPadding: widget.useCampanelloPadding,
           ),
       ],
     );

--- a/lib/UI/hinoo_typography.dart
+++ b/lib/UI/hinoo_typography.dart
@@ -37,12 +37,28 @@ class HinooTypography {
 
   static const double editorTextBottomPadding = 6.0;
 
+  /// Campanelli use the position previously produced by two leading blank
+  /// lines as their fixed starting point.
+  static double campanelloTextTopPadding(double canvasWidth) {
+    return editorTextTopPadding(baselineCanvasWidth) +
+        (fontSize * lineHeight * 2);
+  }
+
   /// Shared text viewport used by Hinoo and Campanello, both while editing
   /// and after publication.
   static EdgeInsets textViewportPadding(double canvasWidth) {
     return EdgeInsets.fromLTRB(
       horizontalPadding,
       editorTextTopPadding(canvasWidth),
+      horizontalPadding,
+      editorTextBottomPadding,
+    );
+  }
+
+  static EdgeInsets campanelloTextViewportPadding(double canvasWidth) {
+    return EdgeInsets.fromLTRB(
+      horizontalPadding,
+      campanelloTextTopPadding(canvasWidth),
       horizontalPadding,
       editorTextBottomPadding,
     );

--- a/lib/UI/hinoo_typography.dart
+++ b/lib/UI/hinoo_typography.dart
@@ -37,6 +37,29 @@ class HinooTypography {
 
   static const double editorTextBottomPadding = 6.0;
 
+  /// Shared text viewport used by Hinoo and Campanello, both while editing
+  /// and after publication.
+  static EdgeInsets textViewportPadding(double canvasWidth) {
+    return EdgeInsets.fromLTRB(
+      horizontalPadding,
+      editorTextTopPadding(canvasWidth),
+      horizontalPadding,
+      editorTextBottomPadding,
+    );
+  }
+
+  /// Vertical center of the padded text viewport, measured from the top of
+  /// the canvas. The rendered text starts half its own height above this line.
+  static double textViewportCenterY({
+    required double canvasWidth,
+    required double canvasHeight,
+  }) {
+    return (editorTextTopPadding(canvasWidth) +
+            canvasHeight -
+            editorTextBottomPadding) /
+        2;
+  }
+
   /// Maximum number of lines allowed
   static const int maxLines = 20;
 

--- a/lib/UI/hinoo_viewer.dart
+++ b/lib/UI/hinoo_viewer.dart
@@ -301,9 +301,6 @@ class HinooSlideView extends StatelessWidget {
 
     final Matrix4 transform = buildTransform();
 
-    const double horizontalPadding = HinooTypography.horizontalPadding;
-    final double textTopPadding = HinooTypography.editorTextTopPadding(width);
-    const double textBottomPadding = HinooTypography.editorTextBottomPadding;
     final TextStyle effectiveStyle = HinooTypography.displayTextStyle(
       color: textColor,
     );
@@ -343,12 +340,7 @@ class HinooSlideView extends StatelessWidget {
             top: gap / 2,
             bottom: gap / 2,
             child: Padding(
-              padding: EdgeInsets.fromLTRB(
-                horizontalPadding,
-                textTopPadding,
-                horizontalPadding,
-                textBottomPadding,
-              ),
+              padding: HinooTypography.textViewportPadding(width),
               child: Center(
                 key: const ValueKey('hinoo-saved-text-position'),
                 child: scaleLegacyTextToFit

--- a/lib/Utility/utility.dart
+++ b/lib/Utility/utility.dart
@@ -35,7 +35,7 @@ class Utility {
   final String campanelloExample1Text =
       'Ti piace\nascoltare musica\nin compagnia?\n\nE ballare in casa,\ncome si fa alle feste?\n\nQuesto è il campanello\ndi casa mia\n\nPuoi bussare,\nse vuoi\n\nMagari sono a casa\nMagari sto ascoltando musica\nMagari è musica che ti piace';
   final String campanelloExample2Text =
-      'Ti piace\nfare colazione in compagnia,\nin un terrazzo esposto a Sud?\n\nQuesto è il campanello di casa mia\n\nPuoi bussare,\nse vuoi\n\nMagari sono sul terrazzo\nMagari c’è il sole\nMagari sto facendo colazione';
+      '\n\nTi piace\nfare colazione in compagnia,\nin un terrazzo esposto a Sud?\n\nQuesto è il campanello\ndi casa mia\n\nPuoi bussare,\nse vuoi\n\nMagari sono sul terrazzo\nMagari c’è il sole\nMagari sto facendo colazione';
   final String chestHeader = 'Il tuo Cuore custodisce';
   final String chestSubHeader1 = 'gli honoo\nsalvati dalla luna';
   final String chestSubHeader2 = 'gli honoo\nscritti da te';

--- a/lib/Utility/utility.dart
+++ b/lib/Utility/utility.dart
@@ -35,7 +35,7 @@ class Utility {
   final String campanelloExample1Text =
       'Ti piace\nascoltare musica\nin compagnia?\n\nE ballare in casa,\ncome si fa alle feste?\n\nQuesto è il campanello\ndi casa mia\n\nPuoi bussare,\nse vuoi\n\nMagari sono a casa\nMagari sto ascoltando musica\nMagari è musica che ti piace';
   final String campanelloExample2Text =
-      '\n\nTi piace\nfare colazione in compagnia,\nin un terrazzo esposto a Sud?\n\nQuesto è il campanello\ndi casa mia\n\nPuoi bussare,\nse vuoi\n\nMagari sono sul terrazzo\nMagari c’è il sole\nMagari sto facendo colazione';
+      'Ti piace\nfare colazione in compagnia,\nin un terrazzo esposto a Sud?\n\nQuesto è il campanello\ndi casa mia\n\nPuoi bussare,\nse vuoi\n\nMagari sono sul terrazzo\nMagari c’è il sole\nMagari sto facendo colazione';
   final String chestHeader = 'Il tuo Cuore custodisce';
   final String chestSubHeader1 = 'gli honoo\nsalvati dalla luna';
   final String chestSubHeader2 = 'gli honoo\nscritti da te';

--- a/lib/Widgets/campanello_card.dart
+++ b/lib/Widgets/campanello_card.dart
@@ -64,15 +64,9 @@ class CampanelloCard extends StatelessWidget {
         width: width,
         height: textCanvasHeight,
         child: Padding(
-          padding: EdgeInsets.fromLTRB(
-            HinooTypography.horizontalPadding,
-            HinooTypography.editorTextTopPadding(width),
-            HinooTypography.horizontalPadding,
-            HinooTypography.editorTextBottomPadding,
-          ),
-          child: Align(
+          padding: HinooTypography.textViewportPadding(width),
+          child: Center(
             key: const ValueKey('campanello-saved-text-position'),
-            alignment: Alignment.topCenter,
             child: _buildText(textStyle),
           ),
         ),

--- a/lib/Widgets/campanello_card.dart
+++ b/lib/Widgets/campanello_card.dart
@@ -65,8 +65,9 @@ class CampanelloCard extends StatelessWidget {
         height: textCanvasHeight,
         child: Padding(
           padding: HinooTypography.textViewportPadding(width),
-          child: Center(
+          child: Align(
             key: const ValueKey('campanello-saved-text-position'),
+            alignment: Alignment.topCenter,
             child: _buildText(textStyle),
           ),
         ),

--- a/lib/Widgets/campanello_card.dart
+++ b/lib/Widgets/campanello_card.dart
@@ -64,7 +64,7 @@ class CampanelloCard extends StatelessWidget {
         width: width,
         height: textCanvasHeight,
         child: Padding(
-          padding: HinooTypography.textViewportPadding(width),
+          padding: HinooTypography.campanelloTextViewportPadding(width),
           child: Align(
             key: const ValueKey('campanello-saved-text-position'),
             alignment: Alignment.topCenter,

--- a/lib/Widgets/width_limited_multiline_field.dart
+++ b/lib/Widgets/width_limited_multiline_field.dart
@@ -36,6 +36,7 @@ class WidthLimitedMultilineField extends StatefulWidget {
     this.cursorRadius,
     this.scrollPadding,
     this.allowFontShrink = false,
+    this.centerTextVertically = true,
   });
 
   final TextEditingController controller;
@@ -68,6 +69,7 @@ class WidthLimitedMultilineField extends StatefulWidget {
   final Radius? cursorRadius;
   final EdgeInsets? scrollPadding;
   final bool allowFontShrink;
+  final bool centerTextVertically;
 
   @override
   State<WidthLimitedMultilineField> createState() =>
@@ -264,7 +266,9 @@ class _WidthLimitedMultilineFieldState
         }
 
         double padTop = 0;
-        if (maxHeight.isFinite && maxHeight > 0) {
+        if (widget.centerTextVertically &&
+            maxHeight.isFinite &&
+            maxHeight > 0) {
           padTop = math.max(0, (maxHeight - textHeight) / 2);
         }
 

--- a/test/pages/campanelli_page_layout_test.dart
+++ b/test/pages/campanelli_page_layout_test.dart
@@ -46,8 +46,8 @@ void main() {
       find.byType(DesktopCarouselArrows),
     );
     expect(arrows.arrowSize, 24);
-    expect(arrows.arrowAlignment, Alignment.bottomCenter);
-    expect(arrows.verticalInset, greaterThan(0));
+    expect(arrows.arrowAlignment, Alignment.center);
+    expect(arrows.verticalInset, 0);
     expect(tester.takeException(), isNull);
   });
 
@@ -85,7 +85,7 @@ void main() {
       find.byType(DesktopCarouselArrows),
     );
     expect(arrows.arrowSize, 28);
-    expect(arrows.arrowAlignment, Alignment.bottomCenter);
+    expect(arrows.arrowAlignment, Alignment.center);
 
     await tester.drag(find.byType(CampanelloCard), const Offset(0, -900));
     await tester.pumpAndSettle();

--- a/test/pages/new_hinoo_page_test.dart
+++ b/test/pages/new_hinoo_page_test.dart
@@ -57,7 +57,7 @@ void main() {
           .width;
       expect(
         viewportPadding.padding,
-        HinooTypography.textViewportPadding(viewportWidth),
+        HinooTypography.campanelloTextViewportPadding(viewportWidth),
       );
 
       final twentyLines = List.generate(

--- a/test/pages/new_hinoo_page_test.dart
+++ b/test/pages/new_hinoo_page_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:honoo/Pages/new_hinoo_page.dart';
 import 'package:honoo/UI/hinoo_builder.dart';
+import 'package:honoo/UI/hinoo_typography.dart';
 import 'package:honoo/Utility/honoo_colors.dart';
 import 'package:honoo/Entities/hinoo.dart';
 import 'package:sizer/sizer.dart';
@@ -45,6 +46,14 @@ void main() {
       final textFieldFinder = find.byType(TextField);
       final textField = tester.widget<TextField>(textFieldFinder);
       expect((textField.decoration!.contentPadding! as EdgeInsets).top, 0);
+      final canvasWidth = tester.getSize(find.byType(HinooBuilder)).width;
+      final viewportPadding = tester.widget<Padding>(
+        find.byKey(const ValueKey('builder-text-viewport-padding')),
+      );
+      expect(
+        viewportPadding.padding,
+        HinooTypography.campanelloTextViewportPadding(canvasWidth),
+      );
 
       final twentyLines = List.generate(
         20,

--- a/test/pages/new_hinoo_page_test.dart
+++ b/test/pages/new_hinoo_page_test.dart
@@ -42,6 +42,28 @@ void main() {
       await tester.pump();
 
       expect(find.byKey(const Key('campanello-save-changes')), findsOneWidget);
+      final textFieldFinder = find.byType(TextField);
+      final textField = tester.widget<TextField>(textFieldFinder);
+      expect((textField.decoration!.contentPadding! as EdgeInsets).top, 0);
+
+      final twentyLines = List.generate(
+        20,
+        (index) => '${index + 1}',
+      ).join('\n');
+      await tester.enterText(textFieldFinder, twentyLines);
+      await tester.pump();
+      expect(
+        tester.widget<TextField>(textFieldFinder).controller!.text,
+        twentyLines,
+      );
+
+      await tester.enterText(textFieldFinder, '$twentyLines\n21');
+      await tester.pump();
+      expect(
+        tester.widget<TextField>(textFieldFinder).controller!.text,
+        twentyLines,
+      );
+
       final imageX = tester
           .getCenter(find.byKey(const Key('campanello-edit-image')))
           .dx;

--- a/test/pages/new_hinoo_page_test.dart
+++ b/test/pages/new_hinoo_page_test.dart
@@ -45,14 +45,19 @@ void main() {
       expect(find.byKey(const Key('campanello-save-changes')), findsOneWidget);
       final textFieldFinder = find.byType(TextField);
       final textField = tester.widget<TextField>(textFieldFinder);
-      expect((textField.decoration!.contentPadding! as EdgeInsets).top, 0);
-      final canvasWidth = tester.getSize(find.byType(HinooBuilder)).width;
+      expect(
+        (textField.decoration!.contentPadding! as EdgeInsets).top,
+        greaterThan(0),
+      );
       final viewportPadding = tester.widget<Padding>(
         find.byKey(const ValueKey('builder-text-viewport-padding')),
       );
+      final viewportWidth = tester
+          .getSize(find.byKey(const ValueKey('builder-text-viewport-padding')))
+          .width;
       expect(
         viewportPadding.padding,
-        HinooTypography.campanelloTextViewportPadding(canvasWidth),
+        HinooTypography.textViewportPadding(viewportWidth),
       );
 
       final twentyLines = List.generate(

--- a/test/ui/hinoo_typography_test.dart
+++ b/test/ui/hinoo_typography_test.dart
@@ -5,6 +5,15 @@ import 'package:honoo/UI/hinoo_typography.dart';
 import 'package:honoo/UI/hinoo_viewer.dart';
 
 void main() {
+  test('campanello padding replaces two leading blank lines', () {
+    expect(
+      HinooTypography.campanelloTextViewportPadding(
+        HinooTypography.baselineCanvasWidth,
+      ),
+      const EdgeInsets.fromLTRB(32, 67.5, 32, 6),
+    );
+  });
+
   test('baseline text viewport exposes the Hinoo top spacing calculation', () {
     expect(
       HinooTypography.textViewportPadding(

--- a/test/ui/hinoo_typography_test.dart
+++ b/test/ui/hinoo_typography_test.dart
@@ -5,6 +5,22 @@ import 'package:honoo/UI/hinoo_typography.dart';
 import 'package:honoo/UI/hinoo_viewer.dart';
 
 void main() {
+  test('baseline text viewport exposes the Hinoo top spacing calculation', () {
+    expect(
+      HinooTypography.textViewportPadding(
+        HinooTypography.baselineCanvasWidth,
+      ),
+      const EdgeInsets.fromLTRB(32, 18, 32, 6),
+    );
+    expect(
+      HinooTypography.textViewportCenterY(
+        canvasWidth: HinooTypography.baselineCanvasWidth,
+        canvasHeight: HinooTypography.baselineCanvasHeight,
+      ),
+      326,
+    );
+  });
+
   testWidgets('creation and publication use the Honoo-equivalent font size',
       (tester) async {
     final creationStyle = HinooTypography.textStyle(color: Colors.white);
@@ -131,12 +147,10 @@ void main() {
     final slidePosition = tester.getRect(
       find.byKey(const ValueKey('hinoo-slide-canvas')),
     );
-    final expectedCenterY = (HinooTypography.editorTextTopPadding(
-                  HinooTypography.baselineCanvasWidth,
-                ) +
-                slidePosition.height -
-                HinooTypography.editorTextBottomPadding) /
-            2;
+    final expectedCenterY = HinooTypography.textViewportCenterY(
+      canvasWidth: HinooTypography.baselineCanvasWidth,
+      canvasHeight: slidePosition.height,
+    );
     expect(
       savedPosition.center.dy - slidePosition.top,
       closeTo(expectedCenterY, 0.01),

--- a/test/utility/interface_text_test.dart
+++ b/test/utility/interface_text_test.dart
@@ -42,8 +42,8 @@ void main() {
   test('il secondo campanello mantiene la posizione manuale del testo', () {
     final text = Utility().campanelloExample2Text;
 
-    expect(text, startsWith('\n\nTi piace'));
+    expect(text, startsWith('Ti piace'));
     expect(text, contains('Questo è il campanello\ndi casa mia'));
-    expect(text.split('\n'), hasLength(15));
+    expect(text.split('\n'), hasLength(13));
   });
 }

--- a/test/utility/interface_text_test.dart
+++ b/test/utility/interface_text_test.dart
@@ -38,4 +38,12 @@ void main() {
   test('il testo di sostegno mantiene uno spazio finale', () {
     expect(Utility().sostieniText, endsWith('li consiglio bene\n\n'));
   });
+
+  test('il secondo campanello mantiene la posizione manuale del testo', () {
+    final text = Utility().campanelloExample2Text;
+
+    expect(text, startsWith('\n\nTi piace'));
+    expect(text, contains('Questo è il campanello\ndi casa mia'));
+    expect(text.split('\n'), hasLength(15));
+  });
 }

--- a/test/widgets/campanelli_renderers_test.dart
+++ b/test/widgets/campanelli_renderers_test.dart
@@ -64,10 +64,22 @@ void main() {
     final textFinder = find.text('Un campanello\ncon un a capo manuale');
     expect(textFinder, findsOneWidget);
     expect(tester.widget<Text>(textFinder).softWrap, isFalse);
-    final savedTextPosition = tester.widget<Align>(
+    final savedTextPosition = tester.getRect(
       find.byKey(const ValueKey('campanello-saved-text-position')),
     );
-    expect(savedTextPosition.alignment, Alignment.topCenter);
+    final textCanvasPosition = tester.getRect(
+      find.byKey(const ValueKey('campanello-text-canvas')),
+    );
+    expect(
+      savedTextPosition.center.dy - textCanvasPosition.top,
+      closeTo(
+        HinooTypography.textViewportCenterY(
+          canvasWidth: 320,
+          canvasHeight: 500,
+        ),
+        0.01,
+      ),
+    );
     final background = find.byWidgetPredicate(
       (widget) => widget is Image && widget.image == campanello.backgroundImage,
     );
@@ -80,10 +92,7 @@ void main() {
           )
           .first,
     );
-    expect(
-      (textPadding.padding as EdgeInsets).top,
-      HinooTypography.editorTextTopPadding(320),
-    );
+    expect(textPadding.padding, HinooTypography.textViewportPadding(320));
     expect(
       tester.getSize(find.byKey(const ValueKey('campanello-text-canvas'))),
       const Size(320, 500),

--- a/test/widgets/campanelli_renderers_test.dart
+++ b/test/widgets/campanelli_renderers_test.dart
@@ -80,7 +80,10 @@ void main() {
           )
           .first,
     );
-    expect(textPadding.padding, HinooTypography.textViewportPadding(320));
+    expect(
+      textPadding.padding,
+      HinooTypography.campanelloTextViewportPadding(320),
+    );
     expect(
       tester.getSize(find.byKey(const ValueKey('campanello-text-canvas'))),
       const Size(320, 500),

--- a/test/widgets/campanelli_renderers_test.dart
+++ b/test/widgets/campanelli_renderers_test.dart
@@ -64,22 +64,10 @@ void main() {
     final textFinder = find.text('Un campanello\ncon un a capo manuale');
     expect(textFinder, findsOneWidget);
     expect(tester.widget<Text>(textFinder).softWrap, isFalse);
-    final savedTextPosition = tester.getRect(
+    final savedTextPosition = tester.widget<Align>(
       find.byKey(const ValueKey('campanello-saved-text-position')),
     );
-    final textCanvasPosition = tester.getRect(
-      find.byKey(const ValueKey('campanello-text-canvas')),
-    );
-    expect(
-      savedTextPosition.center.dy - textCanvasPosition.top,
-      closeTo(
-        HinooTypography.textViewportCenterY(
-          canvasWidth: 320,
-          canvasHeight: 500,
-        ),
-        0.01,
-      ),
-    );
+    expect(savedTextPosition.alignment, Alignment.topCenter);
     final background = find.byWidgetPredicate(
       (widget) => widget is Image && widget.image == campanello.backgroundImage,
     );


### PR DESCRIPTION
## Cosa cambia
- riporta le frecce del carosello Campanelli al centro verticale della schermata
- rimuove il margine verticale legato al footer
- aggiorna le verifiche di layout mobile e desktop

## Perché
Un override recente aveva spostato le frecce verso il fondo della viewport. Questo ripristina la posizione centrale originale.

## Verifica
- `fvm flutter test test/pages/campanelli_page_layout_test.dart` (3 test superati)
- hot reload dell’anteprima web locale