### PR TITLE
Center Home in Campanelli intro toolbar

### DIFF
--- a/lib/Widgets/campanelli_footer.dart
+++ b/lib/Widgets/campanelli_footer.dart
@@ -42,6 +42,7 @@ class CampanelliFooter extends StatelessWidget {
       desiredGap: desiredGap,
       minGap: 16,
       height: iconSize,
+      centerFirstAction: !showCampanello,
       actions: [
         ResponsiveFooterAction(
           asset: "assets/icons/home.svg",

--- a/lib/Widgets/responsive_footer_bar.dart
+++ b/lib/Widgets/responsive_footer_bar.dart
@@ -38,6 +38,7 @@ class ResponsiveFooterBar extends StatelessWidget {
     this.mainAxisAlignment = MainAxisAlignment.center,
     this.alignment = Alignment.center,
     this.expandToAvailableWidth = false,
+    this.centerFirstAction = false,
   });
 
   final List<ResponsiveFooterAction> actions;
@@ -50,6 +51,7 @@ class ResponsiveFooterBar extends StatelessWidget {
   final MainAxisAlignment mainAxisAlignment;
   final AlignmentGeometry alignment;
   final bool expandToAvailableWidth;
+  final bool centerFirstAction;
 
   @override
   Widget build(BuildContext context) {
@@ -63,10 +65,11 @@ class ResponsiveFooterBar extends StatelessWidget {
           final double availableWidth = constraints.maxWidth.isFinite
               ? constraints.maxWidth
               : double.infinity;
-          final double totalIconWidth = actions.fold(
-            0,
-            (sum, action) => sum + action.size,
-          );
+          final bool balanceFirstAction =
+              centerFirstAction && actions.length == 2;
+          final double totalIconWidth =
+              actions.fold(0.0, (sum, action) => sum + action.size) +
+              (balanceFirstAction ? actions.last.size : 0);
           final double iconScale =
               availableWidth.isFinite &&
                   totalIconWidth > availableWidth &&
@@ -74,7 +77,9 @@ class ResponsiveFooterBar extends StatelessWidget {
               ? availableWidth / totalIconWidth
               : 1;
           final double fittedIconWidth = totalIconWidth * iconScale;
-          final int gapCount = math.max(0, actions.length - 1);
+          final int gapCount = balanceFirstAction
+              ? 2
+              : math.max(0, actions.length - 1);
           double gap = effectiveDesiredGap;
 
           if (availableWidth.isFinite && gapCount > 0) {
@@ -101,6 +106,10 @@ class ResponsiveFooterBar extends StatelessWidget {
                     ? MainAxisSize.max
                     : MainAxisSize.min,
                 children: [
+                  if (balanceFirstAction) ...[
+                    SizedBox(width: actions.last.size * iconScale),
+                    SizedBox(width: gap),
+                  ],
                   for (int index = 0; index < actions.length; index++) ...[
                     _FooterIconButton(
                       action: actions[index],

--- a/test/widgets/campanelli_footer_test.dart
+++ b/test/widgets/campanelli_footer_test.dart
@@ -37,8 +37,9 @@ void main() {
     );
   }
 
-  testWidgets('campanello visitatore mostra badge e inoltra le azioni',
-      (tester) async {
+  testWidgets('campanello visitatore mostra badge e inoltra le azioni', (
+    tester,
+  ) async {
     var home = false;
     var knocked = false;
     await pumpFooter(
@@ -61,8 +62,9 @@ void main() {
     expect(knocked, isTrue);
   });
 
-  testWidgets('intro con bussate mostra lista e limita il badge a 99+',
-      (tester) async {
+  testWidgets('intro con bussate mostra lista e limita il badge a 99+', (
+    tester,
+  ) async {
     var opened = false;
     await pumpFooter(
       tester,
@@ -78,13 +80,20 @@ void main() {
     expect(opened, isTrue);
   });
 
-  testWidgets('campanello proprio non mostra azioni di bussata',
-      (tester) async {
-    await pumpFooter(
-      tester,
-      showCampanello: true,
-      isOwnCampanello: true,
+  testWidgets("intro centra l'icona Home nella toolbar", (tester) async {
+    await pumpFooter(tester, showCampanello: false);
+
+    final footer = find.byType(CampanelliFooter);
+    expect(
+      tester.getCenter(find.byTooltip('Home')).dx,
+      tester.getCenter(footer).dx,
     );
+  });
+
+  testWidgets('campanello proprio non mostra azioni di bussata', (
+    tester,
+  ) async {
+    await pumpFooter(tester, showCampanello: true, isOwnCampanello: true);
 
     expect(find.byTooltip('Home'), findsOneWidget);
     expect(find.byTooltip('Campanello'), findsNothing);


### PR DESCRIPTION
## Sintesi
- centra l'icona Home nella toolbar della pagina introduttiva Campanelli
- mantiene invariata la disposizione delle toolbar nelle pagine Campanello successive
- aggiunge un test geometrico per prevenire regressioni

## Verifica
- flutter test --no-pub test/widgets/campanelli_footer_test.dart test/pages/campanelli_page_layout_test.dart
- flutter analyze --no-pub lib/Widgets/responsive_footer_bar.dart lib/Widgets/campanelli_footer.dart test/widgets/campanelli_footer_test.dart
- git diff --check