### PR TITLE
Aggiungi La Banda alla pagina pubblica

### DIFF
--- a/lib/Pages/la_banda_page.dart
+++ b/lib/Pages/la_banda_page.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:honoo/Utility/honoo_colors.dart';
+import 'package:honoo/Widgets/honoo_standard_page.dart';
+
+class LaBandaPage extends StatelessWidget {
+  const LaBandaPage({super.key});
+
+  static const String laBandaText =
+      'La Banda\n\n'
+      'Immagina un gruppo\n'
+      'formato da persone\n'
+      'che condividono\n'
+      'fiducia e stima\n'
+      'reciproca\n'
+      'e tre convinzioni\n\n'
+      'La prima convinzione è che\n'
+      'esprimere la propria creatività\n'
+      'attraverso la realizzazione\n'
+      'di opere\n'
+      'renda la vita più felice\n\n'
+      'La seconda convinzione\n'
+      'consiste nell’essere d’accordo\n'
+      'sull’importanza\n'
+      'di impegnarsi ogni giorno,\n'
+      'per esprimere la propria creatività\n\n'
+      'La terza convinzione\n'
+      'è che la creatività\n'
+      'e l’impegno quotidiano\n'
+      'traggano beneficio\n'
+      'da Incontri periodici,\n'
+      'in cui il cuore sia la creatività,\n'
+      'e dove vengano rispettate\n'
+      'tre regole\n\n'
+      'Sono regole semplici\n\n'
+      'Ma cambiano\n'
+      'completamente\n'
+      'il modo di ascoltarsi\n\n'
+      'Prima regola:\n'
+      'parlano tutti,\n'
+      'a turno\n\n'
+      'Seconda regola:\n'
+      'non si può interrompere nessuno,\n'
+      'per nessun motivo\n\n'
+      'Terza regola:\n'
+      'non si può commentare\n'
+      'quello che ha detto\n'
+      'o letto un altro\n\n'
+      'In ogni Incontro\n'
+      'c’è qualcuno\n'
+      'che ha il compito\n'
+      'di assicurarsi\n'
+      'che queste tre regole\n'
+      'vengano rispettate';
+
+  @override
+  Widget build(BuildContext context) {
+    final TextStyle bodyStyle = GoogleFonts.arvo(
+      color: HonooColor.onBackground,
+      fontSize: 18,
+      fontWeight: FontWeight.w200,
+      height: 1.3,
+    );
+
+    return HonooStandardPage(
+      contentWidthFactor: 0.45,
+      child: Text(
+        laBandaText,
+        key: const Key('la_banda_text'),
+        style: bodyStyle,
+        textAlign: TextAlign.center,
+      ),
+    );
+  }
+}

--- a/lib/Pages/placeholder_page.dart
+++ b/lib/Pages/placeholder_page.dart
@@ -19,6 +19,7 @@ import 'viaggi_isola_page.dart';
 import 'laboratori_siae_page.dart';
 import 'podcast_dirette_page.dart';
 import 'libri_page.dart';
