### PR TITLE
Allow repeated Moon publications

### DIFF
--- a/lib/Controller/honoo_controller.dart
+++ b/lib/Controller/honoo_controller.dart
@@ -37,9 +37,8 @@ class HonooController {
         ..clear()
         ..addAll(
           chest.map(
-            (h) => h.copyWith(
-              isOnMoon: moonContent.contains((h.text, h.image)),
-            ),
+            (h) =>
+                h.copyWith(isOnMoon: moonContent.contains((h.text, h.image))),
           ),
         );
 
@@ -48,8 +47,10 @@ class HonooController {
       final ids = _personal.map((h) => h.dbId).whereType<String>().toList();
       if (ids.isNotEmpty) {
         final client = SupabaseProvider.client;
-        final rows =
-            await client.from('honoo').select('reply_to').in_('reply_to', ids);
+        final rows = await client
+            .from('honoo')
+            .select('reply_to')
+            .in_('reply_to', ids);
 
         // reply_to presenti → esistono risposte
         final repliedParents = <String>{};
@@ -90,7 +91,8 @@ class HonooController {
     final rows = await client
         .from('honoo')
         .select(
-            'id,text,image_url,destination,reply_to,recipient_tag,created_at,updated_at,user_id')
+          'id,text,image_url,destination,reply_to,recipient_tag,created_at,updated_at,user_id',
+        )
         .or('id.eq.$id,reply_to.eq.$id')
         .order('created_at', ascending: true);
 
@@ -116,6 +118,7 @@ class HonooController {
         _personal[index] = _personal[index].copyWith(isOnMoon: true);
         version.value++;
       }
+      h.isOnMoon = true;
       return result;
     } catch (e) {
       debugPrint('duplicateToMoon error: $e');

--- a/lib/Pages/chest_page.dart
+++ b/lib/Pages/chest_page.dart
@@ -613,6 +613,13 @@ class _ChestPageState extends State<ChestPage> with WidgetsBindingObserver {
 
   Future<void> _sendHonooToMoon(Honoo honoo) async {
     if (_isMutating) return;
+    if (honoo.isOnMoon == true) {
+      final confirmed = await showRepeatMoonPublicationDialog(
+        context,
+        contentName: 'honoo',
+      );
+      if (!mounted || confirmed != true) return;
+    }
     setState(() => _isMutating = true);
     try {
       final result = await HonooController().sendToMoon(honoo);
@@ -671,6 +678,13 @@ class _ChestPageState extends State<ChestPage> with WidgetsBindingObserver {
 
   Future<void> _sendHinooToMoon(ChestHinooItem hinoo) async {
     if (_isMutating) return;
+    if (hinoo.isOnMoon) {
+      final confirmed = await showRepeatMoonPublicationDialog(
+        context,
+        contentName: 'hinoo',
+      );
+      if (!mounted || confirmed != true) return;
+    }
     setState(() => _isMutating = true);
     try {
       final result = await _hinooController.sendToMoon(hinoo.draft);

--- a/lib/Services/hinoo_service.dart
+++ b/lib/Services/hinoo_service.dart
@@ -99,7 +99,8 @@ class HinooService {
     });
   }
 
-  /// Inserisce un record type='moon' se non già presente (dedup su fingerprint)
+  /// Inserisce una nuova copia type='moon' a ogni invio. Il fingerprint resta
+  /// disponibile per mostrare nello Scrigno lo stato di pubblicazione.
   static Future<DuplicationResult> duplicateToMoon(HinooDraft draft) async {
     if (draft.isFromMoonSaved) {
       throw ArgumentError(
@@ -153,9 +154,7 @@ class HinooService {
     return _insertDuplicate(data);
   }
 
-  static Future<DuplicationResult> _insertDuplicate(
-    Map<String, dynamic> data,
-  ) {
+  static Future<DuplicationResult> _insertDuplicate(Map<String, dynamic> data) {
     return _reliability.write(() async {
       try {
         await _client.from(_table).insert(data);
@@ -180,9 +179,7 @@ class HinooService {
 
   static Future<void> deleteHinooById(String id) async {
     if (id.trim().isEmpty) return;
-    await _reliability.write(
-      () => _client.from(_table).delete().eq('id', id),
-    );
+    await _reliability.write(() => _client.from(_table).delete().eq('id', id));
   }
 
   static String fingerprint(HinooDraft d) {
@@ -239,8 +236,10 @@ class HinooService {
   }
 
   /// Carica gli Hinoo personali dell'utente (dallo scrigno)
-  static Future<List<HinooDraft>> fetchUserHinoo(String userId,
-      {HinooType type = HinooType.personal}) async {
+  static Future<List<HinooDraft>> fetchUserHinoo(
+    String userId, {
+    HinooType type = HinooType.personal,
+  }) async {
     final typeStr = _toDbType(type);
     final baseQuery = _client
         .from(_table)

--- a/lib/Services/honoo_service.dart
+++ b/lib/Services/honoo_service.dart
@@ -167,8 +167,9 @@ class HonooService {
     return _insertDuplicate(payload);
   }
 
-  /// Duplica un honoo dello scrigno pubblicandolo sulla Luna (nuova INSERT).
-  /// Non tocca l'originale in 'chest'.
+  /// Pubblica una nuova copia dell'honoo sulla Luna a ogni invio.
+  /// Non tocca l'originale in 'chest'; il fingerprint resta disponibile per
+  /// mostrare nello Scrigno che almeno una copia è già stata pubblicata.
   static Future<DuplicationResult> duplicateToMoon(Honoo h) async {
     if (h.isFromMoonSaved) {
       throw ArgumentError(

--- a/lib/Widgets/chest_footer.dart
+++ b/lib/Widgets/chest_footer.dart
@@ -89,16 +89,14 @@ class ChestFooter extends StatelessWidget {
 
   void _addHonooActions(List<ResponsiveFooterAction> actions, Honoo honoo) {
     final isPersonal = honoo.type == HonooType.personal;
-    final hasReplies = honoo.hasReplies == true;
     final isFromMoonSaved = honoo.isFromMoonSaved == true;
-    final isOnMoon = honoo.isOnMoon == true;
     final selectedEntryToPublish = _selectedEntryToPublish(honoo);
+    final isMine = _isMine(honoo.userId);
 
-    if (isPersonal &&
-        !hasReplies &&
-        !isFromMoonSaved &&
-        !isOnMoon &&
-        selectedEntryToPublish == null) {
+    if (selectedConversationEntry == null &&
+        isPersonal &&
+        isMine &&
+        !isFromMoonSaved) {
       actions.add(_moonAction(() => onSendHonooToMoon(honoo)));
     } else if (isFromMoonSaved) {
       actions.add(_replyAction(() => onReplyToHonoo(honoo)));
@@ -107,11 +105,15 @@ class ChestFooter extends StatelessWidget {
     actions.add(_deleteAction(() => onDeleteHonoo(honoo)));
 
     if (selectedEntryToPublish != null) {
-      actions.add(
-        _moonAction(
-          () => onSendConversationEntryToMoon(selectedEntryToPublish),
-        ),
-      );
+      if (selectedEntryToPublish.id == honoo.dbId) {
+        actions.add(_moonAction(() => onSendHonooToMoon(honoo)));
+      } else {
+        actions.add(
+          _moonAction(
+            () => onSendConversationEntryToMoon(selectedEntryToPublish),
+          ),
+        );
+      }
     }
   }
 
@@ -124,15 +126,15 @@ class ChestFooter extends StatelessWidget {
         entry.kind == ConversationEntryKind.deleted) {
       return null;
     }
-    final isMine =
-        entry.ownerId != null &&
-        currentUserId != null &&
-        entry.ownerId == currentUserId;
+    final isMine = _isMine(entry.ownerId);
     final isPersonalEntry = entry.kind == ConversationEntryKind.honoo
         ? entry.honoo!.type == HonooType.personal
         : entry.hinoo!.type == HinooType.personal;
     return isMine && isPersonalEntry && !entry.isFromMoonSaved ? entry : null;
   }
+
+  bool _isMine(String? ownerId) =>
+      ownerId != null && currentUserId != null && ownerId == currentUserId;
 
   bool _canReplyTo(ConversationEntry? entry) =>
       entry != null &&
@@ -146,12 +148,45 @@ class ChestFooter extends StatelessWidget {
   ) {
     final isPersonal = hinoo.draft.type == HinooType.personal;
     final isFromMoonSaved = hinoo.isFromMoonSaved;
-    if (isPersonal && !isFromMoonSaved && !hinoo.isOnMoon) {
+    final selectedEntryToPublish = _selectedEntryToPublishForHinoo(hinoo);
+    if (selectedConversationEntry == null &&
+        isPersonal &&
+        _isMine(hinoo.ownerId) &&
+        !isFromMoonSaved) {
       actions.add(_moonAction(() => onSendHinooToMoon(hinoo)));
     } else if (isFromMoonSaved) {
       actions.add(_replyAction(() => onReplyToHinoo(hinoo)));
     }
     actions.add(_deleteAction(() => onDeleteHinoo(hinoo)));
+
+    if (selectedEntryToPublish != null) {
+      if (selectedEntryToPublish.id == hinoo.id) {
+        actions.add(_moonAction(() => onSendHinooToMoon(hinoo)));
+      } else {
+        actions.add(
+          _moonAction(
+            () => onSendConversationEntryToMoon(selectedEntryToPublish),
+          ),
+        );
+      }
+    }
+  }
+
+  ConversationEntry? _selectedEntryToPublishForHinoo(ChestHinooItem hinoo) {
+    final entry = selectedConversationEntry;
+    final conversationId = hinoo.conversationId ?? hinoo.draft.conversationId;
+    if (entry == null ||
+        conversationId == null ||
+        conversationId.isEmpty ||
+        entry.kind == ConversationEntryKind.deleted) {
+      return null;
+    }
+    final isPersonalEntry = entry.kind == ConversationEntryKind.honoo
+        ? entry.honoo!.type == HonooType.personal
+        : entry.hinoo!.type == HinooType.personal;
+    return _isMine(entry.ownerId) && isPersonalEntry && !entry.isFromMoonSaved
+        ? entry
+        : null;
   }
 
   ResponsiveFooterAction _moonAction(VoidCallback onPressed) => _action(

--- a/lib/Widgets/honoo_dialogs.dart
+++ b/lib/Widgets/honoo_dialogs.dart
@@ -303,3 +303,19 @@ Future<bool?> showHonooDeleteDialog(
     ),
   );
 }
+
+Future<bool?> showRepeatMoonPublicationDialog(
+  BuildContext context, {
+  required String contentName,
+}) {
+  return showDialog<bool>(
+    context: context,
+    barrierDismissible: true,
+    builder: (_) => HonooConfirmDialog(
+      title:
+          'Questo $contentName è già presente sulla Luna, vuoi inviarlo di nuovo?',
+      confirmLabel: 'Sì',
+      cancelLabel: 'No',
+    ),
+  );
+}

--- a/supabase/migrations/20260816120000_allow_repeat_moon_publications.sql
+++ b/supabase/migrations/20260816120000_allow_repeat_moon_publications.sql
@@ -1,0 +1,70 @@
+-- La stessa composizione personale può essere pubblicata sulla Luna più volte.
+-- La deduplica resta attiva solo nello Scrigno, dove salvare ripetutamente una
+-- copia proveniente dalla Luna deve continuare a produrre un solo elemento.
+create extension if not exists pgcrypto with schema extensions;
+
+drop index if exists public.honoo_user_destination_fingerprint_sha256_key;
+drop index if exists public.hinoo_user_type_fingerprint_sha256_key;
+
+do $$
+declare
+  crypto_schema text;
+begin
+  select namespace.nspname
+  into strict crypto_schema
+  from pg_extension as extension
+  join pg_namespace as namespace
+    on namespace.oid = extension.extnamespace
+  where extension.extname = 'pgcrypto';
+
+  execute format(
+    $index$
+      create unique index if not exists honoo_user_chest_fingerprint_sha256_key
+        on public.honoo (
+          user_id,
+          %I.digest(fingerprint, 'sha256')
+        )
+        where fingerprint is not null
+          and destination = 'chest'
+    $index$,
+    crypto_schema
+  );
+
+  execute format(
+    $index$
+      create unique index if not exists hinoo_user_personal_fingerprint_sha256_key
+        on public.hinoo (
+          user_id,
+          %I.digest(fingerprint, 'sha256')
+        )
+        where fingerprint is not null
+          and type = 'personal'
+    $index$,
+    crypto_schema
+  );
+end;
+$$;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_index
+    where indexrelid = 'public.honoo_user_chest_fingerprint_sha256_key'::regclass
+      and indisvalid
+      and indisunique
+  ) then
+    raise exception 'Honoo chest SHA-256 fingerprint index is not valid';
+  end if;
+
+  if not exists (
+    select 1
+    from pg_index
+    where indexrelid = 'public.hinoo_user_personal_fingerprint_sha256_key'::regclass
+      and indisvalid
+      and indisunique
+  ) then
+    raise exception 'Hinoo personal SHA-256 fingerprint index is not valid';
+  end if;
+end;
+$$;

--- a/test/services/honoo_service_test.dart
+++ b/test/services/honoo_service_test.dart
@@ -6,6 +6,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 import 'package:honoo/Services/honoo_service.dart';
+import 'package:honoo/Services/duplication_result.dart';
 import 'package:honoo/Entities/honoo.dart';
 
 class _MockQueryChain extends Mock
@@ -32,10 +33,19 @@ class _MockQueryChain extends Mock
 
 class _MockSupabaseClient extends Mock implements SupabaseClient {}
 
+class _MockAuth extends Mock implements GoTrueClient {}
+
+class _MockSession extends Mock implements Session {}
+
+class _MockUser extends Mock implements User {}
+
 void main() {
   late _MockSupabaseClient client;
   late _MockQueryChain chain;
   late _MockQueryChain hiddenConversations;
+  late _MockAuth auth;
+  late _MockSession session;
+  late _MockUser user;
 
   setUpAll(() {
     registerFallbackValue(<String, dynamic>{});
@@ -45,8 +55,15 @@ void main() {
     client = _MockSupabaseClient();
     chain = _MockQueryChain();
     hiddenConversations = _MockQueryChain();
+    auth = _MockAuth();
+    session = _MockSession();
+    user = _MockUser();
 
     HonooService.$setTestClient(client);
+    when(() => client.auth).thenReturn(auth);
+    when(() => auth.currentSession).thenReturn(session);
+    when(() => session.user).thenReturn(user);
+    when(() => user.id).thenReturn('user-1');
     when(() => client.from('honoo')).thenAnswer((_) => chain);
     when(
       () => client.from('chest_hidden_conversations'),
@@ -244,5 +261,26 @@ void main() {
 
     await expectLater(HonooService.duplicateToMoon(honoo), throwsArgumentError);
     verifyNever(() => client.from('honoo'));
+  });
+
+  test('duplicateToMoon inserisce una nuova riga a ogni invio', () async {
+    final honoo = Honoo(
+      1,
+      'testo',
+      '',
+      '2024-01-01T00:00:00Z',
+      '2024-01-01T00:00:00Z',
+      'user-1',
+      HonooType.personal,
+    );
+    chain.queueResponse(<String, dynamic>{});
+    chain.queueResponse(<String, dynamic>{});
+
+    final first = await HonooService.duplicateToMoon(honoo);
+    final second = await HonooService.duplicateToMoon(honoo);
+
+    expect(first, DuplicationResult.inserted);
+    expect(second, DuplicationResult.inserted);
+    verify(() => chain.insert(any())).called(2);
   });
 }

--- a/test/services/honoo_service_update_duplicate_test.dart
+++ b/test/services/honoo_service_update_duplicate_test.dart
@@ -83,42 +83,47 @@ void main() {
 
   group('HinooService.duplicateToMoon', () {
     HinooDraft sampleDraft() => const HinooDraft(
-          pages: [
-            HinooSlide(
-              text: 'Testo',
-              backgroundImage: null,
-              isTextWhite: true,
-              bgScale: 1.0,
-              bgOffsetX: 0,
-              bgOffsetY: 0,
-            ),
-          ],
-          type: HinooType.personal,
-          recipientTag: null,
+      pages: [
+        HinooSlide(
+          text: 'Testo',
+          backgroundImage: null,
+          isTextWhite: true,
+          bgScale: 1.0,
+          bgOffsetX: 0,
+          bgOffsetY: 0,
+        ),
+      ],
+      type: HinooType.personal,
+      recipientTag: null,
+    );
+
+    test(
+      'il conflitto univoco atomico viene riconosciuto come duplicato',
+      () async {
+        chain.queueError(
+          const PostgrestException(message: 'duplicate', code: '23505'),
         );
 
-    test('il conflitto univoco atomico viene riconosciuto come duplicato',
-        () async {
-      chain.queueError(
-        const PostgrestException(message: 'duplicate', code: '23505'),
-      );
+        final res = await HinooService.duplicateToMoon(sampleDraft());
 
-      final res = await HinooService.duplicateToMoon(sampleDraft());
+        expect(res, DuplicationResult.alreadyPresent);
+        verify(() => client.from('hinoo')).called(1);
+        verify(() => chain.insert(any())).called(1);
+        verifyNever(() => chain.select(any()));
+      },
+    );
 
-      expect(res, DuplicationResult.alreadyPresent);
-      verify(() => client.from('hinoo')).called(1);
-      verify(() => chain.insert(any())).called(1);
-      verifyNever(() => chain.select(any()));
-    });
-
-    test('senza conflitto inserisce e ritorna inserted', () async {
+    test('due invii consecutivi creano due copie sulla Luna', () async {
+      chain.queueResponse(<String, dynamic>{});
       chain.queueResponse(<String, dynamic>{});
 
-      final res = await HinooService.duplicateToMoon(sampleDraft());
+      final first = await HinooService.duplicateToMoon(sampleDraft());
+      final second = await HinooService.duplicateToMoon(sampleDraft());
 
-      expect(res, DuplicationResult.inserted);
-      verify(() => client.from('hinoo')).called(1);
-      verify(() => chain.insert(any())).called(1);
+      expect(first, DuplicationResult.inserted);
+      expect(second, DuplicationResult.inserted);
+      verify(() => client.from('hinoo')).called(2);
+      verify(() => chain.insert(any())).called(2);
       verifyNever(() => chain.select(any()));
     });
 

--- a/test/widgets/chest_footer_test.dart
+++ b/test/widgets/chest_footer_test.dart
@@ -15,6 +15,7 @@ void main() {
     bool isFromMoonSaved = false,
     bool hasReplies = false,
     String? conversationId,
+    String? ownerId,
   }) {
     final honoo =
         Honoo(
@@ -23,7 +24,8 @@ void main() {
             '',
             '2026-01-01T00:00:00Z',
             '2026-01-01T00:00:00Z',
-            type == HonooType.answer ? 'another-user' : 'current-user',
+            ownerId ??
+                (type == HonooType.answer ? 'another-user' : 'current-user'),
             type,
           )
           ..isOnMoon = isOnMoon
@@ -33,25 +35,24 @@ void main() {
     return ChestItem.honoo(honoo, DateTime.utc(2026));
   }
 
-  ChestItem hinooItem({bool isOnMoon = false, bool isFromMoonSaved = false}) =>
-      ChestItem.hinoo(
-        ChestHinooItem(
-          id: 'hinoo-1',
-          draft: const HinooDraft(
-            pages: [
-              HinooSlide(
-                backgroundImage: null,
-                text: 'Test',
-                isTextWhite: true,
-              ),
-            ],
-          ),
-          createdAt: DateTime.utc(2026),
-          isFromMoonSaved: isFromMoonSaved,
-          ownerId: 'current-user',
-          isOnMoon: isOnMoon,
-        ),
-      );
+  ChestItem hinooItem({
+    bool isOnMoon = false,
+    bool isFromMoonSaved = false,
+    String ownerId = 'current-user',
+  }) => ChestItem.hinoo(
+    ChestHinooItem(
+      id: 'hinoo-1',
+      draft: const HinooDraft(
+        pages: [
+          HinooSlide(backgroundImage: null, text: 'Test', isTextWhite: true),
+        ],
+      ),
+      createdAt: DateTime.utc(2026),
+      isFromMoonSaved: isFromMoonSaved,
+      ownerId: ownerId,
+      isOnMoon: isOnMoon,
+    ),
+  );
 
   Future<void> pumpFooter(
     WidgetTester tester, {
@@ -139,7 +140,7 @@ void main() {
     );
   });
 
-  testWidgets('non aggiunge una finta seconda azione per vedere le risposte', (
+  testWidgets('un Honoo personale con risposte conserva l’azione Luna', (
     tester,
   ) async {
     await pumpFooter(
@@ -149,7 +150,8 @@ void main() {
 
     expect(find.byTooltip('Vedi risposte'), findsNothing);
     expect(find.byTooltip('Rispondi'), findsNothing);
-    expect(find.byType(IconButton), findsNWidgets(3));
+    expect(find.byTooltip('Spedisci sulla Luna'), findsOneWidget);
+    expect(find.byType(IconButton), findsNWidgets(4));
   });
 
   testWidgets('Honoo personale mostra Luna e Cancella e inoltra le azioni', (
@@ -192,7 +194,7 @@ void main() {
     expect(deleted, isTrue);
   });
 
-  testWidgets('Honoo già sulla Luna non mostra una seconda azione Luna', (
+  testWidgets('Honoo già sulla Luna continua a mostrare l’azione Luna', (
     tester,
   ) async {
     await pumpFooter(
@@ -200,7 +202,7 @@ void main() {
       item: honooItem(HonooType.personal, isOnMoon: true),
     );
 
-    expect(find.byTooltip('Spedisci sulla Luna'), findsNothing);
+    expect(find.byTooltip('Spedisci sulla Luna'), findsOneWidget);
     expect(find.byTooltip('Cancella'), findsOneWidget);
   });
 
@@ -216,6 +218,17 @@ void main() {
     expect(find.byTooltip('Rispondi'), findsOneWidget);
   });
 
+  testWidgets('Honoo personale di un altro utente non mostra Luna', (
+    tester,
+  ) async {
+    await pumpFooter(
+      tester,
+      item: honooItem(HonooType.personal, ownerId: 'another-user'),
+    );
+
+    expect(find.byTooltip('Spedisci sulla Luna'), findsNothing);
+  });
+
   testWidgets(
     'la selezione del padre della conversazione mostra una sola azione Luna',
     (tester) async {
@@ -225,19 +238,19 @@ void main() {
       );
       item.honoo!.dbId = 'root-1';
       final selectedEntry = ConversationEntry.honoo(item.honoo!);
-      ConversationEntry? publishedEntry;
+      Honoo? publishedHonoo;
 
       await pumpFooter(
         tester,
         item: item,
         selectedConversationEntry: selectedEntry,
-        onSendConversationEntryToMoon: (entry) => publishedEntry = entry,
+        onSendHonooToMoon: (honoo) => publishedHonoo = honoo,
       );
 
       expect(find.byTooltip('Spedisci sulla Luna'), findsOneWidget);
       expect(find.byTooltip('Rispondi'), findsOneWidget);
       await tester.tap(find.byTooltip('Spedisci sulla Luna'));
-      expect(publishedEntry, same(selectedEntry));
+      expect(publishedHonoo, same(item.honoo));
     },
   );
 
@@ -361,12 +374,12 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
-  testWidgets('Hinoo già sulla Luna non mostra una seconda azione Luna', (
+  testWidgets('Hinoo già sulla Luna continua a mostrare l’azione Luna', (
     tester,
   ) async {
     await pumpFooter(tester, item: hinooItem(isOnMoon: true));
 
-    expect(find.byTooltip('Spedisci sulla Luna'), findsNothing);
+    expect(find.byTooltip('Spedisci sulla Luna'), findsOneWidget);
     expect(find.byTooltip('Cancella'), findsOneWidget);
   });
 
@@ -377,6 +390,14 @@ void main() {
 
     expect(find.byTooltip('Spedisci sulla Luna'), findsNothing);
     expect(find.byTooltip('Rispondi'), findsOneWidget);
+  });
+
+  testWidgets('Hinoo personale di un altro utente non mostra Luna', (
+    tester,
+  ) async {
+    await pumpFooter(tester, item: hinooItem(ownerId: 'another-user'));
+
+    expect(find.byTooltip('Spedisci sulla Luna'), findsNothing);
   });
 
   testWidgets('contenuto ricevuto mostra solo Home, Info e Cancella', (

--- a/test/widgets/honoo_dialogs_test.dart
+++ b/test/widgets/honoo_dialogs_test.dart
@@ -23,4 +23,40 @@ void main() {
     expect(find.text('Titolo.'), findsNothing);
     expect(find.text('Messaggio conclusivo.'), findsNothing);
   });
+
+  testWidgets('la ripubblicazione sulla Luna richiede una scelta Sì o No', (
+    tester,
+  ) async {
+    bool? result;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (context) => TextButton(
+            onPressed: () async {
+              result = await showRepeatMoonPublicationDialog(
+                context,
+                contentName: 'honoo',
+              );
+            },
+            child: const Text('Apri'),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Apri'));
+    await tester.pumpAndSettle();
+    expect(
+      find.text(
+        'Questo honoo è già presente sulla Luna, vuoi inviarlo di nuovo?',
+      ),
+      findsOneWidget,
+    );
+    expect(find.text('Sì'), findsOneWidget);
+    expect(find.text('No'), findsOneWidget);
+
+    await tester.tap(find.text('Sì'));
+    await tester.pumpAndSettle();
+    expect(result, isTrue);
+  });
 }


### PR DESCRIPTION
## Cosa cambia
- mostra sempre l'azione Luna per Honoo e Hinoo personali del proprietario, anche se già pubblicati o con risposte
- chiede conferma Sì/No prima di ripubblicare un contenuto già presente sulla Luna
- mantiene escluse risposte ricevute e copie salvate dalla Luna
- consente più righe Luna con lo stesso fingerprint, mantenendo la deduplica nello Scrigno
- conserva l'ordinamento del feed per data di arrivo decrescente

## Verifiche
- fvm flutter test --no-pub --reporter compact: 351 superati, 7 live saltati
- test mirati toolbar, dialoghi, servizi e rendering Hinoo: 34 superati
- fvm flutter analyze --no-pub
- git diff --check

## Nota Supabase
Il lint DB locale non era disponibile perché lo stack Supabase non era attivo su 127.0.0.1:54322. La migrazione usa lo stesso schema di indici SHA-256 della migrazione precedente e ne verifica validità e unicità.