### PR TITLE
Mostra i campanelli reali degli admin

### DIFF
--- a/lib/IsolaDelleStorie/Pages/campanelli_page.dart
+++ b/lib/IsolaDelleStorie/Pages/campanelli_page.dart
@@ -86,23 +86,10 @@ class _CampanelliPageState extends State<CampanelliPage> {
       _campanelliController.state.pendingKnocks;
   Set<String> get _pendingKnockTags => _campanelliController.pendingKnockTags;
   List<String> _ownedHinooIds = const [];
-  static const String campanelloVenceslaoId =
-      'campanello_admin_venceslao_cembalo';
-  static const String campanelloMariAndreeaId =
-      'campanello_admin_mariandreea_lavric';
-  static const String casaVenceslaoId = 'casa_admin_venceslao_cembalo';
-  static const String casaMariAndreeaId = 'casa_admin_mariandreea_lavric';
-  static const String campanelloSirenaBg = 'assets/campanello1.png';
-  static const String campanelloPalombaroBg = 'assets/campanello2.png';
-  static const String casaSirenaBg = 'assets/images/casa_sirena.png';
-  static const String casaPalombaroBg = 'assets/images/casa_palombaro.png';
-  static const String defaultCasaBg = 'assets/images/casa_palombaro.png';
-  static const String userCampanelloBg = 'assets/campanello1.png';
+  static const String defaultCasaBg = 'assets/background.png';
+  static const String userCampanelloBg = 'assets/background.png';
   static const String scrignoOverlay = 'assets/icons/scrigno_di_carta.png';
-  final Set<String> _unlockedCampanelli = {
-    campanelloVenceslaoId,
-    campanelloMariAndreeaId,
-  };
+  final Set<String> _unlockedCampanelli = <String>{};
 
   void _showBusyOverlay(String message) {
     if (!mounted) return;
@@ -324,49 +311,10 @@ class _CampanelliPageState extends State<CampanelliPage> {
     );
   }
 
-  List<_CampanelloEntry> _buildBaseCampanelli() {
-    return [
-      _CampanelloEntry(
-        campanello: CampanelloData(
-          id: campanelloVenceslaoId,
-          campanelloHinooId: null,
-          ownerId: null,
-          backgroundImage: const AssetImage(campanelloSirenaBg),
-          text: Utility().campanelloExample1Text,
-          linkedHouseId: casaVenceslaoId,
-        ),
-        casa: const CasaData(
-          id: casaVenceslaoId,
-          backgroundImage: AssetImage(casaSirenaBg),
-          bgScale: 1.0,
-          bgOffsetX: 0.0,
-          bgOffsetY: 0.0,
-        ),
-      ),
-      _CampanelloEntry(
-        campanello: CampanelloData(
-          id: campanelloMariAndreeaId,
-          campanelloHinooId: null,
-          ownerId: null,
-          backgroundImage: const AssetImage(campanelloPalombaroBg),
-          text: Utility().campanelloExample2Text,
-          linkedHouseId: casaMariAndreeaId,
-        ),
-        casa: const CasaData(
-          id: casaMariAndreeaId,
-          backgroundImage: AssetImage(casaPalombaroBg),
-          bgScale: 1.0,
-          bgOffsetX: 0.0,
-          bgOffsetY: 0.0,
-        ),
-      ),
-    ];
-  }
-
   List<_CampanelloEntry> _buildCampanelli() {
     final userId = SupabaseProvider.client.auth.currentUser?.id;
     if (userId == null) {
-      return _buildBaseCampanelli();
+      return _userEntries;
     }
 
     final ownEntries = _userEntries
@@ -588,7 +536,10 @@ class _CampanelliPageState extends State<CampanelliPage> {
   Future<void> _loadUserEntries() async {
     if (_isLoadingUserEntries) return;
     final user = SupabaseProvider.client.auth.currentUser;
-    if (user == null) return;
+    if (user == null) {
+      await _loadPublicAdminEntries();
+      return;
+    }
 
     setState(() => _isLoadingUserEntries = true);
     try {
@@ -712,6 +663,82 @@ class _CampanelliPageState extends State<CampanelliPage> {
       if (mounted) {
         setState(() => _isLoadingUserEntries = false);
       }
+    }
+  }
+
+  Future<void> _loadPublicAdminEntries() async {
+    setState(() => _isLoadingUserEntries = true);
+    try {
+      final rows = await _campanelliRepository.fetchPublicAdminCampanelli();
+      final entries = <_CampanelloEntry>[];
+      for (final rawRow in rows) {
+        if (rawRow is! Map) continue;
+        final row = Map<String, dynamic>.from(rawRow);
+        final hinooId = row['campanello_hinoo_id']?.toString() ?? '';
+        final ownerId = row['owner_id']?.toString() ?? '';
+        final pages = row['pages'];
+        if (hinooId.isEmpty ||
+            ownerId.isEmpty ||
+            pages is! List ||
+            pages.isEmpty) {
+          continue;
+        }
+        final firstPage = pages.first;
+        if (firstPage is! Map) continue;
+        final slide = HinooSlide.fromJson(Map<String, dynamic>.from(firstPage));
+        if (slide.text.trim().isEmpty) continue;
+        final casaId = 'casa_$hinooId';
+        final houseImageUrl = row['house_image_url']?.toString();
+        entries.add(
+          _CampanelloEntry(
+            campanello: CampanelloData.fromBackend(
+              row: {
+                'id': 'campanello_$hinooId',
+                'campanello_hinoo_id': hinooId,
+                'owner_id': ownerId,
+              },
+              backgroundImage: _campanelloBackgroundProvider(
+                slide.backgroundImage,
+              ),
+              text: slide.text.trim(),
+              linkedHouseId: casaId,
+              bgTransform: slide.bgTransform,
+            ),
+            casa: CasaData.fromBackend(
+              row: {'id': casaId, 'bg_transform': row['house_bg_transform']},
+              backgroundImage: _houseBackgroundProvider(
+                houseImageUrl,
+                slide.backgroundImage,
+              ),
+              bgScale: slide.bgScale,
+              bgOffsetX: slide.bgOffsetX,
+              bgOffsetY: slide.bgOffsetY,
+            ),
+            campanelloBackgroundUrl: slide.backgroundImage,
+            houseImageUrl: houseImageUrl,
+            campanelloIsTextWhite: slide.isTextWhite,
+            campanelloBgScale: slide.bgScale,
+            campanelloBgOffsetX: slide.bgOffsetX,
+            campanelloBgOffsetY: slide.bgOffsetY,
+            campanelloBgTransform: slide.bgTransform,
+          ),
+        );
+      }
+      if (mounted) {
+        setState(() {
+          _userEntries = List<_CampanelloEntry>.unmodifiable(entries);
+          _unlockedCampanelli.addAll(
+            entries.map((entry) => entry.campanello.id),
+          );
+        });
+      }
+    } catch (error, stackTrace) {
+      debugPrint(
+        '[Campanelli] public admins load failed: '
+        '${AppFailure.from(error, stackTrace)}',
+      );
+    } finally {
+      if (mounted) setState(() => _isLoadingUserEntries = false);
     }
   }
 

--- a/lib/Services/campanelli_repository.dart
+++ b/lib/Services/campanelli_repository.dart
@@ -10,6 +10,11 @@ class CampanelliDataRepository {
 
   final SupabaseClient _client;
 
+  Future<List<dynamic>> fetchPublicAdminCampanelli() async {
+    final rows = await _client.rpc('get_public_admin_campanelli');
+    return _asList(rows);
+  }
+
   Future<List<dynamic>> fetchHouseRows() async {
     final rows = await _client
         .from('case')
@@ -98,8 +103,11 @@ class CampanelliDataRepository {
         .not('granted_at', 'is', null);
     return _asList(rows)
         .whereType<Map>()
-        .where((row) => row['share_modes'] is List &&
-            (row['share_modes'] as List).isNotEmpty)
+        .where(
+          (row) =>
+              row['share_modes'] is List &&
+              (row['share_modes'] as List).isNotEmpty,
+        )
         .map((row) => row['target_house_tag']?.toString() ?? '')
         .where((tag) => tag.isNotEmpty)
         .toList(growable: false);

--- a/supabase/migrations/20260817170000_publish_admin_campanelli.sql
+++ b/supabase/migrations/20260817170000_publish_admin_campanelli.sql
@@ -1,0 +1,45 @@
+-- The public Campanelli presentation shows only the real houses belonging to
+-- the two project administrators. Keep the allow-list inside this
+-- security-definer function so anonymous clients cannot inspect auth.users or
+-- enumerate any other house.
+
+create or replace function public.get_public_admin_campanelli()
+returns table (
+  admin_email text,
+  campanello_hinoo_id uuid,
+  owner_id uuid,
+  house_image_url text,
+  house_bg_transform jsonb,
+  created_at timestamptz,
+  pages jsonb
+)
+language sql
+stable
+security definer
+set search_path = pg_catalog, public, auth
+as $$
+  with requested(email, position) as (
+    values
+      ('venceslao.cembalo@gmail.com'::text, 1),
+      ('mariandreealavric@gmail.com'::text, 2)
+  )
+  select
+    requested.email as admin_email,
+    houses.campanello_hinoo_id,
+    houses.owner_id,
+    houses.house_image_url,
+    houses.bg_transform as house_bg_transform,
+    houses.created_at,
+    campanelli.pages
+  from requested
+  join auth.users accounts
+    on lower(accounts.email) = requested.email
+  join public."case" houses
+    on houses.owner_id = accounts.id
+  join public.hinoo campanelli
+    on campanelli.id = houses.campanello_hinoo_id
+  order by requested.position;
+$$;
+
+revoke all on function public.get_public_admin_campanelli() from public;
+grant execute on function public.get_public_admin_campanelli() to anon, authenticated;

--- a/test/pages/campanelli_auth_flow_test.dart
+++ b/test/pages/campanelli_auth_flow_test.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:honoo/IsolaDelleStorie/Pages/campanelli_page.dart';
 import 'package:honoo/Pages/email_login_page.dart';
-import 'package:honoo/Utility/utility.dart';
 import 'package:honoo/Widgets/campanello_card.dart';
 import 'package:mocktail/mocktail.dart';
 
@@ -24,23 +23,58 @@ void main() {
   testWidgets(
     'un ospite vede presentazione, i due admin in ordine e poi il login',
     (tester) async {
+      final rpc = MockQueryChain();
+      rpc.queueResponse(const [
+        {
+          'admin_email': 'venceslao.cembalo@gmail.com',
+          'campanello_hinoo_id': 'hinoo-venceslao',
+          'owner_id': 'admin-venceslao',
+          'house_image_url': null,
+          'pages': [
+            {
+              'backgroundImage': null,
+              'text': 'Campanello di Venceslao',
+              'isTextWhite': true,
+            },
+          ],
+        },
+        {
+          'admin_email': 'mariandreealavric@gmail.com',
+          'campanello_hinoo_id': 'hinoo-mariandreea',
+          'owner_id': 'admin-mariandreea',
+          'house_image_url': null,
+          'pages': [
+            {
+              'backgroundImage': null,
+              'text': 'Campanello di Mari Andreea',
+              'isTextWhite': false,
+            },
+          ],
+        },
+      ]);
+      when(
+        () => harness.client.rpc('get_public_admin_campanelli'),
+      ).thenAnswer((_) => rpc);
+
       await tester.pumpWidget(const MaterialApp(home: CampanelliPage()));
-      await tester.pump();
+      await tester.pumpAndSettle();
 
       CampanelloCard card = tester.widget(find.byType(CampanelloCard));
-      expect(card.data.text, Utility().campanelliText);
+      expect(card.data.isIntro, isTrue);
 
       await tester.drag(find.byType(CampanelloCard), const Offset(-500, 0));
       await tester.pumpAndSettle();
       card = tester.widget(find.byType(CampanelloCard));
-      expect(card.data.campanello?.id, 'campanello_admin_venceslao_cembalo');
-      expect(card.data.text, Utility().campanelloExample1Text);
+      expect(card.data.campanello?.campanelloHinooId, 'hinoo-venceslao');
+      expect(card.data.text, 'Campanello di Venceslao');
+      expect(card.data.text, isNot(contains('Magari sono a casa')));
 
       await tester.drag(find.byType(CampanelloCard), const Offset(-500, 0));
       await tester.pumpAndSettle();
       card = tester.widget(find.byType(CampanelloCard));
-      expect(card.data.campanello?.id, 'campanello_admin_mariandreea_lavric');
-      expect(card.data.text, Utility().campanelloExample2Text);
+      expect(card.data.campanello?.campanelloHinooId, 'hinoo-mariandreea');
+      expect(card.data.text, 'Campanello di Mari Andreea');
+      expect(card.data.text, isNot(contains('Magari sono sul terrazzo')));
 
       await tester.drag(find.byType(CampanelloCard), const Offset(-500, 0));
       await tester.pumpAndSettle();

--- a/test/services/campanelli_repository_test.dart
+++ b/test/services/campanelli_repository_test.dart
@@ -27,36 +27,49 @@ void main() {
 
   tearDown(resetMocktailState);
 
+  test('fetchPublicAdminCampanelli usa la RPC pubblica dedicata', () async {
+    final rpc = MockQueryChain();
+    final rows = <Map<String, dynamic>>[
+      {'admin_email': 'venceslao.cembalo@gmail.com'},
+    ];
+    rpc.queueResponse(rows);
+    when(
+      () => harness.client.rpc('get_public_admin_campanelli'),
+    ).thenAnswer((_) => rpc);
+
+    expect(await repository.fetchPublicAdminCampanelli(), rows);
+    verify(() => harness.client.rpc('get_public_admin_campanelli')).called(1);
+  });
+
   test('fetchHouseRows mantiene colonne e tabella originali', () async {
     final rows = <Map<String, dynamic>>[
-      {'campanello_hinoo_id': 'h-1', 'owner_id': 'user-1'}
+      {'campanello_hinoo_id': 'h-1', 'owner_id': 'user-1'},
     ];
     houses.queueResponse(rows);
 
     expect(await repository.fetchHouseRows(), rows);
     verify(() => harness.client.from('case')).called(1);
-    verify(() => houses.select(
-          'campanello_hinoo_id,owner_id,house_image_url,bg_transform,created_at',
-        )).called(1);
+    verify(
+      () => houses.select(
+        'campanello_hinoo_id,owner_id,house_image_url,bg_transform,created_at',
+      ),
+    ).called(1);
   });
 
   test('fetchShareSettingsRows mantiene filtro sugli Hinoo', () async {
     final rows = <Map<String, dynamic>>[
-      {'campanello_hinoo_id': 'h-1', 'share_mode': 'honoo'}
+      {'campanello_hinoo_id': 'h-1', 'share_mode': 'honoo'},
     ];
     settings.queueResponse(rows);
 
     expect(await repository.fetchShareSettingsRows(['h-1', 'h-2']), rows);
     verify(() => harness.client.from('house_share_settings')).called(1);
-    verify(() => settings.in_(
-          'campanello_hinoo_id',
-          ['h-1', 'h-2'],
-        )).called(1);
+    verify(() => settings.in_('campanello_hinoo_id', ['h-1', 'h-2'])).called(1);
   });
 
   test('fetchHinooRows mantiene filtro sugli identificativi', () async {
     final rows = <Map<String, dynamic>>[
-      {'id': 'h-1', 'pages': <dynamic>[]}
+      {'id': 'h-1', 'pages': <dynamic>[]},
     ];
     hinoo.queueResponse(rows);
 
@@ -73,23 +86,22 @@ void main() {
     verifyNever(() => harness.client.from('hinoo'));
   });
 
-  test('fetchPendingKnockRows filtra case possedute e accessi non concessi',
-      () async {
-    final rows = <Map<String, dynamic>>[
-      {'id': 'knock-1', 'target_house_tag': 'h-1'}
-    ];
-    houseAccess.queueResponse(rows);
+  test(
+    'fetchPendingKnockRows filtra case possedute e accessi non concessi',
+    () async {
+      final rows = <Map<String, dynamic>>[
+        {'id': 'knock-1', 'target_house_tag': 'h-1'},
+      ];
+      houseAccess.queueResponse(rows);
 
-    expect(await repository.fetchPendingKnockRows(['h-1']), rows);
-    verify(() => houseAccess.in_('target_house_tag', ['h-1'])).called(1);
-    verify(() => houseAccess.is_('granted_at', null)).called(1);
-  });
+      expect(await repository.fetchPendingKnockRows(['h-1']), rows);
+      verify(() => houseAccess.in_('target_house_tag', ['h-1'])).called(1);
+      verify(() => houseAccess.is_('granted_at', null)).called(1);
+    },
+  );
 
   test('fetchHinooForKnock mantiene selezione e identificativo', () async {
-    final row = <String, dynamic>{
-      'pages': <dynamic>[],
-      'type': 'answer',
-    };
+    final row = <String, dynamic>{'pages': <dynamic>[], 'type': 'answer'};
     hinoo.queueResponse(row);
 
     expect(await repository.fetchHinooForKnock('h-1'), row);
@@ -111,62 +123,72 @@ void main() {
     final grantedAt = DateTime.utc(2026, 7, 17, 10, 30);
     houseAccess.queueResponse(<String, dynamic>{});
 
-    await repository.grantHouseAccess(
-      knockId: 'knock-1',
-      grantedAt: grantedAt,
-    );
+    await repository.grantHouseAccess(knockId: 'knock-1', grantedAt: grantedAt);
 
-    verify(() => houseAccess.update({
-          'granted_at': '2026-07-17T10:30:00.000Z',
-        })).called(1);
+    verify(
+      () => houseAccess.update({'granted_at': '2026-07-17T10:30:00.000Z'}),
+    ).called(1);
     verify(() => houseAccess.eq('id', 'knock-1')).called(1);
   });
 
   test('approveHouseKnock salva i filtri sulla singola bussata', () async {
     final rpc = MockQueryChain()..queueResponse(null);
-    when(() => harness.client.rpc(
-          'approve_house_knock',
-          params: any(named: 'params'),
-        )).thenAnswer((_) => rpc);
+    when(
+      () => harness.client.rpc(
+        'approve_house_knock',
+        params: any(named: 'params'),
+      ),
+    ).thenAnswer((_) => rpc);
 
     await repository.approveHouseKnock(
       knockId: '42',
       shareModes: const ['home', 'moon'],
     );
 
-    verify(() => harness.client.rpc(
-          'approve_house_knock',
-          params: {
-            'p_knock_id': 42,
-            'p_share_modes': ['home', 'moon'],
-          },
-        )).called(1);
+    verify(
+      () => harness.client.rpc(
+        'approve_house_knock',
+        params: {
+          'p_knock_id': 42,
+          'p_share_modes': ['home', 'moon'],
+        },
+      ),
+    ).called(1);
   });
 
   test('fetchGrantedHouseTags restituisce solo tag validi', () async {
-    when(() => houseAccess.not('granted_at', 'is', null))
-        .thenAnswer((_) => houseAccess);
+    when(
+      () => houseAccess.not('granted_at', 'is', null),
+    ).thenAnswer((_) => houseAccess);
     houseAccess.queueResponse(const [
-      {'target_house_tag': 'house-1', 'share_modes': ['home']},
-      {'target_house_tag': '', 'share_modes': ['all']},
+      {
+        'target_house_tag': 'house-1',
+        'share_modes': ['home'],
+      },
+      {
+        'target_house_tag': '',
+        'share_modes': ['all'],
+      },
       {'target_house_tag': 'legacy-house', 'share_modes': []},
-      {'target_house_tag': 'house-2', 'share_modes': ['moon']},
+      {
+        'target_house_tag': 'house-2',
+        'share_modes': ['moon'],
+      },
     ]);
 
-    expect(
-      await repository.fetchGrantedHouseTags('visitor-1'),
-      ['house-1', 'house-2'],
-    );
+    expect(await repository.fetchGrantedHouseTags('visitor-1'), [
+      'house-1',
+      'house-2',
+    ]);
     verify(() => houseAccess.eq('visitor_id', 'visitor-1')).called(1);
     verify(() => houseAccess.not('granted_at', 'is', null)).called(1);
   });
 
   test('saveShareModes mantiene payload e chiave di conflitto', () async {
     final updatedAt = DateTime.utc(2026, 7, 18, 10, 30);
-    when(() => settings.upsert(
-          any(),
-          onConflict: any(named: 'onConflict'),
-        )).thenAnswer((_) => settings);
+    when(
+      () => settings.upsert(any(), onConflict: any(named: 'onConflict')),
+    ).thenAnswer((_) => settings);
     settings.queueResponse(<String, dynamic>{});
 
     await repository.saveShareModes(
@@ -176,12 +198,14 @@ void main() {
       updatedAt: updatedAt,
     );
 
-    verify(() => settings.upsert({
-          'owner_id': 'owner-1',
-          'campanello_hinoo_id': 'hinoo-1',
-          'share_mode': 'honoo',
-          'share_modes': ['honoo', 'hinoo'],
-          'updated_at': '2026-07-18T10:30:00.000Z',
-        }, onConflict: 'campanello_hinoo_id')).called(1);
+    verify(
+      () => settings.upsert({
+        'owner_id': 'owner-1',
+        'campanello_hinoo_id': 'hinoo-1',
+        'share_mode': 'honoo',
+        'share_modes': ['honoo', 'hinoo'],
+        'updated_at': '2026-07-18T10:30:00.000Z',
+      }, onConflict: 'campanello_hinoo_id'),
+    ).called(1);
   });
 }


### PR DESCRIPTION
## Cosa cambia

- rimuove dal carosello pubblico gli esempi locali Sirena e Palombaro
- mostra i campanelli e le case realmente salvati per `venceslao.cembalo@gmail.com` e `mariandreealavric@gmail.com`, nell'ordine richiesto
- aggiunge una RPC Supabase anonima limitata esclusivamente ai due account admin
- mantiene per gli utenti autenticati il proprio campanello in testa seguito dagli altri in ordine di creazione

## Causa

Il flusso ospite usava due elementi statici con immagini e testi di esempio e non interrogava il backend quando non era presente una sessione autenticata.

## Impatto

Gli ospiti vedono ora soltanto i due campanelli admin reali. Il deploy deve applicare la nuova migrazione Supabase prima di pubblicare il client.

## Verifiche

- `fvm flutter test test/pages/campanelli_auth_flow_test.dart test/services/campanelli_repository_test.dart`
- `fvm flutter analyze`
- `bash tool/check_supabase_migrations.sh`
