### PR TITLE
Implementa il flusso autenticato dei campanelli

### DIFF
--- a/lib/Controller/campanelli_controller.dart
+++ b/lib/Controller/campanelli_controller.dart
@@ -152,6 +152,9 @@ class CampanelliController extends ChangeNotifier {
         entries.add(CampanelliEntry(
           hinooId: id,
           ownerId: ownerId,
+          createdAt:
+              DateTime.tryParse(houseRow['created_at']?.toString() ?? '') ??
+              DateTime.fromMillisecondsSinceEpoch(0, isUtc: true),
           text: text,
           campanelloBackgroundUrl: slide.backgroundImage,
           houseImageUrl: houseRow['house_image_url']?.toString(),
@@ -163,6 +166,13 @@ class CampanelliController extends ChangeNotifier {
           campanelloBgTransform: slide.bgTransform,
         ));
       }
+      entries.sort((a, b) {
+        final aIsOwned = a.ownerId == userId;
+        final bIsOwned = b.ownerId == userId;
+        if (aIsOwned != bIsOwned) return aIsOwned ? -1 : 1;
+        final byCreation = a.createdAt.compareTo(b.createdAt);
+        return byCreation != 0 ? byCreation : a.hinooId.compareTo(b.hinooId);
+      });
       _publish(CampanelliLoadState(
         entries: List<CampanelliEntry>.unmodifiable(entries),
         shareModesByCampanello: shareModes,

--- a/lib/Entities/campanelli_entry.dart
+++ b/lib/Entities/campanelli_entry.dart
@@ -5,6 +5,7 @@ class CampanelliEntry {
   const CampanelliEntry({
     required this.hinooId,
     required this.ownerId,
+    required this.createdAt,
     required this.text,
     required this.campanelloBackgroundUrl,
     required this.houseImageUrl,
@@ -18,6 +19,7 @@ class CampanelliEntry {
 
   final String hinooId;
   final String ownerId;
+  final DateTime createdAt;
   final String text;
   final String? campanelloBackgroundUrl;
   final String? houseImageUrl;

--- a/lib/IsolaDelleStorie/Pages/campanelli_page.dart
+++ b/lib/IsolaDelleStorie/Pages/campanelli_page.dart
@@ -32,6 +32,7 @@ import 'package:honoo/Widgets/busy_overlay.dart';
 import 'package:honoo/Services/campanelli_repository.dart';
 
 import '../../Pages/home_page.dart';
+import '../../Pages/email_login_page.dart';
 import '../../Pages/casa_builder_page.dart';
 import '../../Pages/casa_share_selection_page.dart';
 import '../../Pages/chest_page.dart';
@@ -62,7 +63,7 @@ class _CampanelliPageState extends State<CampanelliPage> {
   static const Curve _kCurve = Curves.easeOutCubic;
   int _campanelloIndex = 0;
   int _verticalPageIndex = 0;
-  int _lastHouseCampanelloIndex = 1;
+  int _lastHouseCampanelloIndex = 0;
   final PageController _pageController = PageController();
   final PageController _campanelloPageController = PageController();
   List<_CampanelloEntry> _userEntries = const [];
@@ -85,10 +86,12 @@ class _CampanelliPageState extends State<CampanelliPage> {
       _campanelliController.state.pendingKnocks;
   Set<String> get _pendingKnockTags => _campanelliController.pendingKnockTags;
   List<String> _ownedHinooIds = const [];
-  static const String campanelloSirenaId = 'campanello_sirena';
-  static const String campanelloPalombaroId = 'campanello_palombaro';
-  static const String casaSirenaId = 'casa_sirena';
-  static const String casaPalombaroId = 'casa_palombaro';
+  static const String campanelloVenceslaoId =
+      'campanello_admin_venceslao_cembalo';
+  static const String campanelloMariAndreeaId =
+      'campanello_admin_mariandreea_lavric';
+  static const String casaVenceslaoId = 'casa_admin_venceslao_cembalo';
+  static const String casaMariAndreeaId = 'casa_admin_mariandreea_lavric';
   static const String campanelloSirenaBg = 'assets/campanello1.png';
   static const String campanelloPalombaroBg = 'assets/campanello2.png';
   static const String casaSirenaBg = 'assets/images/casa_sirena.png';
@@ -97,8 +100,8 @@ class _CampanelliPageState extends State<CampanelliPage> {
   static const String userCampanelloBg = 'assets/campanello1.png';
   static const String scrignoOverlay = 'assets/icons/scrigno_di_carta.png';
   final Set<String> _unlockedCampanelli = {
-    campanelloSirenaId,
-    campanelloPalombaroId,
+    campanelloVenceslaoId,
+    campanelloMariAndreeaId,
   };
 
   void _showBusyOverlay(String message) {
@@ -325,15 +328,15 @@ class _CampanelliPageState extends State<CampanelliPage> {
     return [
       _CampanelloEntry(
         campanello: CampanelloData(
-          id: campanelloSirenaId,
+          id: campanelloVenceslaoId,
           campanelloHinooId: null,
           ownerId: null,
           backgroundImage: const AssetImage(campanelloSirenaBg),
           text: Utility().campanelloExample1Text,
-          linkedHouseId: casaSirenaId,
+          linkedHouseId: casaVenceslaoId,
         ),
         casa: const CasaData(
-          id: casaSirenaId,
+          id: casaVenceslaoId,
           backgroundImage: AssetImage(casaSirenaBg),
           bgScale: 1.0,
           bgOffsetX: 0.0,
@@ -342,15 +345,15 @@ class _CampanelliPageState extends State<CampanelliPage> {
       ),
       _CampanelloEntry(
         campanello: CampanelloData(
-          id: campanelloPalombaroId,
+          id: campanelloMariAndreeaId,
           campanelloHinooId: null,
           ownerId: null,
           backgroundImage: const AssetImage(campanelloPalombaroBg),
           text: Utility().campanelloExample2Text,
-          linkedHouseId: casaPalombaroId,
+          linkedHouseId: casaMariAndreeaId,
         ),
         casa: const CasaData(
-          id: casaPalombaroId,
+          id: casaMariAndreeaId,
           backgroundImage: AssetImage(casaPalombaroBg),
           bgScale: 1.0,
           bgOffsetX: 0.0,
@@ -363,7 +366,7 @@ class _CampanelliPageState extends State<CampanelliPage> {
   List<_CampanelloEntry> _buildCampanelli() {
     final userId = SupabaseProvider.client.auth.currentUser?.id;
     if (userId == null) {
-      return [..._buildBaseCampanelli(), ..._userEntries];
+      return _buildBaseCampanelli();
     }
 
     final ownEntries = _userEntries
@@ -372,7 +375,7 @@ class _CampanelliPageState extends State<CampanelliPage> {
     final otherEntries = _userEntries
         .where((entry) => entry.campanello.ownerId != userId)
         .toList(growable: false);
-    return [...ownEntries, ..._buildBaseCampanelli(), ...otherEntries];
+    return [...ownEntries, ...otherEntries];
   }
 
   HinooDraft _campanelloDraftFor(_CampanelloEntry entry) {
@@ -420,7 +423,7 @@ class _CampanelliPageState extends State<CampanelliPage> {
       (entry) => entry.campanello.ownerId == userId,
     );
     if (ownIndex < 0) return;
-    final int pageIndex = ownIndex + 1;
+    final int pageIndex = ownIndex;
     setState(() {
       _campanelloIndex = pageIndex;
       _lastHouseCampanelloIndex = pageIndex;
@@ -448,6 +451,14 @@ class _CampanelliPageState extends State<CampanelliPage> {
   }
 
   Future<void> _handleInviteRequestTap() async {
+    if (SupabaseProvider.client.auth.currentUser == null) {
+      final loggedIn = await Navigator.of(
+        context,
+      ).push<bool>(MaterialPageRoute(builder: (_) => const EmailLoginPage()));
+      if (!mounted || loggedIn != true) return;
+      await _loadUserEntries();
+      if (!mounted) return;
+    }
     if (!_campanelliController.beginInviteRequest()) return;
     try {
       if (_hasOwnHouse) {
@@ -531,8 +542,9 @@ class _CampanelliPageState extends State<CampanelliPage> {
   List<CampanelloPageData> _buildCampanelloPages(
     List<_CampanelloEntry> campanelli,
   ) {
+    final isGuest = SupabaseProvider.client.auth.currentUser == null;
     final pages = <CampanelloPageData>[
-      CampanelloPageData.intro(Utility().campanelliText),
+      if (isGuest) CampanelloPageData.intro(Utility().campanelliText),
       for (final campanello in campanelli)
         CampanelloPageData.campanello(campanello.campanello),
     ];
@@ -544,6 +556,10 @@ class _CampanelliPageState extends State<CampanelliPage> {
           'Vuoi\n anche tu\n una casa\n sull\'Isola?\n\nClicca qui',
         ),
       );
+    }
+
+    if (pages.isEmpty) {
+      pages.add(CampanelloPageData.intro('Nessun campanello disponibile'));
     }
 
     return pages;
@@ -652,10 +668,10 @@ class _CampanelliPageState extends State<CampanelliPage> {
         if (hasOwnEntry) {
           WidgetsBinding.instance.addPostFrameCallback((_) {
             if (!mounted || !_campanelloPageController.hasClients) return;
-            _campanelloPageController.jumpToPage(1);
+            _campanelloPageController.jumpToPage(0);
             setState(() {
-              _campanelloIndex = 1;
-              _lastHouseCampanelloIndex = 1;
+              _campanelloIndex = 0;
+              _lastHouseCampanelloIndex = 0;
             });
           });
         }
@@ -785,8 +801,8 @@ class _CampanelliPageState extends State<CampanelliPage> {
       (e) => e.campanello.campanelloHinooId == tag,
     );
     if (idx < 0) return;
-    // Horizontal PageView uses a pages list with an intro at index 0
-    final int pageIndex = idx + 1;
+    final bool hasIntro = SupabaseProvider.client.auth.currentUser == null;
+    final int pageIndex = idx + (hasIntro ? 1 : 0);
     // Ensure we are on the campanelli layer (vertical page 0)
     if (_pageController.hasClients) {
       await _pageController.animateToPage(
@@ -1053,18 +1069,18 @@ class _CampanelliPageState extends State<CampanelliPage> {
             0,
             campanelloPages.length - 1,
           );
-          final int houseCampanelloIndex = safeCampanelloIndex == 0
-              ? 1
-              : safeCampanelloIndex;
-          final int casaIndex = (houseCampanelloIndex - 1).clamp(
-            0,
-            campanelli.length - 1,
-          );
-          final bool showCampanello = safeCampanelloIndex > 0;
+          final activePage = campanelloPages[safeCampanelloIndex];
+          final CampanelloData? activeCampanello = activePage.campanello;
+          final _CampanelloEntry? activeEntry = activeCampanello == null
+              ? null
+              : campanelli.cast<_CampanelloEntry?>().firstWhere(
+                  (entry) => entry?.campanello.id == activeCampanello.id,
+                  orElse: () => null,
+                );
+          final _CampanelloEntry? houseEntry =
+              activeEntry ?? (campanelli.isEmpty ? null : campanelli.first);
+          final bool showCampanello = activeCampanello != null;
           final bool showFooter = _verticalPageIndex == 0;
-          final CampanelloData? activeCampanello = showCampanello
-              ? campanelli[casaIndex].campanello
-              : null;
           final user = SupabaseProvider.client.auth.currentUser;
           final String? activeCampanelloId =
               activeCampanello?.campanelloHinooId;
@@ -1090,6 +1106,9 @@ class _CampanelliPageState extends State<CampanelliPage> {
           final int maxCampanelloIndex = math.max(
             0,
             campanelloPages.length - 1,
+          );
+          final int firstCampanelloPageIndex = campanelloPages.indexWhere(
+            (page) => page.campanello != null,
           );
           const int maxVerticalIndex = verticalPages - 1;
 
@@ -1169,21 +1188,18 @@ class _CampanelliPageState extends State<CampanelliPage> {
                         onPageChanged: (index) {
                           _revealCarouselArrows();
                           if (index == 1) {
-                            _lastHouseCampanelloIndex = _campanelloIndex == 0
-                                ? 1
+                            _lastHouseCampanelloIndex = activeCampanello == null
+                                ? math.max(0, firstCampanelloPageIndex)
                                 : _campanelloIndex;
                           }
                           if (index == 0) {
-                            final int target = _campanelloIndex == 0
-                                ? _lastHouseCampanelloIndex
-                                : _campanelloIndex;
-                            if (target > 0 &&
-                                _campanelloPageController.hasClients) {
+                            final int target = _lastHouseCampanelloIndex;
+                            if (_campanelloPageController.hasClients) {
                               _campanelloPageController.jumpToPage(target);
                             }
                             setState(() {
                               _verticalPageIndex = index;
-                              if (target > 0) _campanelloIndex = target;
+                              _campanelloIndex = target;
                             });
                             return;
                           }
@@ -1234,27 +1250,41 @@ class _CampanelliPageState extends State<CampanelliPage> {
                                               _revealCarouselArrows();
                                               setState(() {
                                                 _campanelloIndex = index;
-                                                if (index > 0) {
+                                                if (campanelloPages[index]
+                                                        .campanello !=
+                                                    null) {
                                                   _lastHouseCampanelloIndex =
                                                       index;
                                                 }
                                               });
                                             },
                                             itemBuilder: (context, pageIndex) {
+                                              final page =
+                                                  campanelloPages[pageIndex];
                                               final _CampanelloEntry? entry =
-                                                  pageIndex > 0 &&
-                                                      pageIndex <=
-                                                          campanelli.length
-                                                  ? campanelli[pageIndex - 1]
-                                                  : null;
+                                                  page.campanello == null
+                                                  ? null
+                                                  : campanelli
+                                                        .cast<
+                                                          _CampanelloEntry?
+                                                        >()
+                                                        .firstWhere(
+                                                          (candidate) =>
+                                                              candidate
+                                                                  ?.campanello
+                                                                  .id ==
+                                                              page
+                                                                  .campanello!
+                                                                  .id,
+                                                          orElse: () => null,
+                                                        );
                                               final bool isOwnEntry =
                                                   entry != null &&
                                                   user != null &&
                                                   entry.campanello.ownerId ==
                                                       user.id;
                                               return CampanelloCard(
-                                                data:
-                                                    campanelloPages[pageIndex],
+                                                data: page,
                                                 width: canvasSize.width,
                                                 height: canvasSize.height,
                                                 onRequestTap:
@@ -1284,75 +1314,73 @@ class _CampanelliPageState extends State<CampanelliPage> {
                               ),
                             ),
                           ),
-                          casaUnlocked
-                              ? AnimatedSwitcher(
-                                  duration: const Duration(milliseconds: 480),
-                                  switchInCurve: Curves.easeOutCubic,
-                                  switchOutCurve: Curves.easeOutCubic,
-                                  transitionBuilder: (child, animation) {
-                                    final curved = CurvedAnimation(
-                                      parent: animation,
-                                      curve: Curves.elasticOut,
-                                    );
-                                    final offsetAnimation = Tween<Offset>(
-                                      begin: const Offset(0, 0.28),
-                                      end: Offset.zero,
-                                    ).animate(curved);
-                                    final scale = Tween<double>(
-                                      begin: 0.97,
-                                      end: 1.0,
-                                    ).animate(curved);
-                                    return SlideTransition(
-                                      position: offsetAnimation,
-                                      child: ScaleTransition(
-                                        scale: scale,
-                                        child: FadeTransition(
-                                          opacity: animation,
-                                          child: child,
-                                        ),
-                                      ),
-                                    );
-                                  },
-                                  child: Center(
-                                    child: CasaSection(
-                                      key: ValueKey(
-                                        '${campanelli[casaIndex].casa.id}_open',
-                                      ),
-                                      casa: campanelli[casaIndex].casa,
-                                      isUnlocked: casaUnlocked,
-                                      scrignoAsset: scrignoOverlay,
-                                      onScrignoTap: scrignoTap,
-                                      footerIconSize: footerIconSize,
-                                      scrignoSize: scrignoSize,
-                                      footerBottomSpacing: footerBottomSpacing,
-                                      width: casaWidth,
-                                      height: casaHeight,
-                                      onEditTap: isOwnCampanello
-                                          ? () =>
-                                                _editCasa(campanelli[casaIndex])
-                                          : null,
+                          if (houseEntry == null)
+                            const SizedBox.expand()
+                          else if (casaUnlocked)
+                            AnimatedSwitcher(
+                              duration: const Duration(milliseconds: 480),
+                              switchInCurve: Curves.easeOutCubic,
+                              switchOutCurve: Curves.easeOutCubic,
+                              transitionBuilder: (child, animation) {
+                                final curved = CurvedAnimation(
+                                  parent: animation,
+                                  curve: Curves.elasticOut,
+                                );
+                                final offsetAnimation = Tween<Offset>(
+                                  begin: const Offset(0, 0.28),
+                                  end: Offset.zero,
+                                ).animate(curved);
+                                final scale = Tween<double>(
+                                  begin: 0.97,
+                                  end: 1.0,
+                                ).animate(curved);
+                                return SlideTransition(
+                                  position: offsetAnimation,
+                                  child: ScaleTransition(
+                                    scale: scale,
+                                    child: FadeTransition(
+                                      opacity: animation,
+                                      child: child,
                                     ),
                                   ),
-                                )
-                              : Center(
-                                  child: CasaSection(
-                                    key: ValueKey(
-                                      '${campanelli[casaIndex].casa.id}_closed',
-                                    ),
-                                    casa: campanelli[casaIndex].casa,
-                                    isUnlocked: casaUnlocked,
-                                    scrignoAsset: scrignoOverlay,
-                                    onScrignoTap: scrignoTap,
-                                    footerIconSize: footerIconSize,
-                                    scrignoSize: scrignoSize,
-                                    footerBottomSpacing: footerBottomSpacing,
-                                    width: casaWidth,
-                                    height: casaHeight,
-                                    onEditTap: isOwnCampanello
-                                        ? () => _editCasa(campanelli[casaIndex])
-                                        : null,
-                                  ),
+                                );
+                              },
+                              child: Center(
+                                child: CasaSection(
+                                  key: ValueKey('${houseEntry.casa.id}_open'),
+                                  casa: houseEntry.casa,
+                                  isUnlocked: casaUnlocked,
+                                  scrignoAsset: scrignoOverlay,
+                                  onScrignoTap: scrignoTap,
+                                  footerIconSize: footerIconSize,
+                                  scrignoSize: scrignoSize,
+                                  footerBottomSpacing: footerBottomSpacing,
+                                  width: casaWidth,
+                                  height: casaHeight,
+                                  onEditTap: isOwnCampanello
+                                      ? () => _editCasa(houseEntry)
+                                      : null,
                                 ),
+                              ),
+                            )
+                          else
+                            Center(
+                              child: CasaSection(
+                                key: ValueKey('${houseEntry.casa.id}_closed'),
+                                casa: houseEntry.casa,
+                                isUnlocked: casaUnlocked,
+                                scrignoAsset: scrignoOverlay,
+                                onScrignoTap: scrignoTap,
+                                footerIconSize: footerIconSize,
+                                scrignoSize: scrignoSize,
+                                footerBottomSpacing: footerBottomSpacing,
+                                width: casaWidth,
+                                height: casaHeight,
+                                onEditTap: isOwnCampanello
+                                    ? () => _editCasa(houseEntry)
+                                    : null,
+                              ),
+                            ),
                         ],
                       ),
                     ),

--- a/lib/Services/campanelli_repository.dart
+++ b/lib/Services/campanelli_repository.dart
@@ -13,7 +13,9 @@ class CampanelliDataRepository {
   Future<List<dynamic>> fetchHouseRows() async {
     final rows = await _client
         .from('case')
-        .select('campanello_hinoo_id,owner_id,house_image_url,bg_transform');
+        .select(
+          'campanello_hinoo_id,owner_id,house_image_url,bg_transform,created_at',
+        );
     return _asList(rows);
   }
 

--- a/test/controllers/campanelli_controller_test.dart
+++ b/test/controllers/campanelli_controller_test.dart
@@ -169,6 +169,57 @@ void main() {
     expect(state.entries.single.houseImageUrl, 'other-house.png');
   });
 
+  test('mette il proprio campanello in testa e gli altri per creazione',
+      () async {
+    when(repository.fetchHouseRows).thenAnswer((_) async => const [
+          {
+            'campanello_hinoo_id': 'hinoo-newer',
+            'owner_id': 'user-3',
+            'created_at': '2026-08-03T10:00:00Z',
+          },
+          {
+            'campanello_hinoo_id': 'hinoo-owned',
+            'owner_id': 'user-1',
+            'created_at': '2026-08-04T10:00:00Z',
+          },
+          {
+            'campanello_hinoo_id': 'hinoo-older',
+            'owner_id': 'user-2',
+            'created_at': '2026-08-01T10:00:00Z',
+          },
+        ]);
+    when(() => repository.fetchShareSettingsRows(any()))
+        .thenAnswer((_) async => const []);
+    when(() => repository.fetchHinooRows(any())).thenAnswer((_) async => const [
+          {
+            'id': 'hinoo-newer',
+            'pages': [
+              {'text': 'Più recente'}
+            ],
+          },
+          {
+            'id': 'hinoo-owned',
+            'pages': [
+              {'text': 'Mio'}
+            ],
+          },
+          {
+            'id': 'hinoo-older',
+            'pages': [
+              {'text': 'Più vecchio'}
+            ],
+          },
+        ]);
+
+    final state = await controller.load('user-1');
+
+    expect(state.entries.map((entry) => entry.hinooId), [
+      'hinoo-owned',
+      'hinoo-older',
+      'hinoo-newer',
+    ]);
+  });
+
   test('pubblica uno stato di errore senza conservare dati parziali', () async {
     when(repository.fetchHouseRows).thenThrow(StateError('offline'));
 

--- a/test/pages/campanelli_auth_flow_test.dart
+++ b/test/pages/campanelli_auth_flow_test.dart
@@ -1,0 +1,129 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:honoo/IsolaDelleStorie/Pages/campanelli_page.dart';
+import 'package:honoo/Pages/email_login_page.dart';
+import 'package:honoo/Utility/utility.dart';
+import 'package:honoo/Widgets/campanello_card.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../test_supabase_helper.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  setUpAll(registerSupabaseFallbacks);
+
+  late SupabaseTestHarness harness;
+
+  setUp(() {
+    harness = SupabaseTestHarness();
+    harness.enableOverrides();
+  });
+
+  tearDown(() => harness.disableOverrides());
+
+  testWidgets(
+    'un ospite vede presentazione, i due admin in ordine e poi il login',
+    (tester) async {
+      await tester.pumpWidget(const MaterialApp(home: CampanelliPage()));
+      await tester.pump();
+
+      CampanelloCard card = tester.widget(find.byType(CampanelloCard));
+      expect(card.data.text, Utility().campanelliText);
+
+      await tester.drag(find.byType(CampanelloCard), const Offset(-500, 0));
+      await tester.pumpAndSettle();
+      card = tester.widget(find.byType(CampanelloCard));
+      expect(card.data.campanello?.id, 'campanello_admin_venceslao_cembalo');
+      expect(card.data.text, Utility().campanelloExample1Text);
+
+      await tester.drag(find.byType(CampanelloCard), const Offset(-500, 0));
+      await tester.pumpAndSettle();
+      card = tester.widget(find.byType(CampanelloCard));
+      expect(card.data.campanello?.id, 'campanello_admin_mariandreea_lavric');
+      expect(card.data.text, Utility().campanelloExample2Text);
+
+      await tester.drag(find.byType(CampanelloCard), const Offset(-500, 0));
+      await tester.pumpAndSettle();
+      card = tester.widget(find.byType(CampanelloCard));
+      expect(card.data.text, contains('una casa'));
+
+      await tester.tap(find.text('Clicca qui'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(EmailLoginPage), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'un utente autenticato entra sul proprio campanello e poi vede gli altri',
+    (tester) async {
+      harness.disableOverrides();
+      harness = SupabaseTestHarness(withAuthenticatedUser: true);
+      harness.enableOverrides();
+
+      final houses = harness.stubTable('case');
+      final settings = harness.stubTable('house_share_settings');
+      final hinoo = harness.stubTable('hinoo');
+      final houseAccess = harness.stubTable('house_access');
+      final houseInvites = harness.stubTable('house_invites');
+      when(() => harness.user.email).thenReturn('utente@example.com');
+      when(
+        () => houseAccess.not('granted_at', 'is', null),
+      ).thenAnswer((_) => houseAccess);
+
+      houses.queueResponse(const [
+        {
+          'campanello_hinoo_id': 'newer',
+          'owner_id': 'user-3',
+          'created_at': '2026-08-03T10:00:00Z',
+        },
+        {
+          'campanello_hinoo_id': 'owned',
+          'owner_id': 'test_user',
+          'created_at': '2026-08-04T10:00:00Z',
+        },
+        {
+          'campanello_hinoo_id': 'older',
+          'owner_id': 'user-2',
+          'created_at': '2026-08-01T10:00:00Z',
+        },
+      ]);
+      settings.queueResponse(const []);
+      hinoo.queueResponse(const [
+        {
+          'id': 'newer',
+          'pages': [
+            {'text': 'Campanello più recente'},
+          ],
+        },
+        {
+          'id': 'owned',
+          'pages': [
+            {'text': 'Il mio campanello'},
+          ],
+        },
+        {
+          'id': 'older',
+          'pages': [
+            {'text': 'Campanello più vecchio'},
+          ],
+        },
+      ]);
+      houseAccess
+        ..queueResponse(const [])
+        ..queueResponse(const []);
+      houseInvites.queueResponse(const []);
+
+      await tester.pumpWidget(const MaterialApp(home: CampanelliPage()));
+      await tester.pumpAndSettle();
+
+      CampanelloCard card = tester.widget(find.byType(CampanelloCard));
+      expect(card.data.text, 'Il mio campanello');
+
+      await tester.drag(find.byType(CampanelloCard), const Offset(-500, 0));
+      await tester.pumpAndSettle();
+      card = tester.widget(find.byType(CampanelloCard));
+      expect(card.data.text, 'Campanello più vecchio');
+    },
+  );
+}

--- a/test/services/campanelli_repository_test.dart
+++ b/test/services/campanelli_repository_test.dart
@@ -36,7 +36,7 @@ void main() {
     expect(await repository.fetchHouseRows(), rows);
     verify(() => harness.client.from('case')).called(1);
     verify(() => houses.select(
-          'campanello_hinoo_id,owner_id,house_image_url,bg_transform',
+          'campanello_hinoo_id,owner_id,house_image_url,bg_transform,created_at',
         )).called(1);
   });
 


### PR DESCRIPTION
## Cosa cambia

- per gli ospiti mostra la presentazione, il campanello di Venceslao, quello di Mariandreea e infine la richiesta di creazione della Casa
- dalla richiesta apre il login e, al rientro autenticato, prosegue automaticamente con la richiesta all’amministratore
- per gli utenti autenticati apre direttamente il carosello reale, con il proprio campanello in testa e gli altri ordinati per data di creazione
- riallinea la navigazione tra campanello e Casa alla presenza opzionale della pagina introduttiva

## Perché

Il carosello usava sempre una pagina introduttiva e mescolava i campanelli dimostrativi con quelli reali. Questo impediva di distinguere correttamente il percorso ospite da quello autenticato e rendeva fragili gli indici di navigazione.

## Verifiche

- `flutter analyze --no-pub`
- `flutter test --no-pub test/controllers/campanelli_controller_test.dart test/services/campanelli_repository_test.dart test/pages/campanelli_auth_flow_test.dart test/pages/campanelli_page_layout_test.dart`