### PR TITLE
Fix chest thread display and Moon actions

### DIFF
--- a/lib/Pages/chest_page.dart
+++ b/lib/Pages/chest_page.dart
@@ -8,6 +8,8 @@ import 'package:honoo/Services/chest_repository.dart';
 import 'package:honoo/Services/download_capture_service.dart';
 import 'package:honoo/Services/chest_hint_service.dart';
 import 'package:honoo/Services/duplication_result.dart';
+import 'package:honoo/Services/hinoo_service.dart';
+import 'package:honoo/Services/honoo_service.dart';
 import 'package:honoo/Services/reply_system_notification.dart';
 import 'package:honoo/Services/auth_navigation_service.dart';
 
@@ -708,7 +710,18 @@ class _ChestPageState extends State<ChestPage> with WidgetsBindingObserver {
     setState(() => _isMutating = true);
     try {
       if (entry.kind == ConversationEntryKind.honoo) {
-        final result = await HonooController().sendToMoon(entry.honoo!);
+        final honoo = entry.honoo!;
+        final alreadyOnMoon =
+            honoo.isOnMoon || await HonooService.hasMoonCopy(honoo);
+        if (!mounted) return;
+        if (alreadyOnMoon) {
+          final confirmed = await showRepeatMoonPublicationDialog(
+            context,
+            contentName: 'honoo',
+          );
+          if (!mounted || confirmed != true) return;
+        }
+        final result = await HonooController().sendToMoon(honoo);
         if (!mounted) return;
         showHonooToast(
           context,
@@ -717,7 +730,17 @@ class _ChestPageState extends State<ChestPage> with WidgetsBindingObserver {
               : "L'honoo era già presente sulla Luna.",
         );
       } else {
-        final result = await _hinooController.sendToMoon(entry.hinoo!);
+        final hinoo = entry.hinoo!;
+        final alreadyOnMoon = await HinooService.hasMoonCopy(hinoo);
+        if (!mounted) return;
+        if (alreadyOnMoon) {
+          final confirmed = await showRepeatMoonPublicationDialog(
+            context,
+            contentName: 'hinoo',
+          );
+          if (!mounted || confirmed != true) return;
+        }
+        final result = await _hinooController.sendToMoon(hinoo);
         if (!mounted) return;
         final text = result == HinooMoonResult.published
             ? "L'hinoo è anche sulla Luna."

--- a/lib/Services/hinoo_service.dart
+++ b/lib/Services/hinoo_service.dart
@@ -110,7 +110,11 @@ class HinooService {
     final userId = _client.auth.currentUser?.id;
     if (userId == null) throw 'Utente non autenticato';
 
-    final sanitized = draft.copyWith(type: HinooType.moon);
+    final sanitized = HinooDraft(
+      pages: draft.pages,
+      type: HinooType.moon,
+      baseCanvasHeight: draft.baseCanvasHeight,
+    );
     final fp = fingerprint(sanitized);
 
     final data = {
@@ -118,9 +122,9 @@ class HinooService {
       'type': _toDbType(HinooType.moon),
       'pages': sanitized.toJson()['pages'],
       'fingerprint': fp,
-      'recipient_tag': sanitized.recipientTag,
-      'reply_to': sanitized.replyTo,
-      'is_from_moon_saved': sanitized.isFromMoonSaved,
+      'recipient_tag': null,
+      'reply_to': null,
+      'is_from_moon_saved': false,
       'created_at': DateTime.now().toIso8601String(),
     };
 
@@ -194,6 +198,33 @@ class HinooService {
       if (d.recipientTag != null) 'recipient=${d.recipientTag}',
     ];
     return parts.join('||');
+  }
+
+  static Future<bool> hasMoonCopy(HinooDraft draft) async {
+    final userId = _client.auth.currentUser?.id;
+    if (userId == null) throw 'Utente non autenticato';
+    final sanitized = HinooDraft(
+      pages: draft.pages,
+      type: HinooType.moon,
+      baseCanvasHeight: draft.baseCanvasHeight,
+    );
+    final fingerprints = <String>{
+      fingerprint(sanitized),
+      // Compatibilità con le copie create prima che i riferimenti privati
+      // della conversazione venissero rimossi dalla pubblicazione Luna.
+      fingerprint(draft.copyWith(type: HinooType.moon)),
+    }.toList(growable: false);
+    final row = await _reliability.read(
+      () async => await _client
+          .from(_table)
+          .select('id')
+          .eq('user_id', userId)
+          .eq('type', 'moon')
+          .in_('fingerprint', fingerprints)
+          .limit(1)
+          .maybeSingle(),
+    );
+    return row != null;
   }
 
   static bool _isMissingMoonSavedColumn(PostgrestException e) {

--- a/lib/Services/honoo_service.dart
+++ b/lib/Services/honoo_service.dart
@@ -196,6 +196,22 @@ class HonooService {
 
   static String fingerprint(Honoo h) => '${h.text}\u001f${h.image}';
 
+  static Future<bool> hasMoonCopy(Honoo h) async {
+    final session = _client.auth.currentSession;
+    if (session == null) throw Exception('Nessuna sessione attiva');
+    final row = await _reliability.read(
+      () async => await _client
+          .from('honoo')
+          .select('id')
+          .eq('user_id', session.user.id)
+          .eq('destination', 'moon')
+          .eq('fingerprint', fingerprint(h))
+          .limit(1)
+          .maybeSingle(),
+    );
+    return row != null;
+  }
+
   static Future<DuplicationResult> _insertDuplicate(
     Map<String, dynamic> payload,
   ) {

--- a/lib/UI/unified_thread_view.dart
+++ b/lib/UI/unified_thread_view.dart
@@ -329,8 +329,15 @@ class _UnifiedThreadViewState extends State<UnifiedThreadView>
       final latestReceivedIndex = reversed.indexWhere(_isReceivedReply);
       if (latestReceivedIndex >= 0) return latestReceivedIndex;
     }
-    final receivedIndex = reversed.indexWhere(_shouldReveal);
-    return receivedIndex < 0 ? 0 : receivedIndex;
+    if (widget.preferLatestReceived) {
+      final latestReceivedIndex = reversed.indexWhere(_isReceivedReply);
+      if (latestReceivedIndex >= 0) return latestReceivedIndex;
+    }
+    // Nell'apertura normale la pagina 0 corrisponde sempre al contenuto più
+    // recente, indipendentemente dal fatto che sia una risposta ricevuta, una
+    // risposta inviata o un nuovo contenuto. Solo una notifica esplicita può
+    // spostare il focus su un elemento precedente.
+    return 0;
   }
 
   void _showLatestReceivedAndReveal({bool forceFocus = false}) {
@@ -366,26 +373,19 @@ class _UnifiedThreadViewState extends State<UnifiedThreadView>
         (e.honoo != null && (e.honoo!.isFromMoonSaved == true));
     if (isMoon) return false;
 
-    final bool isReply = e.honoo != null
-        ? (e.honoo!.type == HonooType.answer)
-        : (e.hinoo != null && e.hinoo!.type == HinooType.answer);
+    if (!_isReceivedReply(e)) return false;
 
     final revealEntryId = widget.revealEntryId;
     if (revealEntryId != null && revealEntryId.isNotEmpty) {
-      return isReply && e.id == revealEntryId;
+      return e.id == revealEntryId;
     }
-    if (widget.preferLatestReceived) {
-      final currentUserId =
-          widget.currentUserId ?? Supabase.instance.client.auth.currentUser?.id;
-      if (currentUserId != null && e.ownerId == currentUserId) return false;
-    }
-    return isReply;
+    return true;
   }
 
   bool _isReceivedReply(ConversationEntry entry) {
     if (!_isDisplayableReply(entry)) return false;
     final currentUserId =
-        widget.currentUserId ?? Supabase.instance.client.auth.currentUser?.id;
+        widget.currentUserId ?? SupabaseProvider.client.auth.currentUser?.id;
     return currentUserId == null || entry.ownerId != currentUserId;
   }
 

--- a/lib/Widgets/chest_footer.dart
+++ b/lib/Widgets/chest_footer.dart
@@ -127,10 +127,12 @@ class ChestFooter extends StatelessWidget {
       return null;
     }
     final isMine = _isMine(entry.ownerId);
-    final isPersonalEntry = entry.kind == ConversationEntryKind.honoo
-        ? entry.honoo!.type == HonooType.personal
-        : entry.hinoo!.type == HinooType.personal;
-    return isMine && isPersonalEntry && !entry.isFromMoonSaved ? entry : null;
+    final isPublishableEntry = entry.kind == ConversationEntryKind.honoo
+        ? entry.honoo!.type != HonooType.moon
+        : entry.hinoo!.type != HinooType.moon;
+    return isMine && isPublishableEntry && !entry.isFromMoonSaved
+        ? entry
+        : null;
   }
 
   bool _isMine(String? ownerId) =>
@@ -181,10 +183,12 @@ class ChestFooter extends StatelessWidget {
         entry.kind == ConversationEntryKind.deleted) {
       return null;
     }
-    final isPersonalEntry = entry.kind == ConversationEntryKind.honoo
-        ? entry.honoo!.type == HonooType.personal
-        : entry.hinoo!.type == HinooType.personal;
-    return _isMine(entry.ownerId) && isPersonalEntry && !entry.isFromMoonSaved
+    final isPublishableEntry = entry.kind == ConversationEntryKind.honoo
+        ? entry.honoo!.type != HonooType.moon
+        : entry.hinoo!.type != HinooType.moon;
+    return _isMine(entry.ownerId) &&
+            isPublishableEntry &&
+            !entry.isFromMoonSaved
         ? entry
         : null;
   }

--- a/test/services/honoo_service_test.dart
+++ b/test/services/honoo_service_test.dart
@@ -74,6 +74,8 @@ void main() {
     when(() => chain.delete()).thenAnswer((_) => chain);
     when(() => chain.eq(any(), any())).thenAnswer((_) => chain);
     when(() => chain.in_(any(), any())).thenAnswer((_) => chain);
+    when(() => chain.limit(any())).thenAnswer((_) => chain);
+    when(() => chain.maybeSingle()).thenAnswer((_) => chain);
     when(() => chain.or(any())).thenAnswer((_) => chain);
     when(
       () => chain.order(any(), ascending: any(named: 'ascending')),
@@ -282,5 +284,26 @@ void main() {
     expect(first, DuplicationResult.inserted);
     expect(second, DuplicationResult.inserted);
     verify(() => chain.insert(any())).called(2);
+  });
+
+  test('hasMoonCopy riconosce una pubblicazione Honoo precedente', () async {
+    final honoo = Honoo(
+      1,
+      'testo',
+      '',
+      '2024-01-01T00:00:00Z',
+      '2024-01-01T00:00:00Z',
+      'user-1',
+      HonooType.answer,
+    );
+    chain.queueResponse(<String, dynamic>{'id': 'moon-1'});
+
+    expect(await HonooService.hasMoonCopy(honoo), isTrue);
+
+    verify(() => chain.eq('user_id', 'user-1')).called(1);
+    verify(() => chain.eq('destination', 'moon')).called(1);
+    verify(
+      () => chain.eq('fingerprint', HonooService.fingerprint(honoo)),
+    ).called(1);
   });
 }

--- a/test/services/honoo_service_update_duplicate_test.dart
+++ b/test/services/honoo_service_update_duplicate_test.dart
@@ -69,6 +69,7 @@ void main() {
 
     when(() => chain.select(any())).thenAnswer((_) => chain);
     when(() => chain.eq(any(), any())).thenAnswer((_) => chain);
+    when(() => chain.in_(any(), any())).thenAnswer((_) => chain);
     when(() => chain.limit(any())).thenAnswer((_) => chain);
     when(() => chain.insert(any())).thenAnswer((_) => chain);
     when(() => chain.maybeSingle()).thenAnswer((_) => chain);
@@ -136,5 +137,59 @@ void main() {
       );
       verifyNever(() => client.from('hinoo'));
     });
+
+    test(
+      'una risposta viene pubblicata senza legami con la conversazione',
+      () async {
+        chain.queueResponse(<String, dynamic>{});
+        final reply = sampleDraft().copyWith(
+          type: HinooType.answer,
+          recipientTag: 'destinatario',
+          replyTo: 'parent-1',
+          conversationId: 'conversation-1',
+        );
+
+        final result = await HinooService.duplicateToMoon(reply);
+
+        expect(result, DuplicationResult.inserted);
+        final payload =
+            verify(() => chain.insert(captureAny())).captured.single
+                as Map<String, dynamic>;
+        expect(payload['type'], 'moon');
+        expect(payload['recipient_tag'], isNull);
+        expect(payload['reply_to'], isNull);
+        expect(payload.containsKey('conversation_id'), isFalse);
+        expect(payload['is_from_moon_saved'], isFalse);
+        expect(payload['fingerprint'], isNot(contains('destinatario')));
+      },
+    );
+
+    test(
+      'riconosce anche il fingerprint usato dalle vecchie risposte',
+      () async {
+        chain.queueResponse(<String, dynamic>{'id': 'moon-1'});
+        final reply = sampleDraft().copyWith(
+          type: HinooType.answer,
+          recipientTag: 'destinatario',
+          replyTo: 'parent-1',
+          conversationId: 'conversation-1',
+        );
+
+        expect(await HinooService.hasMoonCopy(reply), isTrue);
+
+        final fingerprints =
+            verify(() => chain.in_('fingerprint', captureAny())).captured.single
+                as List<String>;
+        expect(fingerprints, hasLength(2));
+        expect(
+          fingerprints.any((value) => value.contains('destinatario')),
+          isTrue,
+        );
+        expect(
+          fingerprints.any((value) => !value.contains('destinatario')),
+          isTrue,
+        );
+      },
+    );
   });
 }

