### PR TITLE
Fix Campanello flows and Hinoo canvas downloads

### DIFF
--- a/lib/IsolaDelleStorie/Pages/campanelli_page.dart
+++ b/lib/IsolaDelleStorie/Pages/campanelli_page.dart
@@ -407,7 +407,28 @@ class _CampanelliPageState extends State<CampanelliPage> {
         ),
       ),
     );
-    if (updated == true && mounted) await _loadUserEntries();
+    if (updated == true && mounted) {
+      await _loadUserEntries();
+      if (mounted) await _showOwnCampanello();
+    }
+  }
+
+  Future<void> _showOwnCampanello() async {
+    final String? userId = SupabaseProvider.client.auth.currentUser?.id;
+    if (userId == null) return;
+    final int ownIndex = _buildCampanelli().indexWhere(
+      (entry) => entry.campanello.ownerId == userId,
+    );
+    if (ownIndex < 0) return;
+    final int pageIndex = ownIndex + 1;
+    setState(() {
+      _campanelloIndex = pageIndex;
+      _lastHouseCampanelloIndex = pageIndex;
+    });
+    await WidgetsBinding.instance.endOfFrame;
+    if (_campanelloPageController.hasClients) {
+      _campanelloPageController.jumpToPage(pageIndex);
+    }
   }
 
   Future<void> _editCasa(_CampanelloEntry entry) async {

--- a/lib/Pages/chest_page.dart
+++ b/lib/Pages/chest_page.dart
@@ -1073,7 +1073,7 @@ class _ChestPageState extends State<ChestPage> with WidgetsBindingObserver {
       revealEntryId: _pendingRevealEntryId,
       onSelectConversationEntry: (entry) =>
           _selectConversationEntry(_convIdOfItem(item), entry),
-      onDownload: () => _handleDownloadForItem(item, repaintKey),
+      onDownload: (captureKey) => _handleDownloadForItem(item, captureKey),
       conversationRefreshToken: _conversationRefreshToken,
     );
   }

--- a/lib/Pages/chest_page.dart
+++ b/lib/Pages/chest_page.dart
@@ -1019,7 +1019,6 @@ class _ChestPageState extends State<ChestPage> with WidgetsBindingObserver {
         await showDownloadSaveResult(
           context: context,
           contentName: contentName,
-          openSavedImage: _downloadCaptureService.openSavedImage,
           result: result,
         );
       } else {

--- a/lib/Pages/new_hinoo_page.dart
+++ b/lib/Pages/new_hinoo_page.dart
@@ -24,6 +24,7 @@ import 'placeholder_page.dart';
 import '../Entities/hinoo.dart';
 import '../Entities/reply_navigation_result.dart';
 import 'casa_builder_page.dart';
+import '../IsolaDelleStorie/Pages/campanelli_page.dart';
 import '../Widgets/conversation_notification_prompt.dart';
 import '../Widgets/repeated_reply_prompt.dart';
 import '../Widgets/text_box_download_button.dart';
@@ -79,6 +80,7 @@ class _NewHinooPageState extends State<NewHinooPage>
   bool _bgUploadInProgress = false;
   bool _hasBackground = false;
   bool _campanelloEditStarted = false;
+  Size? _unobstructedCanvasSize;
 
   bool get _isWriteStep => _builderStep == 'writeText';
   bool get _hasMinTextForDownload => _currentTextLength >= 1;
@@ -320,7 +322,16 @@ class _NewHinooPageState extends State<NewHinooPage>
             campanello: hinooDraft,
           );
           if (!mounted) return;
-          showHonooToast(context, message: 'Campanello aggiornato.');
+          await showDialog<void>(
+            context: context,
+            barrierDismissible: false,
+            builder: (_) => const HonooConfirmDialog(
+              title: 'la modifica è stata effettuata',
+              confirmLabel: 'OK',
+              showCancel: false,
+            ),
+          );
+          if (!mounted) return;
           Navigator.of(context).pop(true);
           return;
         }
@@ -485,12 +496,14 @@ class _NewHinooPageState extends State<NewHinooPage>
     return w;
   }
 
