### PR TITLE
Fix conversation realtime ordering

### DIFF
--- a/lib/Controller/chest_controller.dart
+++ b/lib/Controller/chest_controller.dart
@@ -417,6 +417,11 @@ class ChestController extends ValueNotifier<ChestState> {
       final hinooLatest = <String, DateTime>{};
       final hinooLatestReceived = <String, DateTime>{};
       final hinooReplies = <String, List<HinooThreadEntry>>{};
+      final hinooRootByConversation = <String, String>{
+        for (final item in value.hinoo)
+          if ((item.conversationId ?? '').isNotEmpty)
+            item.conversationId!: item.id,
+      };
       final rootIds = value.hinoo.map((item) => item.id).toList();
       final rows = await _reliability.refresh<List<dynamic>>(
         () => _repository.fetchHinooReplyRows(userId, rootIds),
@@ -430,11 +435,14 @@ class ChestController extends ValueNotifier<ChestState> {
       for (final row in rows.whereType<Map>()) {
         final id = row['id']?.toString() ?? '';
         if (id.isNotEmpty && !seenHinooIds.add(id)) continue;
-        final rootId = row['reply_to']?.toString() ?? '';
+        final storedRootId = row['reply_to']?.toString() ?? '';
         final conversationId = row['conversation_id']?.toString() ?? '';
+        final rootId = storedRootId.isNotEmpty
+            ? storedRootId
+            : hinooRootByConversation[conversationId] ?? '';
         final activityKey = conversationId.isNotEmpty ? conversationId : rootId;
         final pages = row['pages'];
-        if (rootId.isEmpty || pages is! List) continue;
+        if (activityKey.isEmpty || pages is! List) continue;
         final created =
             DateTime.tryParse((row['created_at'] ?? '').toString()) ??
             DateTime.fromMillisecondsSinceEpoch(0);
@@ -445,18 +453,20 @@ class ChestController extends ValueNotifier<ChestState> {
               .toList(),
           type: HinooType.answer,
           recipientTag: row['recipient_tag'] as String?,
-          replyTo: rootId,
+          replyTo: rootId.isEmpty ? null : rootId,
         );
-        hinooReplies
-            .putIfAbsent(rootId, () => <HinooThreadEntry>[])
-            .add(
-              HinooThreadEntry(
-                draft: draft,
-                authorId: row['user_id']?.toString(),
-                isReply: true,
-                createdAt: created,
-              ),
-            );
+        if (rootId.isNotEmpty) {
+          hinooReplies
+              .putIfAbsent(rootId, () => <HinooThreadEntry>[])
+              .add(
+                HinooThreadEntry(
+                  draft: draft,
+                  authorId: row['user_id']?.toString(),
+                  isReply: true,
+                  createdAt: created,
+                ),
+              );
+        }
         final existing = hinooLatest[activityKey];
         if (existing == null || created.isAfter(existing)) {
           hinooLatest[activityKey] = created;

--- a/lib/Services/chest_repository.dart
+++ b/lib/Services/chest_repository.dart
@@ -108,7 +108,9 @@ class ChestRepository {
         .select(
           'id,conversation_id,reply_to,pages,type,recipient_tag,created_at,user_id',
         )
-        .eq('type', 'answer')
+        .or(
+          'type.eq.answer,and(conversation_id.not.is.null,recipient_tag.not.is.null)',
+        )
         .eq('recipient_tag', userId)
         .order('created_at', ascending: true);
     final repliesFromUser = await _client
@@ -116,7 +118,9 @@ class ChestRepository {
         .select(
           'id,conversation_id,reply_to,pages,type,recipient_tag,created_at,user_id',
         )
-        .eq('type', 'answer')
+        .or(
+          'type.eq.answer,and(conversation_id.not.is.null,recipient_tag.not.is.null)',
+        )
         .eq('user_id', userId)
         .order('created_at', ascending: true);
     return _withoutHiddenConversations([

--- a/lib/Services/conversation_service.dart
+++ b/lib/Services/conversation_service.dart
@@ -279,6 +279,16 @@ class ConversationService {
           ),
           refresh,
         )
+        .on(
+          RealtimeListenTypes.postgresChanges,
+          ChannelFilter(
+            event: '*',
+            schema: 'public',
+            table: 'conversation_tombstones',
+            filter: 'conversation_id=eq.$conversationId',
+          ),
+          refresh,
+        )
         .subscribe((status, [error]) {
           if (status == 'SUBSCRIBED') {
             onStatus?.call(

--- a/lib/Services/hinoo_service.dart
+++ b/lib/Services/hinoo_service.dart
@@ -53,7 +53,6 @@ class HinooService {
       'conversation_id': draft.conversationId,
       'is_from_moon_saved': draft.isFromMoonSaved,
       'fingerprint': (draft.type == HinooType.moon) ? fingerprint(draft) : null,
-      'created_at': DateTime.now().toIso8601String(),
     };
 
     final res = await _insertPublished(data);
@@ -74,7 +73,6 @@ class HinooService {
       'conversation_id': draft.conversationId,
       'is_from_moon_saved': draft.isFromMoonSaved,
       'fingerprint': (draft.type == HinooType.moon) ? fingerprint(draft) : null,
-      'created_at': DateTime.now().toIso8601String(),
     };
 
     final res = await _insertPublished(data);
@@ -125,7 +123,6 @@ class HinooService {
       'recipient_tag': null,
       'reply_to': null,
       'is_from_moon_saved': false,
-      'created_at': DateTime.now().toIso8601String(),
     };
 
     return _insertDuplicate(data);
@@ -152,7 +149,6 @@ class HinooService {
       'conversation_id': sanitized.conversationId,
       'is_from_moon_saved': true,
       'fingerprint': fp,
-      'created_at': DateTime.now().toIso8601String(),
     };
 
     return _insertDuplicate(data);

--- a/lib/UI/unified_thread_view.dart
+++ b/lib/UI/unified_thread_view.dart
@@ -217,6 +217,10 @@ class _UnifiedThreadViewState extends State<UnifiedThreadView>
     final generation = ++_loadGeneration;
     final conversationId = widget.conversationId;
     final pageBeforeLoad = _currentPageIndex;
+    final selectedEntryBeforeLoad =
+        pageBeforeLoad > 0 && pageBeforeLoad < _entries.length
+        ? _entries.reversed.elementAt(pageBeforeLoad)
+        : null;
     if (_entries.isEmpty) {
       setState(() => _loading = true);
     }
@@ -241,10 +245,28 @@ class _UnifiedThreadViewState extends State<UnifiedThreadView>
       _showLatestReceivedAndReveal(forceFocus: wasEmpty);
       if (widget.isActive && _entries.isNotEmpty) {
         final hasExplicitReveal = (widget.revealEntryId ?? '').isNotEmpty;
-        final selectedPage = (wasEmpty || hasExplicitReveal)
+        final reversed = _entries.reversed.toList(growable: false);
+        var selectedPage = (wasEmpty || hasExplicitReveal)
             ? _pageToShowFirst
             : pageBeforeLoad.clamp(0, _entries.length - 1);
-        widget.onSelect?.call(_entries.reversed.elementAt(selectedPage));
+        if (!wasEmpty &&
+            !hasExplicitReveal &&
+            selectedEntryBeforeLoad != null) {
+          final preservedPage = reversed.indexWhere(
+            (entry) =>
+                entry.kind == selectedEntryBeforeLoad.kind &&
+                entry.id == selectedEntryBeforeLoad.id,
+          );
+          if (preservedPage >= 0) selectedPage = preservedPage;
+        }
+        if (selectedPage != pageBeforeLoad) {
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            if (!mounted || !_pageController.hasClients) return;
+            _pageController.jumpToPage(selectedPage);
+            _currentPageIndex = selectedPage;
+          });
+        }
+        widget.onSelect?.call(reversed[selectedPage]);
       }
     } catch (error) {
       if (!mounted ||

--- a/supabase/migrations/20260816203000_enable_conversation_tombstones_realtime.sql
+++ b/supabase/migrations/20260816203000_enable_conversation_tombstones_realtime.sql
@@ -1,0 +1,15 @@
+-- Keep deleted-content placeholders in sync without waiting for client polling.
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_publication_tables
+    where pubname = 'supabase_realtime'
+      and schemaname = 'public'
+      and tablename = 'conversation_tombstones'
+  ) then
+    alter publication supabase_realtime
+      add table public.conversation_tombstones;
+  end if;
+end
+$$;

--- a/test/controllers/chest_controller_test.dart
+++ b/test/controllers/chest_controller_test.dart
@@ -199,6 +199,84 @@ void main() {
   });
 
   test(
+    'loadReplies collega una risposta Hinoo legacy tramite conversation_id',
+    () async {
+      when(() => repository.fetchHinooRows('user-1')).thenAnswer(
+        (_) async => [
+          {
+            'id': 'hinoo-root',
+            'conversation_id': 'legacy-conversation',
+            'pages': [
+              <String, dynamic>{
+                'backgroundImage': 'root.png',
+                'text': 'Radice',
+                'isTextWhite': true,
+              },
+            ],
+            'type': 'personal',
+            'created_at': '2024-01-01T10:00:00Z',
+            'user_id': 'user-1',
+          },
+        ],
+      );
+      when(
+        () => repository.fetchHinooMoonFingerprints('user-1'),
+      ).thenAnswer((_) async => const {});
+      when(
+        () => repository.fetchHonooReplyRows('user-1'),
+      ).thenAnswer((_) async => const []);
+      when(
+        () => repository.fetchHinooReplyRows('user-1', ['hinoo-root']),
+      ).thenAnswer(
+        (_) async => [
+          {
+            'id': 'legacy-reply',
+            'conversation_id': 'legacy-conversation',
+            'reply_to': null,
+            'recipient_tag': 'user-1',
+            'created_at': '2024-01-01T11:00:00Z',
+            'user_id': 'user-2',
+            'pages': [
+              <String, dynamic>{
+                'backgroundImage': 'reply.png',
+                'text': 'Risposta legacy',
+                'isTextWhite': true,
+              },
+            ],
+          },
+        ],
+      );
+
+      await controller.loadHinoo('user-1');
+      await controller.loadReplies('user-1');
+
+      expect(
+        controller.value.hinooLatestReplies['legacy-conversation'],
+        DateTime.parse('2024-01-01T11:00:00Z'),
+      );
+      expect(
+        controller.value.hinooLatestReceivedReplies['legacy-conversation'],
+        DateTime.parse('2024-01-01T11:00:00Z'),
+      );
+      expect(
+        controller
+            .value
+            .hinooRepliesByRoot['hinoo-root']!
+            .single
+            .draft
+            .pages
+            .single
+            .text,
+        'Risposta legacy',
+      );
+      expect(
+        controller.value.hinooRepliesByRoot['hinoo-root']!.single.draft.replyTo,
+        'hinoo-root',
+      );
+    },
+  );
+
+  test(
     'un errore conserva i dati precedenti e termina il caricamento',
     () async {
       when(

--- a/test/services/chest_repository_test.dart
+++ b/test/services/chest_repository_test.dart
@@ -109,6 +109,28 @@ void main() {
     },
   );
 
+  test('fetchHinooReplyRows include le risposte legacy senza reply_to', () async {
+    hiddenConversations.queueResponse(<Map<String, dynamic>>[]);
+    hinoo.queueResponse([
+      {'id': 'legacy-received'},
+    ]);
+    hinoo.queueResponse([
+      {'id': 'legacy-sent'},
+    ]);
+
+    final result = await repository.fetchHinooReplyRows('user-1', const []);
+
+    expect(result, [
+      {'id': 'legacy-received'},
+      {'id': 'legacy-sent'},
+    ]);
+    verify(
+      () => hinoo.or(
+        'type.eq.answer,and(conversation_id.not.is.null,recipient_tag.not.is.null)',
+      ),
+    ).called(2);
+  });
+
   test('deleteHinoo elimina esclusivamente la riga indicata', () async {
     hinoo.queueResponse(<String, dynamic>{});
 

--- a/test/services/hinoo_service_reply_test.dart
+++ b/test/services/hinoo_service_reply_test.dart
@@ -90,12 +90,14 @@ void main() {
 
     await HinooService.publishHinoo(draft);
 
-    final captured = verify(() => chain.insert(captureAny())).captured.single
-        as Map<String, dynamic>;
+    final captured =
+        verify(() => chain.insert(captureAny())).captured.single
+            as Map<String, dynamic>;
     expect(captured['type'], 'answer');
     expect(captured['reply_to'], 'root-1');
     expect(captured['recipient_tag'], 'recipient-1');
     expect(captured['conversation_id'], 'conversation-1');
+    expect(captured.containsKey('created_at'), isFalse);
   });
 
   test('publishHinoo: non salva una risposta senza reply_to', () async {

--- a/test/services/honoo_service_update_duplicate_test.dart
+++ b/test/services/honoo_service_update_duplicate_test.dart
@@ -161,6 +161,7 @@ void main() {
         expect(payload.containsKey('conversation_id'), isFalse);
         expect(payload['is_from_moon_saved'], isFalse);
         expect(payload['fingerprint'], isNot(contains('destinatario')));
+        expect(payload.containsKey('created_at'), isFalse);
       },
     );
 

--- a/test/widgets/unified_thread_reveal_test.dart
+++ b/test/widgets/unified_thread_reveal_test.dart
@@ -293,7 +293,7 @@ void main() {
     expect(find.byKey(const Key('reply_reveal_parent')), findsNothing);
   });
 
-  testWidgets('lo swipe resta sulla pagina scelta dopo il rebuild del padre', (
+  testWidgets('una nuova risposta non sposta la pagina scelta con lo swipe', (
     tester,
   ) async {
     tester.view.devicePixelRatio = 1;
@@ -319,37 +319,51 @@ void main() {
         replyTo: 'root-scroll',
       ),
     );
+    final newReply = ConversationEntry.honoo(
+      honoo(
+        id: 'reply-scroll-new',
+        text: 'Nuova risposta realtime',
+        owner: 'other',
+        createdAt: '2026-07-20T12:00:00Z',
+        type: HonooType.answer,
+        replyTo: 'reply-scroll',
+      ),
+    );
+    var entries = [root, reply];
     String? selectedId;
 
-    await tester.pumpWidget(
-      MaterialApp(
-        home: StatefulBuilder(
-          builder: (context, setState) => Scaffold(
-            body: UnifiedThreadView(
-              conversationId: 'conversation-1',
-              maxWidth: 600,
-              maxHeight: 700,
-              isActive: true,
-              currentUserId: 'me',
-              conversationLoader: (_) async => [root, reply],
-              onSelect: (entry) {
-                selectedId = entry.id;
-                setState(() {});
-              },
-            ),
-          ),
+    Widget app(int refreshToken) => MaterialApp(
+      home: Scaffold(
+        body: UnifiedThreadView(
+          key: const Key('scroll-refresh-thread'),
+          conversationId: 'conversation-1',
+          maxWidth: 600,
+          maxHeight: 700,
+          isActive: true,
+          currentUserId: 'me',
+          refreshToken: refreshToken,
+          conversationLoader: (_) async => entries,
+          onSelect: (entry) => selectedId = entry.id,
         ),
       ),
     );
+
+    await tester.pumpWidget(app(0));
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 1000));
     expect(selectedId, 'reply-scroll');
 
     await tester.drag(find.byType(PageView), const Offset(0, -650));
     await tester.pumpAndSettle();
+    expect(selectedId, 'root-scroll');
+
+    entries = [root, reply, newReply];
+    await tester.pumpWidget(app(1));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
 
     expect(selectedId, 'root-scroll');
-    expect(find.text('Contenuto a cui si è risposto'), findsOneWidget);
+    expect(tester.widget<PageView>(find.byType(PageView)).controller!.page, 2);
   });
 
   testWidgets('un errore di conversazione mostra Riprova', (tester) async {


### PR DESCRIPTION
## Cosa corregge

- mantiene visibile il contenuto selezionato quando una risposta realtime viene aggiunta in testa alla conversazione
- ripristina il collegamento e l'ordinamento delle risposte Hinoo legacy prive di `reply_to`, usando `conversation_id`
- lascia al database l'assegnazione di `created_at` per ordinare Honoo e Hinoo secondo l'effettivo arrivo sulla Luna
- aggiorna le conversazioni anche quando viene inserita una tombstone e abilita la tabella al canale Supabase Realtime

## Perché

Il refresh realtime ricostruiva le pagine senza riallineare l'indice selezionato; inoltre alcune risposte Hinoo legacy venivano escluse dai filtri o dalle mappe di attività. I timestamp Hinoo generati dal client potevano infine alterare l'ordine di arrivo.

## Verifiche

- `flutter analyze`: superato
- test mirati: 58 superati
- suite completa: 359 superati, 7 esclusi
- `git diff --check`: superato
- `supabase db lint`: non eseguibile perché lo stack Supabase locale non è attivo su `127.0.0.1:54322`; la migrazione segue lo schema idempotente già usato nel repository