--- a/test/widgets/chest_footer_test.dart
+++ b/test/widgets/chest_footer_test.dart
@@ -39,6 +39,7 @@ void main() {
     bool isOnMoon = false,
     bool isFromMoonSaved = false,
     String ownerId = 'current-user',
+    String? conversationId,
   }) => ChestItem.hinoo(
     ChestHinooItem(
       id: 'hinoo-1',
@@ -51,6 +52,7 @@ void main() {
       isFromMoonSaved: isFromMoonSaved,
       ownerId: ownerId,
       isOnMoon: isOnMoon,
+      conversationId: conversationId,
     ),
   );
 
@@ -251,6 +253,81 @@ void main() {
       expect(find.byTooltip('Rispondi'), findsOneWidget);
       await tester.tap(find.byTooltip('Spedisci sulla Luna'));
       expect(publishedHonoo, same(item.honoo));
+    },
+  );
+
+  testWidgets(
+    'una propria risposta Honoo mostra Luna e pubblica la selezione',
+    (tester) async {
+      final item = honooItem(
+        HonooType.personal,
+        conversationId: 'conversation-1',
+      );
+      item.honoo!.dbId = 'root-1';
+      final reply =
+          Honoo(
+              2,
+              'Risposta propria',
+              '',
+              '2026-01-01T01:00:00Z',
+              '2026-01-01T01:00:00Z',
+              'current-user',
+              HonooType.answer,
+            )
+            ..dbId = 'reply-1'
+            ..replyTo = 'root-1'
+            ..conversationId = 'conversation-1';
+      final selectedEntry = ConversationEntry.honoo(reply);
+      ConversationEntry? publishedEntry;
+
+      await pumpFooter(
+        tester,
+        item: item,
+        selectedConversationEntry: selectedEntry,
+        onSendConversationEntryToMoon: (entry) => publishedEntry = entry,
+      );
+
+      expect(find.byTooltip('Spedisci sulla Luna'), findsOneWidget);
+      await tester.tap(find.byTooltip('Spedisci sulla Luna'));
+      expect(publishedEntry, same(selectedEntry));
+    },
+  );
+
+  testWidgets(
+    'una propria risposta Hinoo mostra Luna e pubblica la selezione',
+    (tester) async {
+      final item = hinooItem(conversationId: 'conversation-1');
+      const replyDraft = HinooDraft(
+        pages: [
+          HinooSlide(
+            backgroundImage: null,
+            text: 'Risposta propria',
+            isTextWhite: true,
+          ),
+        ],
+        type: HinooType.answer,
+        recipientTag: 'destinatario',
+        replyTo: 'root-1',
+        conversationId: 'conversation-1',
+      );
+      final selectedEntry = ConversationEntry.hinoo(
+        replyDraft,
+        createdAt: DateTime.utc(2026, 1, 1, 1),
+        ownerId: 'current-user',
+        id: 'reply-hinoo-1',
+      );
+      ConversationEntry? publishedEntry;
+
+      await pumpFooter(
+        tester,
+        item: item,
+        selectedConversationEntry: selectedEntry,
+        onSendConversationEntryToMoon: (entry) => publishedEntry = entry,
+      );
+
+      expect(find.byTooltip('Spedisci sulla Luna'), findsOneWidget);
+      await tester.tap(find.byTooltip('Spedisci sulla Luna'));
+      expect(publishedEntry, same(selectedEntry));
     },
   );
 