-  void _triggerDownloadFromBuilder() {
+  Future<bool> _triggerDownloadFromBuilder() async {
     final dyn = _builderKey.currentState as dynamic;
     if (dyn?.openDownloadDialogPublic != null) {
-      dyn.openDownloadDialogPublic();
+      final dynamic saved = await dyn.openDownloadDialogPublic();
+      return saved == true;
     } else {
       _warnMissingApi('_triggerDownloadFromBuilder → openDownloadDialogPublic');
+      return false;
     }
   }
 
@@ -511,7 +524,15 @@ class _NewHinooPageState extends State<NewHinooPage>
       return;
     }
 
-    _triggerDownloadFromBuilder();
+    final bool saved = await _triggerDownloadFromBuilder();
+    if (!saved || !mounted) return;
+    final Widget destination = widget.isCampanello
+        ? const CampanelliPage()
+        : const ChestPage();
+    Navigator.of(context).pushAndRemoveUntil(
+      MaterialPageRoute(builder: (_) => destination),
+      (route) => false,
+    );
   }
 
   void _warnMissingApi(String what) {
@@ -756,6 +777,12 @@ class _NewHinooPageState extends State<NewHinooPage>
               canvasH = canvasAvailableH;
               canvasW = canvasH * ar;
             }
+            if (kbOpen && _unobstructedCanvasSize != null) {
+              canvasW = _unobstructedCanvasSize!.width;
+              canvasH = _unobstructedCanvasSize!.height;
+            } else if (!kbOpen) {
+              _unobstructedCanvasSize = Size(canvasW, canvasH);
+            }
             _lastCanvasHeight = HinooTypography.baselineCanvasHeight;
 
             final Widget mainColumn = Column(
@@ -795,6 +822,7 @@ class _NewHinooPageState extends State<NewHinooPage>
                             _buildEditorControls(),
                             const SizedBox(height: editorControlsGap),
                             SizedBox(
+                              key: const Key('hinoo-editor-card'),
                               width: canvasW,
                               height: canvasH,
                               child: ClipRect(
@@ -804,6 +832,9 @@ class _NewHinooPageState extends State<NewHinooPage>
                                   onPngExported: _onPngExported,
                                   hintText: _kWriteHint,
                                   useCampanelloPadding: widget.isCampanello,
+                                  downloadContentName: widget.isCampanello
+                                      ? 'campanello'
+                                      : 'hinoo',
                                   backgroundPromptText: widget.isCampanello
                                       ? 'Scrivi qui\n'
                                             'tutto quello che vuoi\n'

--- a/lib/Pages/new_honoo_page.dart
+++ b/lib/Pages/new_honoo_page.dart
@@ -327,7 +327,15 @@ class _NewHonooPageState extends State<NewHonooPage> {
     }
 
     if (!mounted) return;
-    await state.downloadHonooPublic(context, fileName: trimmed);
+    final bool saved = await state.downloadHonooPublic(
+      context,
+      fileName: trimmed,
+    );
+    if (!saved || !mounted) return;
+    Navigator.of(context).pushAndRemoveUntil(
+      MaterialPageRoute(builder: (_) => const ChestPage()),
+      (route) => false,
+    );
   }
 
   void _onBuilderFocusChanged(bool hasFocus) {

--- a/lib/UI/hinoo_builder.dart
+++ b/lib/UI/hinoo_builder.dart
@@ -52,6 +52,7 @@ class HinooBuilder extends StatefulWidget {
     this.initialDraft,
     this.centerTextVertically = true,
     this.useCampanelloPadding = false,
+    this.downloadContentName = 'hinoo',
   });
 
   final ValueChanged<dynamic>? onHinooChanged;
@@ -61,6 +62,7 @@ class HinooBuilder extends StatefulWidget {
   final HinooDraft? initialDraft;
   final bool centerTextVertically;
   final bool useCampanelloPadding;
+  final String downloadContentName;
 
   @override
   State<HinooBuilder> createState() => _HinooBuilderState();
@@ -237,15 +239,15 @@ class _HinooBuilderState extends State<HinooBuilder> {
     _step = _WizardStep.changeBg;
   }
 
-  Future<void> _openDownloadDialog() async {
-    if (!mounted || _pages.isEmpty) return;
+  Future<bool> _openDownloadDialog() async {
+    if (!mounted || _pages.isEmpty) return false;
     final bool? confirmed = await showDialog<bool>(
       context: context,
       barrierDismissible: true,
       builder: (_) => const DownloadHinooDialog(),
     );
-    if (confirmed != true) return;
-    if (!mounted) return;
+    if (confirmed != true) return false;
+    if (!mounted) return false;
     final String? chosenName = await showDialog<String>(
       context: context,
       barrierDismissible: true,
@@ -253,15 +255,15 @@ class _HinooBuilderState extends State<HinooBuilder> {
     );
     final String? trimmed = chosenName?.trim();
     if (trimmed == null || trimmed.isEmpty) {
-      return;
+      return false;
     }
-    if (!mounted) return;
+    if (!mounted) return false;
     _lastFileBaseName = trimmed;
-    await _downloadHinoo(baseName: trimmed);
+    return _downloadHinoo(baseName: trimmed);
   }
 
-  Future<void> _downloadHinoo({String? baseName}) async {
-    if (!mounted) return;
+  Future<bool> _downloadHinoo({String? baseName}) async {
+    if (!mounted) return false;
     final BuildContext currentContext = context;
     final HinooExportMode exportMode = _resolveExportMode();
     bool progressVisible = false;
@@ -312,19 +314,20 @@ class _HinooBuilderState extends State<HinooBuilder> {
         message: 'hinoo creati con honoo',
       );
       await dismissProgressDialogIfNeeded();
-      if (!currentContext.mounted) return;
+      if (!currentContext.mounted) return false;
       await showDownloadSaveResult(
         context: currentContext,
-        contentName: 'hinoo',
-        openSavedImage: saver.openSavedImage,
+        contentName: widget.downloadContentName,
         result: result,
       );
+      return result.savedToGallery;
     } catch (e) {
       if (mounted) {
         await dismissProgressDialogIfNeeded();
-        if (!currentContext.mounted) return;
+        if (!currentContext.mounted) return false;
         showHonooToast(currentContext, message: 'Errore download: $e');
       }
+      return false;
     } finally {
       if (mounted) {
         await dismissProgressDialogIfNeeded();
@@ -432,8 +435,8 @@ class _HinooBuilderState extends State<HinooBuilder> {
   void deleteCurrentPagePublic() => _deleteCurrentPage(); // già usata
   void clearContentPublic() => _clearContent();
   Future<void> openPreviewDialogPublic() => _openPreviewDialog();
-  Future<void> openDownloadDialogPublic() => _openDownloadDialog();
-  Future<void> downloadAllPagesPublic({String? baseName}) =>
+  Future<bool> openDownloadDialogPublic() => _openDownloadDialog();
+  Future<bool> downloadAllPagesPublic({String? baseName}) =>
       _downloadHinoo(baseName: baseName);
   Future<void> replaceBackgroundPublic() => _pickAndUploadBackground();
   void confirmBackgroundPublic() => _confirmBgAndLock();
@@ -748,8 +751,7 @@ class _HinooBuilderState extends State<HinooBuilder> {
       if (!mounted) return;
       await showDownloadSaveResult(
         context: context,
-        contentName: 'hinoo',
-        openSavedImage: saver.openSavedImage,
+        contentName: widget.downloadContentName,
         result: result,
       );
     } catch (e) {

--- a/lib/UI/hinoo_thread_view.dart
+++ b/lib/UI/hinoo_thread_view.dart
@@ -22,7 +22,7 @@ class HinooThreadView extends StatefulWidget {
   final double maxHeight;
   final double maxWidth;
   final String? rootAuthorId;
-  final VoidCallback? onDownloadTap;
+  final ValueChanged<GlobalKey>? onDownloadTap;
 
   @override
   State<HinooThreadView> createState() => _HinooThreadViewState();
@@ -140,7 +140,7 @@ class _HinooThreadViewState extends State<HinooThreadView>
                     maxWidth: widget.maxWidth,
                     isReply: entry.isReply,
                     authorId: entry.authorId,
-                    onDownloadTap: widget.onDownloadTap,
+                    onDownloadCanvasTap: widget.onDownloadTap,
                   ),
                 );
               },

--- a/lib/UI/hinoo_viewer.dart
+++ b/lib/UI/hinoo_viewer.dart
@@ -18,6 +18,7 @@ class HinooViewer extends StatefulWidget {
   final double maxWidth;
   final Color gapColor;
   final VoidCallback? onDownloadTap;
+  final ValueChanged<GlobalKey>? onDownloadCanvasTap;
   const HinooViewer({
     super.key,
     required this.draft,
@@ -25,6 +26,7 @@ class HinooViewer extends StatefulWidget {
     required this.maxWidth,
     this.gapColor = HonooColor.background,
     this.onDownloadTap,
+    this.onDownloadCanvasTap,
     this.isReply = false,
     this.authorId,
     this.viewerUserId,
@@ -39,6 +41,7 @@ class HinooViewer extends StatefulWidget {
 
 class _HinooViewerState extends State<HinooViewer> {
   late final PageController _vController;
+  final GlobalKey _downloadBoundaryKey = GlobalKey();
   Timer? _snapTimer;
 
   @override
@@ -105,6 +108,9 @@ class _HinooViewerState extends State<HinooViewer> {
     }
     final double displayW = baselineW * scale;
     final double displayH = baselineH * scale;
+    final VoidCallback? onDownloadTap = widget.onDownloadCanvasTap != null
+        ? () => widget.onDownloadCanvasTap!(_downloadBoundaryKey)
+        : widget.onDownloadTap;
 
     final String? currentUserId =
         widget.viewerUserId ?? SupabaseProvider.client.auth.currentUser?.id;
@@ -142,72 +148,75 @@ class _HinooViewerState extends State<HinooViewer> {
           height: displayH,
           child: FittedBox(
             fit: BoxFit.contain,
-            child: SizedBox(
-              width: baselineW,
-              height: baselineH,
-              child: Stack(
-                clipBehavior: Clip.none,
-                children: [
-                  ClipRRect(
-                    borderRadius: BorderRadius.circular(5),
-                    child: Listener(
-                      onPointerSignal: (event) {
-                        if (event is PointerScrollEvent &&
-                            widget.draft.pages.length > 1 &&
-                            _vController.hasClients &&
-                            _vController.position.haveDimensions) {
-                          final position = _vController.position;
-                          if ((position.maxScrollExtent -
-                                      position.minScrollExtent)
-                                  .abs() <
-                              0.5) {
-                            return;
+            child: RepaintBoundary(
+              key: _downloadBoundaryKey,
+              child: SizedBox(
+                width: baselineW,
+                height: baselineH,
+                child: Stack(
+                  clipBehavior: Clip.none,
+                  children: [
+                    ClipRRect(
+                      borderRadius: BorderRadius.circular(5),
+                      child: Listener(
+                        onPointerSignal: (event) {
+                          if (event is PointerScrollEvent &&
+                              widget.draft.pages.length > 1 &&
+                              _vController.hasClients &&
+                              _vController.position.haveDimensions) {
+                            final position = _vController.position;
+                            if ((position.maxScrollExtent -
+                                        position.minScrollExtent)
+                                    .abs() <
+                                0.5) {
+                              return;
+                            }
+                            final double target =
+                                (position.pixels + event.scrollDelta.dy).clamp(
+                                  position.minScrollExtent,
+                                  position.maxScrollExtent,
+                                );
+                            if ((target - position.pixels).abs() > 0.5) {
+                              _vController.jumpTo(target);
+                              _scheduleSnap();
+                            }
                           }
-                          final double target =
-                              (position.pixels + event.scrollDelta.dy).clamp(
-                                position.minScrollExtent,
-                                position.maxScrollExtent,
+                        },
+                        child: ScrollConfiguration(
+                          behavior: ScrollConfiguration.of(context).copyWith(
+                            dragDevices: {
+                              PointerDeviceKind.touch,
+                              PointerDeviceKind.mouse,
+                              PointerDeviceKind.stylus,
+                              PointerDeviceKind.trackpad,
+                            },
+                          ),
+                          child: PageView.builder(
+                            scrollDirection: Axis.vertical,
+                            controller: _vController,
+                            // disabilita scroll interno in contesti di thread verticale a pagina intera
+                            physics: const NeverScrollableScrollPhysics(),
+                            allowImplicitScrolling: true,
+                            onPageChanged: _prefetchPagesFrom,
+                            itemCount: widget.draft.pages.length,
+                            itemBuilder: (context, index) {
+                              return HinooSlideView(
+                                slide: widget.draft.pages[index],
+                                width: baselineW,
+                                height: baselineH,
+                                gap: 0,
+                                gapColor: widget.gapColor,
+                                scaleLegacyTextToFit:
+                                    widget.draft.baseCanvasHeight == null,
+                                onDownloadTap: onDownloadTap,
                               );
-                          if ((target - position.pixels).abs() > 0.5) {
-                            _vController.jumpTo(target);
-                            _scheduleSnap();
-                          }
-                        }
-                      },
-                      child: ScrollConfiguration(
-                        behavior: ScrollConfiguration.of(context).copyWith(
-                          dragDevices: {
-                            PointerDeviceKind.touch,
-                            PointerDeviceKind.mouse,
-                            PointerDeviceKind.stylus,
-                            PointerDeviceKind.trackpad,
-                          },
-                        ),
-                        child: PageView.builder(
-                          scrollDirection: Axis.vertical,
-                          controller: _vController,
-                          // disabilita scroll interno in contesti di thread verticale a pagina intera
-                          physics: const NeverScrollableScrollPhysics(),
-                          allowImplicitScrolling: true,
-                          onPageChanged: _prefetchPagesFrom,
-                          itemCount: widget.draft.pages.length,
-                          itemBuilder: (context, index) {
-                            return HinooSlideView(
-                              slide: widget.draft.pages[index],
-                              width: baselineW,
-                              height: baselineH,
-                              gap: 0,
-                              gapColor: widget.gapColor,
-                              scaleLegacyTextToFit:
-                                  widget.draft.baseCanvasHeight == null,
-                              onDownloadTap: widget.onDownloadTap,
-                            );
-                          },
+                            },
+                          ),
                         ),
                       ),
                     ),
-                  ),
-                ],
+                  ],
+                ),
               ),
             ),
           ),

--- a/lib/UI/honoo_builder.dart
+++ b/lib/UI/honoo_builder.dart
@@ -452,13 +452,13 @@ class HonooBuilderState extends State<HonooBuilder> {
     }
   }
 
-  Future<void> downloadHonooPublic(
+  Future<bool> downloadHonooPublic(
     BuildContext context, {
     String? fileName,
   }) async {
     if (!hasImage) {
       showHonooToast(context, message: 'Devi prima caricare un’immagine.');
-      return;
+      return false;
     }
 
     setState(() => _hideEditorActionsForCapture = true);
@@ -474,9 +474,9 @@ class HonooBuilderState extends State<HonooBuilder> {
       }
     }
     if (bytes == null || bytes.isEmpty) {
-      if (!context.mounted) return;
+      if (!context.mounted) return false;
       showHonooToast(context, message: 'Impossibile generare il file PNG.');
-      return;
+      return false;
     }
 
     final saver = getDownloadSaver();
@@ -492,13 +492,13 @@ class HonooBuilderState extends State<HonooBuilder> {
       DownloadImage(filename: '$rawName.png', bytes: bytes),
     ]);
 
-    if (!context.mounted) return;
+    if (!context.mounted) return false;
     await showDownloadSaveResult(
       context: context,
       contentName: 'honoo',
-      openSavedImage: saver.openSavedImage,
       result: result,
     );
+    return result.savedToGallery;
   }
 
   void resetContent() {

--- a/lib/UI/unified_thread_view.dart
+++ b/lib/UI/unified_thread_view.dart
@@ -454,21 +454,16 @@ class _UnifiedThreadViewState extends State<UnifiedThreadView>
         );
         break;
       case ConversationEntryKind.hinoo:
-        card = RepaintBoundary(
-          key: repaintKey,
-          child: HinooViewer(
-            draft: entry.hinoo!,
-            maxHeight: widget.maxHeight,
-            maxWidth: widget.maxWidth,
-            isReply: entry.hinoo!.type == HinooType.answer,
-            authorId: entry.ownerId,
-            viewerUserId: widget.currentUserId,
-            gapColor: style.backgroundColor,
-            onDownloadTap: () => _downloadFromBoundary(
-              repaintKey: repaintKey,
-              baseName: 'hinoo',
-            ),
-          ),
+        card = HinooViewer(
+          draft: entry.hinoo!,
+          maxHeight: widget.maxHeight,
+          maxWidth: widget.maxWidth,
+          isReply: entry.hinoo!.type == HinooType.answer,
+          authorId: entry.ownerId,
+          viewerUserId: widget.currentUserId,
+          gapColor: style.backgroundColor,
+          onDownloadCanvasTap: (canvasKey) =>
+              _downloadFromBoundary(repaintKey: canvasKey, baseName: 'hinoo'),
         );
         break;
       case ConversationEntryKind.deleted:

--- a/lib/Utility/download_capture.dart
+++ b/lib/Utility/download_capture.dart
@@ -28,7 +28,6 @@ Future<void> captureAndSave(
         contentName: baseName.toLowerCase().startsWith('hinoo')
             ? 'hinoo'
             : 'honoo',
-        openSavedImage: _downloadCaptureService.openSavedImage,
         result: result,
       );
     } else {

--- a/lib/Widgets/chest_info_dialog.dart
+++ b/lib/Widgets/chest_info_dialog.dart
@@ -28,7 +28,7 @@ const chestInfoTextDirections =
     "quello che hai salvato\n"
     "dalla Luna\n";
 
-const chestInfoTextBeforeOwnReply = "\n\nla tua risposta,\n";
+const chestInfoTextBeforeOwnReply = "\n\nla tua risposta\n";
 
 const chestInfoTextBeforeReceivedReply =
     "\n\ne, se arriva,\n"

--- a/lib/Widgets/chest_item_view.dart
+++ b/lib/Widgets/chest_item_view.dart
@@ -44,7 +44,7 @@ class ChestItemView extends StatelessWidget {
   final String? focusConversationId;
   final String? revealEntryId;
   final ValueChanged<ConversationEntry> onSelectConversationEntry;
-  final VoidCallback onDownload;
+  final ValueChanged<GlobalKey> onDownload;
   final int conversationRefreshToken;
 
   @override
@@ -90,12 +90,14 @@ class ChestItemView extends StatelessWidget {
       },
     );
     final card = isConversation
-        ? RepaintBoundary(key: repaintKey, child: content)
+        ? content
         : ClipRRect(
             borderRadius: BorderRadius.circular(12),
             child: SizedBox(
               width: cardWidth,
-              child: RepaintBoundary(key: repaintKey, child: content),
+              child: isHonoo
+                  ? RepaintBoundary(key: repaintKey, child: content)
+                  : content,
             ),
           );
     final keyedCard = KeyedSubtree(
@@ -120,7 +122,10 @@ class ChestItemView extends StatelessWidget {
     return SizedBox(
       width: maxWidth,
       height: availableHeight,
-      child: HonooCard(honoo: honoo, onDownloadTap: onDownload),
+      child: HonooCard(
+        honoo: honoo,
+        onDownloadTap: () => onDownload(repaintKey),
+      ),
     );
   }
 
@@ -140,7 +145,7 @@ class ChestItemView extends StatelessWidget {
         maxHeight: availableHeight,
         maxWidth: maxWidth,
         authorId: hinoo.ownerId,
-        onDownloadTap: onDownload,
+        onDownloadCanvasTap: onDownload,
       );
     }
     return HinooThreadView(
@@ -169,7 +174,6 @@ class ChestItemView extends StatelessWidget {
                 focusConversationId == conversationId)
         ? revealEntryId
         : null,
-    onDownloadTap: onDownload,
     refreshToken: conversationRefreshToken,
   );
 }

--- a/lib/Widgets/gallery_save_dialog.dart
+++ b/lib/Widgets/gallery_save_dialog.dart
@@ -5,7 +5,6 @@ import 'package:honoo/Widgets/honoo_dialogs.dart';
 Future<void> showDownloadSaveResult({
   required BuildContext context,
   required String contentName,
-  required Future<bool> Function(DownloadSaveResult result) openSavedImage,
   required DownloadSaveResult result,
 }) async {
   if (!result.savedToGallery) {
@@ -15,21 +14,18 @@ Future<void> showDownloadSaveResult({
     return;
   }
 
-  final bool? openGallery = await showDialog<bool>(
+  final String subject = switch (contentName.toLowerCase()) {
+    'campanello' => 'Il campanello',
+    'honoo' => 'L’honoo',
+    _ => 'L’hinoo',
+  };
+  await showDialog<bool>(
     context: context,
-    barrierDismissible: true,
+    barrierDismissible: false,
     builder: (_) => HonooConfirmDialog(
-      title:
-          'L’$contentName è stato salvato\n'
-          'nella tua Galleria delle Foto',
-      confirmLabel: 'Apri galleria',
-      cancelLabel: 'Ignora',
+      title: '$subject è nella tua Galleria delle foto',
+      confirmLabel: 'OK',
+      showCancel: false,
     ),
   );
-  if (openGallery != true || !context.mounted) return;
-
-  final bool opened = await openSavedImage(result);
-  if (!opened && context.mounted) {
-    showHonooToast(context, message: 'Impossibile aprire l’immagine salvata.');
-  }
 }

--- a/lib/Widgets/honoo_dialogs.dart
+++ b/lib/Widgets/honoo_dialogs.dart
@@ -67,12 +67,14 @@ class HonooConfirmDialog extends StatelessWidget {
     this.message,
     required this.confirmLabel,
     this.cancelLabel = 'Annulla',
+    this.showCancel = true,
   });
 
   final String title;
   final String? message;
   final String confirmLabel;
   final String cancelLabel;
+  final bool showCancel;
 
   @override
   Widget build(BuildContext context) {
@@ -118,15 +120,17 @@ class HonooConfirmDialog extends StatelessWidget {
                 ),
               ),
             ),
-            const SizedBox(height: 12),
-            TextButton(
-              onPressed: () => Navigator.of(context).pop(false),
-              style: TextButton.styleFrom(foregroundColor: Colors.white54),
-              child: Text(
-                cancelLabel,
-                style: HonooDialogStyles.tertiaryAction(),
+            if (showCancel) ...[
+              const SizedBox(height: 12),
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(false),
+                style: TextButton.styleFrom(foregroundColor: Colors.white54),
+                child: Text(
+                  cancelLabel,
+                  style: HonooDialogStyles.tertiaryAction(),
+                ),
               ),
-            ),
+            ],
           ],
         ),
       ),

--- a/test/pages/new_hinoo_page_test.dart
+++ b/test/pages/new_hinoo_page_test.dart
@@ -107,6 +107,46 @@ void main() {
     expect(find.byTooltip('Apri il tuo Cuore'), findsOneWidget);
   });
 
+  testWidgets('la tastiera mobile non ridimensiona la card hinoo', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(390, 844);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    addTearDown(tester.view.resetViewInsets);
+
+    await tester.pumpWidget(
+      Sizer(
+        builder: (context, orientation, deviceType) {
+          return const MaterialApp(
+            home: NewHinooPage(
+              initialDraft: HinooDraft(
+                pages: [
+                  HinooSlide(
+                    backgroundImage: null,
+                    text: 'Testo',
+                    isTextWhite: true,
+                  ),
+                ],
+              ),
+            ),
+          );
+        },
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final card = find.byKey(const Key('hinoo-editor-card'));
+    final Size sizeBeforeKeyboard = tester.getSize(card);
+
+    tester.view.viewInsets = const FakeViewPadding(bottom: 320);
+    await tester.pump();
+
+    expect(tester.getSize(card), sizeBeforeKeyboard);
+    expect(find.byType(TextField), findsOneWidget);
+  });
+
   testWidgets('il cestino hinoo appare nella toolbar di modifica immagine', (
     tester,
   ) async {

--- a/test/widgets/chest_info_dialog_test.dart
+++ b/test/widgets/chest_info_dialog_test.dart
@@ -51,7 +51,7 @@ void main() {
       "quello che hai salvato\n"
       "dalla Luna\n"
       "\uFFFC\n\n"
-      "la tua risposta,\n"
+      "la tua risposta\n"
       "\uFFFC\n\n"
       "e, se arriva,\n"
       "la risposta alla tua risposta\n"

--- a/test/widgets/chest_item_view_animation_test.dart
+++ b/test/widgets/chest_item_view_animation_test.dart
@@ -57,7 +57,7 @@ void main() {
             focusConversationId: null,
             revealEntryId: null,
             onSelectConversationEntry: (ConversationEntry _) {},
-            onDownload: () {},
+            onDownload: (_) {},
             conversationRefreshToken: 0,
           ),
         ),

--- a/test/widgets/gallery_save_dialog_test.dart
+++ b/test/widgets/gallery_save_dialog_test.dart
@@ -41,7 +41,6 @@ void main() {
               onPressed: () => showDownloadSaveResult(
                 context: context,
                 contentName: contentName,
-                openSavedImage: saver.openSavedImage,
                 result: result,
               ),
               child: const Text('Salva'),
@@ -54,35 +53,33 @@ void main() {
     await tester.pumpAndSettle();
   }
 
-  testWidgets('Ignora chiude il dialogo senza aprire la galleria', (
+  testWidgets('mostra il popup honoo e torna alla schermata con OK', (
     tester,
   ) async {
     final saver = _FakeDownloadSaver();
     await pumpDialog(tester, saver);
 
     expect(
-      find.text(
-        'L’honoo è stato salvato\n'
-        'nella tua Galleria delle Foto',
-      ),
+      find.text('L’honoo è nella tua Galleria delle foto'),
       findsOneWidget,
     );
+    expect(find.text('Ignora'), findsNothing);
 
-    await tester.tap(find.text('Ignora'));
+    await tester.tap(find.text('OK'));
     await tester.pumpAndSettle();
 
     expect(saver.openCalled, isFalse);
     expect(find.text('Salva'), findsOneWidget);
   });
 
-  testWidgets('Apri galleria apre esattamente il file salvato', (tester) async {
+  testWidgets('non apre la galleria dopo la conferma', (tester) async {
     final saver = _FakeDownloadSaver();
     await pumpDialog(tester, saver);
 
-    await tester.tap(find.text('Apri galleria'));
+    await tester.tap(find.text('OK'));
     await tester.pumpAndSettle();
 
-    expect(saver.openCalled, isTrue);
+    expect(saver.openCalled, isFalse);
     expect(find.text('Salva'), findsOneWidget);
   });
 
@@ -91,10 +88,19 @@ void main() {
     await pumpDialog(tester, saver, contentName: 'hinoo');
 
     expect(
-      find.text(
-        'L’hinoo è stato salvato\n'
-        'nella tua Galleria delle Foto',
-      ),
+      find.text('L’hinoo è nella tua Galleria delle foto'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('il messaggio usa correttamente il nome campanello', (
+    tester,
+  ) async {
+    final saver = _FakeDownloadSaver();
+    await pumpDialog(tester, saver, contentName: 'campanello');
+
+    expect(
+      find.text('Il campanello è nella tua Galleria delle foto'),
       findsOneWidget,
     );
   });

--- a/test/widgets/hinoo_download_boundary_test.dart
+++ b/test/widgets/hinoo_download_boundary_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:honoo/Entities/hinoo.dart';
+import 'package:honoo/Services/download_capture_service.dart';
+import 'package:honoo/UI/hinoo_viewer.dart';
+
+void main() {
+  testWidgets('il download usa il canvas Hinoo e produce 1080x1920', (
+    tester,
+  ) async {
+    GlobalKey? capturedKey;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            width: 390,
+            height: 700,
+            child: HinooViewer(
+              draft: const HinooDraft(
+                pages: [
+                  HinooSlide(
+                    backgroundImage: null,
+                    text: 'Solo Hinoo',
+                    isTextWhite: true,
+                  ),
+                ],
+              ),
+              maxHeight: 700,
+              maxWidth: 390,
+              authorId: 'test_user',
+              viewerUserId: 'test_user',
+              onDownloadCanvasTap: (key) => capturedKey = key,
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    await tester.tap(find.byTooltip('download'));
+    await tester.pump();
+
+    final boundary =
+        capturedKey!.currentContext!.findRenderObject() as RenderBox;
+    expect(boundary.size, const Size(360, 640));
+    expect(DownloadCaptureService.pixelRatioForHeight(boundary.size.height), 3);
+  });
+}


### PR DESCRIPTION
## What
- rende affidabile il salvataggio delle modifiche al Campanello, mostra la conferma nello stile dell’app e riporta al carosello sul Campanello dell’utente
- mantiene il Campanello dell’utente prima degli altri nel carosello
- uniforma i popup di download per hinoo, honoo e Campanello e riporta alla schermata corretta dopo il salvataggio
- rimuove la virgola dall’informativa dello Scrigno
- mantiene invariata la dimensione della card Hinoo su mobile quando appare la tastiera

## Why
Il salvataggio del Campanello non restituiva un feedback affidabile né riposizionava il carosello, mentre i download avevano comportamenti e messaggi diversi. Su mobile la comparsa della tastiera poteva inoltre ridimensionare la card di modifica.

## Impact
Flussi di modifica e download più chiari e coerenti; nessuna modifica ai dati esistenti o alle API.

## Root cause
I builder di download non restituivano l’esito del salvataggio alle pagine chiamanti, l’editor Campanello chiudeva subito dopo un toast e il layout Hinoo ricalcolava la dimensione disponibile durante l’apertura della tastiera.

## Checks
- `flutter analyze` sui 13 file modificati: nessun problema
- 17 test mirati: tutti superati