### PR TITLE
Uniforma i popup di download su tutte le piattaforme

### DIFF
--- a/lib/Pages/chest_page.dart
+++ b/lib/Pages/chest_page.dart
@@ -1015,20 +1015,11 @@ class _ChestPageState extends State<ChestPage> with WidgetsBindingObserver {
         message: 'creato con honoo',
       );
       if (!mounted) return;
-      if (result.savedToGallery) {
-        await showDownloadSaveResult(
-          context: context,
-          contentName: contentName,
-          result: result,
-        );
-      } else {
-        showHonooToast(
-          context,
-          message: result.message.isNotEmpty
-              ? result.message
-              : 'Download avviato.',
-        );
-      }
+      await showDownloadSaveResult(
+        context: context,
+        contentName: contentName,
+        result: result,
+      );
     } catch (e) {
       if (!mounted) return;
       showHonooToast(context, message: 'Errore download: $e');

--- a/lib/UI/hinoo_builder.dart
+++ b/lib/UI/hinoo_builder.dart
@@ -320,7 +320,7 @@ class _HinooBuilderState extends State<HinooBuilder> {
         contentName: widget.downloadContentName,
         result: result,
       );
-      return result.savedToGallery;
+      return true;
     } catch (e) {
       if (mounted) {
         await dismissProgressDialogIfNeeded();

--- a/lib/UI/honoo_builder.dart
+++ b/lib/UI/honoo_builder.dart
@@ -498,7 +498,7 @@ class HonooBuilderState extends State<HonooBuilder> {
       contentName: 'honoo',
       result: result,
     );
-    return result.savedToGallery;
+    return true;
   }
 
   void resetContent() {

--- a/lib/Utility/download_capture.dart
+++ b/lib/Utility/download_capture.dart
@@ -19,20 +19,17 @@ Future<void> captureAndSave(
     final result = await _downloadCaptureService.captureAndSave(
       repaintKey: repaintKey,
       baseName: baseName,
+      message: message ?? toastOnStart,
     );
 
     if (!rootNav.mounted) return;
-    if (result.savedToGallery) {
-      await showDownloadSaveResult(
-        context: rootNav.context,
-        contentName: baseName.toLowerCase().startsWith('hinoo')
-            ? 'hinoo'
-            : 'honoo',
-        result: result,
-      );
-    } else {
-      showHonooToast(rootNav.context, message: message ?? toastOnStart);
-    }
+    await showDownloadSaveResult(
+      context: rootNav.context,
+      contentName: baseName.toLowerCase().startsWith('hinoo')
+          ? 'hinoo'
+          : 'honoo',
+      result: result,
+    );
   } catch (e) {
     if (rootNav != null && rootNav.mounted) {
       showHonooToast(rootNav.context, message: 'Errore download: $e');

--- a/lib/Widgets/gallery_save_dialog.dart
+++ b/lib/Widgets/gallery_save_dialog.dart
@@ -7,13 +7,9 @@ Future<void> showDownloadSaveResult({
   required String contentName,
   required DownloadSaveResult result,
 }) async {
-  if (!result.savedToGallery) {
-    if (result.message.isNotEmpty) {
-      showHonooToast(context, message: result.message);
-    }
-    return;
-  }
-
+  // Sul web savedToGallery resta false anche quando il download o la
+  // condivisione sono partiti correttamente. Arrivare qui significa che il
+  // salvataggio si è concluso senza errori, quindi il feedback resta uniforme.
   final String subject = switch (contentName.toLowerCase()) {
     'campanello' => 'Il campanello',
     'honoo' => 'L’honoo',

--- a/test/widgets/gallery_save_dialog_test.dart
+++ b/test/widgets/gallery_save_dialog_test.dart
@@ -32,6 +32,7 @@ void main() {
     WidgetTester tester,
     _FakeDownloadSaver saver, {
     String contentName = 'honoo',
+    DownloadSaveResult saveResult = result,
   }) async {
     await tester.pumpWidget(
       MaterialApp(
@@ -41,7 +42,7 @@ void main() {
               onPressed: () => showDownloadSaveResult(
                 context: context,
                 contentName: contentName,
-                result: result,
+                result: saveResult,
               ),
               child: const Text('Salva'),
             ),
@@ -103,5 +104,24 @@ void main() {
       find.text('Il campanello è nella tua Galleria delle foto'),
       findsOneWidget,
     );
+  });
+
+  testWidgets('mostra lo stesso popup per un download web', (tester) async {
+    final saver = _FakeDownloadSaver();
+    await pumpDialog(
+      tester,
+      saver,
+      contentName: 'campanello',
+      saveResult: const DownloadSaveResult(
+        message: 'Download avviato.',
+        savedToGallery: false,
+      ),
+    );
+
+    expect(
+      find.text('Il campanello è nella tua Galleria delle foto'),
+      findsOneWidget,
+    );
+    expect(find.text('Download avviato.'), findsNothing);
   });
 }


### PR DESCRIPTION
## Cosa cambia

- mostra lo stesso popup di conferma per Honoo, Hinoo e Campanello su web e piattaforme native
- considera riuscito il flusso dopo che il salvataggio/download termina senza errori, permettendo la navigazione prevista anche sul web
- mantiene i messaggi di errore esistenti quando il salvataggio fallisce
- aggiunge copertura esplicita per il risultato web con `savedToGallery: false`

## Perché

Sul web il download saver restituisce `savedToGallery: false` anche quando il download o la condivisione sono partiti correttamente. I chiamanti interpretavano quel valore come mancato salvataggio e mostravano un toast al posto del popup mobile, bloccando inoltre la navigazione successiva.

## Verifiche

- `flutter analyze` sui sei file modificati
- 12 test mirati su popup, editor Hinoo/Campanello e boundary 1080x1920
- build web release con PWA disabilitata