+import 'la_banda_page.dart';
 import 'regia_agenti_page.dart';
 
 class PlaceholderPage extends StatefulWidget {
@@ -53,6 +54,8 @@ class _PlaceholderPageState extends State<PlaceholderPage> {
   static const double _honooBottomSpacing = 15;
   static const double _libriTopSpacing = 5;
   static const double _libriBottomSpacing = 30;
+  static const double _laBandaTopSpacing = 5;
+  static const double _laBandaBottomSpacing = 30;
   static const double _regiaAgentiTopSpacing = 18 * 1.3;
   static const double _regiaAgentiBottomSpacing = 30;
   static const double _regiaAgentiIconSizeReduction = 15;
@@ -215,6 +218,7 @@ class _PlaceholderPageState extends State<PlaceholderPage> {
     const String viaggiLine = "Viaggi sull'Isola delle Storie";
     const String podcastLine = 'Podcast e dirette';
     const String libriLine = 'Libri';
+    const String laBandaLine = 'La Banda';
     const String regiaAgentiLine = 'Regia degli Agenti';
     const String venceslaoLine = 'Venceslao Cembalo';
     final String text1First = Utility().text1First;
@@ -427,6 +431,28 @@ class _PlaceholderPageState extends State<PlaceholderPage> {
           Navigator.of(
             context,
           ).push(MaterialPageRoute(builder: (_) => const ViaggiIsolaPage()));
+        },
+      ),
+      _linkTextBlock(
+        context,
+        laBandaLine,
+        baseTextStyle,
+        onTap: () {
+          Navigator.of(
+            context,
+          ).push(MaterialPageRoute(builder: (_) => const LaBandaPage()));
+        },
+      ),
+      ..._materialIconBlockWithSpacing(
+        Icons.groups,
+        inlineIconHeight,
+        topSpacing: _laBandaTopSpacing,
+        bottomSpacing: _laBandaBottomSpacing,
+        color: _linkIconColor,
+        onTap: () {
+          Navigator.of(
+            context,
+          ).push(MaterialPageRoute(builder: (_) => const LaBandaPage()));
         },
       ),
       _linkTextBlock(

--- a/test/pages/la_banda_page_test.dart
+++ b/test/pages/la_banda_page_test.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:honoo/Pages/la_banda_page.dart';
+import 'package:honoo/Pages/placeholder_page.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('la landing apre La Banda dal link e dalla sua icona', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(390, 844);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(const MaterialApp(home: PlaceholderPage()));
+    await tester.pumpAndSettle();
+
+    final link = find.text('La Banda');
+    final icon = find.byIcon(Icons.groups);
+    expect(link, findsOneWidget);
+    expect(icon, findsOneWidget);
+
+    await tester.ensureVisible(link);
+    await tester.tap(link);
+    await tester.pumpAndSettle();
+    expect(find.byType(LaBandaPage), findsOneWidget);
+
+    tester.state<NavigatorState>(find.byType(Navigator)).pop();
+    await tester.pumpAndSettle();
+    await tester.ensureVisible(icon);
+    await tester.tap(icon);
+    await tester.pumpAndSettle();
+    expect(find.byType(LaBandaPage), findsOneWidget);
+  });
+
+  testWidgets('La Banda mostra il testo completo nello stile informativo', (
+    tester,
+  ) async {
+    await tester.pumpWidget(const MaterialApp(home: LaBandaPage()));
+    await tester.pumpAndSettle();
+
+    final text = tester.widget<Text>(find.byKey(const Key('la_banda_text')));
+    expect(text.data, LaBandaPage.laBandaText);
+    expect(text.textAlign, TextAlign.center);
+    expect(text.style?.fontSize, 18);
+    expect(text.style?.height, 1.3);
+    expect(text.data, startsWith('La Banda\n\nImmagina un gruppo'));
+    expect(text.data, contains('Prima regola:\nparlano tutti,\na turno'));
+    expect(text.data, endsWith('che queste tre regole\nvengano rispettate'));
+  });
+}

--- a/test/pages/regia_agenti_page_test.dart
+++ b/test/pages/regia_agenti_page_test.dart
@@ -70,16 +70,19 @@ void main() {
         'Esplorazioni lunari',
         'Feste',
         "Viaggi sull'Isola delle Storie",
+        'La Banda',
         'Regia degli Agenti',
         'Podcast e dirette',
         'Libri',
       ]),
     );
     final viaggiIndex = visibleTexts.indexOf("Viaggi sull'Isola delle Storie");
+    final laBandaIndex = visibleTexts.indexOf('La Banda');
     final regiaIndex = visibleTexts.indexOf('Regia degli Agenti');
     final podcastIndex = visibleTexts.indexOf('Podcast e dirette');
     final libriIndex = visibleTexts.indexOf('Libri');
-    expect(regiaIndex, viaggiIndex + 1);
+    expect(laBandaIndex, viaggiIndex + 1);
+    expect(regiaIndex, laBandaIndex + 1);
     expect(regiaIndex, lessThan(podcastIndex));
     expect(libriIndex, podcastIndex + 1);
 


### PR DESCRIPTION
## Cosa cambia
- aggiunge il link La Banda prima di Regia degli Agenti
- aggiunge un'icona di gruppo cliccabile nello stile della pagina
- mostra il testo completo in una pagina informativa dedicata
- copre ordine, navigazione e contenuto con test widget

## Verifiche
- fvm flutter test test/pages/la_banda_page_test.dart test/pages/regia_agenti_page_test.dart
- fvm flutter analyze
- git diff --check