### PR TITLE
Uniforma i testi delle sezioni pubbliche

### DIFF
--- a/lib/Pages/feste_page.dart
+++ b/lib/Pages/feste_page.dart
@@ -7,6 +7,7 @@ class FestePage extends StatelessWidget {
   const FestePage({super.key});
 
   static const String festeText =
+      "Feste\n\n"
       "Una festa di honoo\n"
       "si svolge\n"
       "in uno spazio\n"
@@ -27,7 +28,7 @@ class FestePage extends StatelessWidget {
       "il gusto della sorpresa,\n"
       "quando sarai invitato\n"
       "alla tua prima\n"
-      "festa di honoo\n";
+      "festa di honoo\n\n";
 
   @override
   Widget build(BuildContext context) {
@@ -39,7 +40,12 @@ class FestePage extends StatelessWidget {
     );
     return HonooStandardPage(
       contentWidthFactor: 0.45,
-      child: Text(festeText, style: bodyStyle, textAlign: TextAlign.center),
+      child: Text(
+        festeText,
+        key: const Key('section_text'),
+        style: bodyStyle,
+        textAlign: TextAlign.center,
+      ),
     );
   }
 }

--- a/lib/Pages/la_banda_page.dart
+++ b/lib/Pages/la_banda_page.dart
@@ -51,7 +51,7 @@ class LaBandaPage extends StatelessWidget {
       'che ha il compito\n'
       'di assicurarsi\n'
       'che queste tre regole\n'
-      'vengano rispettate';
+      'vengano rispettate\n\n';
 
   @override
   Widget build(BuildContext context) {
@@ -66,7 +66,7 @@ class LaBandaPage extends StatelessWidget {
       contentWidthFactor: 0.45,
       child: Text(
         laBandaText,
-        key: const Key('la_banda_text'),
+        key: const Key('section_text'),
         style: bodyStyle,
         textAlign: TextAlign.center,
       ),

--- a/lib/Pages/laboratori_siae_page.dart
+++ b/lib/Pages/laboratori_siae_page.dart
@@ -44,7 +44,7 @@ class LaboratoriSiaePage extends StatelessWidget {
       "nel 2025\n"
       "honoo ha partecipato\n"
       "a un Bando Siae\n"
-      "E ha vinto\n";
+      "E ha vinto\n\n";
 
   @override
   Widget build(BuildContext context) {
@@ -91,6 +91,7 @@ class LaboratoriSiaePage extends StatelessWidget {
     );
 
     final List<InlineSpan> spans = [
+      TextSpan(text: 'Laboratori teatrali\n\n', style: baseTextStyle),
       TextSpan(text: 'honoo e ', style: baseTextStyle),
       TextSpan(
         text: 'Crocopie',
@@ -138,6 +139,7 @@ class LaboratoriSiaePage extends StatelessWidget {
                 child: Padding(
                   padding: const EdgeInsets.symmetric(horizontal: 24.0),
                   child: RichText(
+                    key: const Key('section_text'),
                     textAlign: TextAlign.center,
                     text: TextSpan(children: spans),
                   ),

--- a/lib/Pages/libri_page.dart
+++ b/lib/Pages/libri_page.dart
@@ -26,6 +26,7 @@ class LibriPage extends StatelessWidget {
     String headerText(String text) => text.replaceAll('\n', ' ').trim();
 
     final spans = <InlineSpan>[
+      TextSpan(text: 'Libri\n\n', style: style),
       TextSpan(text: intro, style: style),
       TextSpan(
         text: 'Isola delle Storie\n\n',
@@ -58,7 +59,8 @@ class LibriPage extends StatelessWidget {
               MaterialPageRoute(
                 builder: (_) => ComingSoonPage(
                   header: headerText(
-                      'Isole delle Storie\n(con illustrazioni di Joel Folda)'),
+                    'Isole delle Storie\n(con illustrazioni di Joel Folda)',
+                  ),
                   quote: '',
                   bibliography: '',
                 ),
@@ -124,7 +126,7 @@ class LibriPage extends StatelessWidget {
           },
       ),
       TextSpan(
-        text: 'Papà,\nma tu mi vuoi bene?\n',
+        text: 'Papà,\nma tu mi vuoi bene?\n\n',
         style: style.copyWith(
           decoration: TextDecoration.underline,
           fontWeight: FontWeight.w700,
@@ -147,6 +149,7 @@ class LibriPage extends StatelessWidget {
     return HonooStandardPage(
       contentWidthFactor: 0.45,
       child: RichText(
+        key: const Key('section_text'),
         textAlign: TextAlign.center,
         text: TextSpan(children: spans),
       ),

--- a/lib/Pages/luna_page.dart
+++ b/lib/Pages/luna_page.dart
@@ -9,6 +9,7 @@ class LunaPage extends StatelessWidget {
   const LunaPage({super.key});
 
   static const String lunaText =
+      "Esplorazioni lunari\n\n"
       "Cosa c’è\n"
       "oggi\n"
       "sulla Luna?\n\n"
@@ -48,7 +49,7 @@ class LunaPage extends StatelessWidget {
       "se l’incantesimo del Mago\n"
       "li avesse fatti riapparire\n"
       "dalle nostre parti,\n"
-      "in questi giorni\n";
+      "in questi giorni\n\n";
 
   @override
   Widget build(BuildContext context) {
@@ -67,7 +68,12 @@ class LunaPage extends StatelessWidget {
           (route) => false,
         );
       },
-      child: Text(lunaText, style: baseTextStyle, textAlign: TextAlign.center),
+      child: Text(
+        lunaText,
+        key: const Key('section_text'),
+        style: baseTextStyle,
+        textAlign: TextAlign.center,
+      ),
     );
   }
 }

--- a/lib/Pages/performance_page.dart
+++ b/lib/Pages/performance_page.dart
@@ -7,6 +7,7 @@ class PerformancePage extends StatelessWidget {
   const PerformancePage({super.key});
 
   static const String performanceText =
+      "Performance\n\n"
       "Venceslao Cembalo,\n"
       "Antonio Della Guardia\n"
       "e Sira Sebastianelli\n"
@@ -26,7 +27,7 @@ class PerformancePage extends StatelessWidget {
       "progettata da Ettore Sottsass\n\n"
       "Sì,\n"
       "honoo è stato invitato\n"
-      "alla Triennale\n";
+      "alla Triennale\n\n";
 
   @override
   Widget build(BuildContext context) {
@@ -40,6 +41,7 @@ class PerformancePage extends StatelessWidget {
       contentWidthFactor: 0.45,
       child: Text(
         performanceText,
+        key: const Key('section_text'),
         style: bodyStyle,
         textAlign: TextAlign.center,
       ),

--- a/lib/Pages/podcast_dirette_page.dart
+++ b/lib/Pages/podcast_dirette_page.dart
@@ -18,6 +18,7 @@ class PodcastDirettePage extends StatelessWidget {
     );
 
     final List<InlineSpan> spans = [
+      TextSpan(text: 'Podcast e dirette\n\n', style: style),
       TextSpan(text: 'honoo\nsi ascolta\ne si guarda\n\n', style: style),
       TextSpan(text: 'È voce\nÈ immagine\n\n', style: style),
       TextSpan(
@@ -86,6 +87,7 @@ class PodcastDirettePage extends StatelessWidget {
     return HonooStandardPage(
       contentWidthFactor: 0.45,
       child: RichText(
+        key: const Key('section_text'),
         textAlign: TextAlign.center,
         text: TextSpan(children: spans),
       ),

--- a/lib/Pages/regia_agenti_page.dart
+++ b/lib/Pages/regia_agenti_page.dart
@@ -12,6 +12,7 @@ class RegiaAgentiPage extends StatelessWidget {
       'https://www.linkedin.com/authwall?trk=gf&trkInfo=AQEKiDvNCY9k5wAAAZ_TKfSQOVjSt8GjBHYntEjt-HPxCMb7xQr32j-xeaqLUkZnvfqrUpn83qHvXKKKYHIKY1acgmDf7htNSAFpkUS9bOm7DEa8a16eUbCCpTlD4T-EdrqpifM=&original_referer=&sessionRedirect=https%3A%2F%2Fwww.linkedin.com%2Fin%2Falessandro-molina1%3Futm_source%3Dshare_via%26utm_content%3Dprofile%26utm_medium%3Dmember_ios';
 
   static const String _textBeforeAlessandro =
+      'Regia degli Agenti\n\n'
       '“Regia degli Agenti”\n'
       'non è una mia espressione,\n'
       'ma del mio amico\n';
@@ -65,7 +66,7 @@ class RegiaAgentiPage extends StatelessWidget {
       'gli agenti\n'
       'significa\n'
       'imparare\n'
-      'a tessere';
+      'a tessere\n\n';
 
   static const String regiaAgentiText =
       '${_textBeforeAlessandro}Alessandro Molina$_textAfterAlessandro';
@@ -104,7 +105,7 @@ class RegiaAgentiPage extends StatelessWidget {
             const TextSpan(text: _textAfterAlessandro),
           ],
         ),
-        key: const Key('regia_agenti_text'),
+        key: const Key('section_text'),
         textAlign: TextAlign.center,
       ),
     );

--- a/lib/Pages/viaggi_isola_page.dart
+++ b/lib/Pages/viaggi_isola_page.dart
@@ -8,6 +8,7 @@ class ViaggiIsolaPage extends StatelessWidget {
   const ViaggiIsolaPage({super.key});
 
   static const String _textAboveMap =
+      "Viaggi sull'Isola delle Storie\n\n"
       "Apri gli occhi,\n"
       "c’è l’Isola\n"
       "davanti a te\n\n"
@@ -32,7 +33,7 @@ class ViaggiIsolaPage extends StatelessWidget {
       "i leoni,\n"
       "ma questo\n"
       "lo scoprirai,\n"
-      "se ne avrai voglia\n";
+      "se ne avrai voglia\n\n";
 
   @override
   Widget build(BuildContext context) {
@@ -47,6 +48,7 @@ class ViaggiIsolaPage extends StatelessWidget {
     return HonooStandardPage(
       contentWidthFactor: 0.45,
       child: Column(
+        key: const Key('section_text'),
         crossAxisAlignment: CrossAxisAlignment.center,
         children: [
           Text(_textAboveMap, style: bodyStyle, textAlign: TextAlign.center),

--- a/test/pages/la_banda_page_test.dart
+++ b/test/pages/la_banda_page_test.dart
@@ -41,13 +41,16 @@ void main() {
     await tester.pumpWidget(const MaterialApp(home: LaBandaPage()));
     await tester.pumpAndSettle();
 
-    final text = tester.widget<Text>(find.byKey(const Key('la_banda_text')));
+    final text = tester.widget<Text>(find.byKey(const Key('section_text')));
     expect(text.data, LaBandaPage.laBandaText);
     expect(text.textAlign, TextAlign.center);
     expect(text.style?.fontSize, 18);
     expect(text.style?.height, 1.3);
     expect(text.data, startsWith('La Banda\n\nImmagina un gruppo'));
     expect(text.data, contains('Prima regola:\nparlano tutti,\na turno'));
-    expect(text.data, endsWith('che queste tre regole\nvengano rispettate'));
+    expect(
+      text.data,
+      endsWith('che queste tre regole\nvengano rispettate\n\n'),
+    );
   });
 }

--- a/test/pages/placeholder_section_text_structure_test.dart
+++ b/test/pages/placeholder_section_text_structure_test.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:honoo/Pages/feste_page.dart';
+import 'package:honoo/Pages/la_banda_page.dart';
+import 'package:honoo/Pages/laboratori_siae_page.dart';
+import 'package:honoo/Pages/libri_page.dart';
+import 'package:honoo/Pages/luna_page.dart';
+import 'package:honoo/Pages/performance_page.dart';
+import 'package:honoo/Pages/podcast_dirette_page.dart';
+import 'package:honoo/Pages/regia_agenti_page.dart';
+import 'package:honoo/Pages/viaggi_isola_page.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  final sections = <(String, Widget)>[
+    ('Performance', const PerformancePage()),
+    ('Laboratori teatrali', const LaboratoriSiaePage()),
+    ('Esplorazioni lunari', const LunaPage()),
+    ('Feste', const FestePage()),
+    ("Viaggi sull'Isola delle Storie", const ViaggiIsolaPage()),
+    ('La Banda', const LaBandaPage()),
+    ('Regia degli Agenti', const RegiaAgentiPage()),
+    ('Podcast e dirette', const PodcastDirettePage()),
+    ('Libri', const LibriPage()),
+  ];
+
+  for (final (title, page) in sections) {
+    testWidgets('$title inizia col titolo del link e termina con due a capo', (
+      tester,
+    ) async {
+      await tester.pumpWidget(MaterialApp(home: page));
+      await tester.pumpAndSettle();
+
+      final contentFinder = find.byKey(const Key('section_text'));
+      expect(contentFinder, findsOneWidget);
+
+      final Widget content = tester.widget(contentFinder);
+      final String plainText;
+      if (content is Text) {
+        plainText = content.data ?? content.textSpan!.toPlainText();
+      } else if (content is RichText) {
+        plainText = content.text.toPlainText();
+      } else {
+        final textWidgets = tester.widgetList<Text>(
+          find.descendant(of: contentFinder, matching: find.byType(Text)),
+        );
+        plainText = textWidgets
+            .map((text) => text.data ?? text.textSpan!.toPlainText())
+            .join();
+      }
+
+      expect(plainText, startsWith('$title\n\n'));
+      expect(plainText, endsWith('\n\n'));
+      expect(plainText, isNot(endsWith('\n\n\n')));
+    });
+  }
+}

--- a/test/pages/regia_agenti_page_test.dart
+++ b/test/pages/regia_agenti_page_test.dart
@@ -107,9 +107,7 @@ void main() {
     await tester.pumpWidget(const MaterialApp(home: RegiaAgentiPage()));
     await tester.pumpAndSettle();
 
-    final text = tester.widget<Text>(
-      find.byKey(const Key('regia_agenti_text')),
-    );
+    final text = tester.widget<Text>(find.byKey(const Key('section_text')));
     expect(text.textSpan?.toPlainText(), RegiaAgentiPage.regiaAgentiText);
     expect(text.textAlign, TextAlign.center);
     expect(text.textSpan?.toPlainText(), contains('Alessandro Molina'));
@@ -120,7 +118,7 @@ void main() {
     expect(text.textSpan?.toPlainText(), isNot(contains('a tessere idee')));
     expect(
       text.textSpan?.toPlainText(),
-      endsWith('E dirigere\ngli agenti\nsignifica\nimparare\na tessere'),
+      endsWith('E dirigere\ngli agenti\nsignifica\nimparare\na tessere\n\n'),
     );
 
     final rootSpan = text.textSpan! as TextSpan;


### PR DESCRIPTION
## Riepilogo
- uniforma le sezioni da Performance a Libri con il titolo corrispondente all’inizio del testo
- garantisce due ritorni a capo alla fine di ogni contenuto
- aggiunge un test parametrico per tutte e nove le sezioni

## Verifiche
- fvm flutter test test/pages/placeholder_section_text_structure_test.dart test/pages/la_banda_page_test.dart test/pages/regia_agenti_page_test.dart
- fvm flutter analyze
- git diff --check