--- a/test/widgets/unified_thread_reveal_test.dart
+++ b/test/widgets/unified_thread_reveal_test.dart
@@ -225,7 +225,7 @@ void main() {
     expect(find.byType(PageView), findsNothing);
   });
 
-  testWidgets('una nuova risposta riavvia il reveal dopo il refresh', (
+  testWidgets('una nuova risposta propria resta blu dopo il refresh', (
     tester,
   ) async {
     tester.view.devicePixelRatio = 1;
@@ -289,11 +289,8 @@ void main() {
     await tester.pump(const Duration(milliseconds: 350));
 
     expect(find.text('Seconda risposta appena salvata'), findsOneWidget);
-    final foreground = tester.widget<Transform>(
-      find.byKey(const Key('reply_reveal_foreground')),
-    );
-    expect(foreground.transform.getTranslation().y, lessThan(0));
-    expect(find.byKey(const Key('reply_reveal_parent')), findsOneWidget);
+    expect(find.byKey(const Key('reply_reveal_foreground')), findsNothing);
+    expect(find.byKey(const Key('reply_reveal_parent')), findsNothing);
   });
 
   testWidgets('lo swipe resta sulla pagina scelta dopo il rebuild del padre', (
@@ -780,10 +777,77 @@ void main() {
 
         expect(explicitSemanticsLabel('Risposta inviata'), findsOneWidget);
         expect(borderWithColor(HonooColor.secondary), findsNothing);
-        expect(find.byKey(const Key('reply_reveal_parent')), findsOneWidget);
+        expect(find.byKey(const Key('reply_reveal_parent')), findsNothing);
       },
     );
   }
+
+  testWidgets('l’apertura mostra il contenuto più recente anche se è proprio', (
+    tester,
+  ) async {
+    final root = ConversationEntry.honoo(
+      honoo(
+        id: 'root-latest',
+        text: 'Contenuto iniziale',
+        owner: 'other',
+        createdAt: '2026-07-20T10:00:00Z',
+      ),
+    );
+    final receivedReply = ConversationEntry.honoo(
+      honoo(
+        id: 'received-latest',
+        text: 'Risposta ricevuta precedente',
+        owner: 'other',
+        createdAt: '2026-07-20T11:00:00Z',
+        type: HonooType.answer,
+        replyTo: 'root-latest',
+      ),
+    );
+    final latestOwnReply = ConversationEntry.honoo(
+      honoo(
+        id: 'own-latest',
+        text: 'Ultima risposta inviata',
+        owner: 'me',
+        createdAt: '2026-07-20T12:00:00Z',
+        type: HonooType.answer,
+        replyTo: 'received-latest',
+      ),
+    );
+    ConversationEntry? selected;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: UnifiedThreadView(
+            conversationId: 'conversation-latest',
+            maxWidth: 600,
+            maxHeight: 700,
+            isActive: true,
+            currentUserId: 'me',
+            conversationLoader: (_) async => [
+              root,
+              receivedReply,
+              latestOwnReply,
+            ],
+            onSelect: (entry) => selected = entry,
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 350));
+
+    expect(selected?.id, 'own-latest');
+    expect(find.text('Ultima risposta inviata'), findsOneWidget);
+    expect(find.byKey(const Key('reply_reveal_parent')), findsNothing);
+    expect(
+      find.byWidgetPredicate(
+        (widget) =>
+            widget is ColoredBox && widget.color == HonooColor.background,
+      ),
+      findsWidgets,
+    );
+  });
 
   testWidgets('un burst Realtime viene coalesciato in un solo refresh', (
     tester,


### PR DESCRIPTION
## Riepilogo
- mostra per prima l'ultima voce della conversazione nelle aperture normali, mantenendo il focus sulle risposte ricevute quando si arriva da una notifica
- mantiene interamente blu le risposte proprie ed evita l'animazione del contenuto padre che causava fasce rosse o bianche
- mostra l'azione Luna per Honoo e Hinoo propri, comprese le risposte, escludendo contenuti altrui e salvati dalla Luna
- chiede conferma prima di ripubblicare un contenuto già presente sulla Luna e permette invii ripetuti
- scollega le copie Hinoo pubblicate dai riferimenti privati della conversazione, così vengono visualizzate sulla Luna in ordine di arrivo

## Verifiche
- flutter analyze --no-pub
- flutter test --no-pub (357 test superati, 7 test live saltati per configurazione assente)
- git diff --check